### PR TITLE
Allow creation of custom endpoint icons

### DIFF
--- a/packages/endpoints-overlay/src/EndpointsOverlay.story.js
+++ b/packages/endpoints-overlay/src/EndpointsOverlay.story.js
@@ -1,9 +1,11 @@
 import BaseMap from "@opentripplanner/base-map";
+import PropTypes from "prop-types";
 import React from "react";
 import { action } from "@storybook/addon-actions";
 import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { storiesOf } from "@storybook/react";
+import { Cat, Dog } from "styled-icons/fa-solid";
 
 import EndpointsOverlay from ".";
 
@@ -32,6 +34,14 @@ const toLocation = {
 };
 const locations = [fromLocation, toLocation];
 
+function MapMarkerIcon({ type }) {
+  return type === "from" ? <Cat size={40} /> : <Dog size={40} />;
+}
+
+MapMarkerIcon.propTypes = {
+  type: PropTypes.string.isRequired
+};
+
 storiesOf("EndpointsOverlay", module)
   .addDecorator(withA11y)
   .addDecorator(withInfo)
@@ -55,6 +65,17 @@ storiesOf("EndpointsOverlay", module)
         rememberPlace={rememberPlace}
         setLocation={setLocation}
         showUserSettings
+        toLocation={toLocation}
+        visible
+      />
+    </BaseMap>
+  ))
+  .add("EndpointsOverlay with custom map markers", () => (
+    <BaseMap center={center} zoom={zoom}>
+      <EndpointsOverlay
+        fromLocation={fromLocation}
+        MapMarkerIcon={MapMarkerIcon}
+        setLocation={setLocation}
         toLocation={toLocation}
         visible
       />

--- a/packages/endpoints-overlay/src/endpoint.js
+++ b/packages/endpoints-overlay/src/endpoint.js
@@ -18,30 +18,10 @@ import {
 
 import * as Styled from "./styled";
 
-function DefaultMapMarkerIcon({ location, type }) {
-  return (
-    <Styled.StackedIconContainer title={location.name}>
-      {type === "from" ? (
-        // From icon should have white circle background
-        <>
-          <Styled.StackedCircle size={24} />
-          <Styled.StackedLocationIcon size={24} type={type} />
-        </>
-      ) : (
-        <>
-          <Styled.StackedToIcon size={24} type="to" />
-          <Styled.ToIcon size={20} type={type} />
-        </>
-      )}
-    </Styled.StackedIconContainer>
-  );
-}
-
-DefaultMapMarkerIcon.propTypes = {
-  location: locationType.isRequired,
-  type: PropTypes.string.isRequired
-};
-
+/**
+ * These icons are used to render common icons for user locations. These will
+ * only show up in applications that allow saving user locations.
+ */
 function UserLocationIcon({ type }) {
   switch (type) {
     case "briefcase":
@@ -201,13 +181,9 @@ Endpoint.propTypes = {
   forgetPlace: PropTypes.func.isRequired,
   location: locationType.isRequired,
   locations: PropTypes.arrayOf(locationType).isRequired,
-  MapMarkerIcon: PropTypes.elementType,
+  MapMarkerIcon: PropTypes.elementType.isRequired,
   rememberPlace: PropTypes.func.isRequired,
   setLocation: PropTypes.func.isRequired,
   showUserSettings: PropTypes.bool.isRequired,
   type: PropTypes.string.isRequired
-};
-
-Endpoint.defaultProps = {
-  MapMarkerIcon: DefaultMapMarkerIcon
 };

--- a/packages/endpoints-overlay/src/endpoint.js
+++ b/packages/endpoints-overlay/src/endpoint.js
@@ -18,7 +18,31 @@ import {
 
 import * as Styled from "./styled";
 
-function Icon({ type }) {
+function DefaultMapMarkerIcon({ location, type }) {
+  return (
+    <Styled.StackedIconContainer title={location.name}>
+      {type === "from" ? (
+        // From icon should have white circle background
+        <>
+          <Styled.StackedCircle size={24} />
+          <Styled.StackedLocationIcon size={24} type={type} />
+        </>
+      ) : (
+        <>
+          <Styled.StackedToIcon size={24} type="to" />
+          <Styled.ToIcon size={20} type={type} />
+        </>
+      )}
+    </Styled.StackedIconContainer>
+  );
+}
+
+DefaultMapMarkerIcon.propTypes = {
+  location: locationType.isRequired,
+  type: PropTypes.string.isRequired
+};
+
+function UserLocationIcon({ type }) {
   switch (type) {
     case "briefcase":
       return <Briefcase size={12} />;
@@ -35,7 +59,7 @@ function Icon({ type }) {
   }
 }
 
-Icon.propTypes = {
+UserLocationIcon.propTypes = {
   type: PropTypes.string.isRequired
 };
 
@@ -87,7 +111,13 @@ export default class Endpoint extends Component {
   };
 
   render() {
-    const { location, locations, showUserSettings, type } = this.props;
+    const {
+      location,
+      locations,
+      MapMarkerIcon,
+      showUserSettings,
+      type
+    } = this.props;
     const position =
       location && location.lat && location.lon
         ? [location.lat, location.lon]
@@ -97,20 +127,7 @@ export default class Endpoint extends Component {
     const isWork = match && match.type === "work";
     const isHome = match && match.type === "home";
     const iconHtml = ReactDOMServer.renderToStaticMarkup(
-      <Styled.StackedIconContainer title={location.name}>
-        {type === "from" ? (
-          // From icon should have white circle background
-          <>
-            <Styled.StackedCircle size={24} />
-            <Styled.StackedLocationIcon size={24} type={type} />
-          </>
-        ) : (
-          <>
-            <Styled.StackedToIcon size={24} type="to" />
-            <Styled.ToIcon size={20} type={type} />
-          </>
-        )}
-      </Styled.StackedIconContainer>
+      <MapMarkerIcon location={location} type={type} />
     );
     const otherType = type === "from" ? "to" : "from";
     const icon = isWork ? "briefcase" : isHome ? "home" : "map-marker";
@@ -125,7 +142,7 @@ export default class Endpoint extends Component {
           <Popup>
             <div>
               <strong>
-                <Icon type={icon} /> {location.name}
+                <UserLocationIcon type={icon} /> {location.name}
               </strong>
               <div>
                 <Styled.Button
@@ -134,11 +151,11 @@ export default class Endpoint extends Component {
                 >
                   {isHome ? (
                     <span>
-                      <Icon type="times" /> Forget home
+                      <UserLocationIcon type="times" /> Forget home
                     </span>
                   ) : (
                     <span>
-                      <Icon type="home" /> Save as home
+                      <UserLocationIcon type="home" /> Save as home
                     </span>
                   )}
                 </Styled.Button>
@@ -150,23 +167,24 @@ export default class Endpoint extends Component {
                 >
                   {isWork ? (
                     <span>
-                      <Icon type="times" /> Forget work
+                      <UserLocationIcon type="times" /> Forget work
                     </span>
                   ) : (
                     <span>
-                      <Icon type="briefcase" /> Save as work
+                      <UserLocationIcon type="briefcase" /> Save as work
                     </span>
                   )}
                 </Styled.Button>
               </div>
               <div>
                 <Styled.Button onClick={this.clearLocation}>
-                  <Icon type="times" /> Remove as {type} location
+                  <UserLocationIcon type="times" /> Remove as {type} location
                 </Styled.Button>
               </div>
               <div>
                 <Styled.Button onClick={this.swapLocation}>
-                  <Icon type="refresh" /> Change to {otherType} location
+                  <UserLocationIcon type="refresh" /> Change to {otherType}{" "}
+                  location
                 </Styled.Button>
               </div>
             </div>
@@ -183,8 +201,13 @@ Endpoint.propTypes = {
   forgetPlace: PropTypes.func.isRequired,
   location: locationType.isRequired,
   locations: PropTypes.arrayOf(locationType).isRequired,
+  MapMarkerIcon: PropTypes.elementType,
   rememberPlace: PropTypes.func.isRequired,
   setLocation: PropTypes.func.isRequired,
   showUserSettings: PropTypes.bool.isRequired,
   type: PropTypes.string.isRequired
+};
+
+Endpoint.defaultProps = {
+  MapMarkerIcon: DefaultMapMarkerIcon
 };

--- a/packages/endpoints-overlay/src/index.js
+++ b/packages/endpoints-overlay/src/index.js
@@ -3,6 +3,31 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import Endpoint from "./endpoint";
+import * as Styled from "./styled";
+
+function DefaultMapMarkerIcon({ location, type }) {
+  return (
+    <Styled.StackedIconContainer title={location.name}>
+      {type === "from" ? (
+        // From icon should have white circle background
+        <>
+          <Styled.StackedCircle size={24} />
+          <Styled.StackedLocationIcon size={24} type={type} />
+        </>
+      ) : (
+        <>
+          <Styled.StackedToIcon size={24} type="to" />
+          <Styled.ToIcon size={20} type={type} />
+        </>
+      )}
+    </Styled.StackedIconContainer>
+  );
+}
+
+DefaultMapMarkerIcon.propTypes = {
+  location: locationType.isRequired,
+  type: PropTypes.string.isRequired
+};
 
 function EndpointsOverlay({
   clearLocation,
@@ -111,7 +136,7 @@ EndpointsOverlay.defaultProps = {
   forgetPlace: noop,
   rememberPlace: noop,
   locations: [],
-  MapMarkerIcon: undefined,
+  MapMarkerIcon: DefaultMapMarkerIcon,
   showUserSettings: false
 };
 

--- a/packages/endpoints-overlay/src/index.js
+++ b/packages/endpoints-overlay/src/index.js
@@ -9,6 +9,7 @@ function EndpointsOverlay({
   forgetPlace,
   fromLocation,
   locations,
+  MapMarkerIcon,
   rememberPlace,
   setLocation,
   showUserSettings,
@@ -21,6 +22,7 @@ function EndpointsOverlay({
         forgetPlace={forgetPlace}
         location={fromLocation}
         locations={locations}
+        MapMarkerIcon={MapMarkerIcon}
         rememberPlace={rememberPlace}
         setLocation={setLocation}
         showUserSettings={showUserSettings}
@@ -31,6 +33,7 @@ function EndpointsOverlay({
         forgetPlace={forgetPlace}
         location={toLocation}
         locations={locations}
+        MapMarkerIcon={MapMarkerIcon}
         rememberPlace={rememberPlace}
         setLocation={setLocation}
         showUserSettings={showUserSettings}
@@ -65,6 +68,18 @@ EndpointsOverlay.propTypes = {
    */
   locations: PropTypes.arrayOf(locationType),
   /**
+   * An optional custom component that can be used to create custom html that
+   * is used in a leaflet divIcon to render the map marker icon for each
+   * endpoint.
+   *
+   * See https://leafletjs.com/reference-1.6.0.html#divicon
+   *
+   * This component is passed 2 props:
+   * - location: either the from or to location depending on the endpoint
+   * - type: either "from" or "to"
+   */
+  MapMarkerIcon: PropTypes.elementType,
+  /**
    * Dispatched when a user clicks on the remember place button in the user
    * settings. Not needed unless user settings is activated. Dispatched with an
    * argument in the form of:
@@ -96,6 +111,7 @@ EndpointsOverlay.defaultProps = {
   forgetPlace: noop,
   rememberPlace: noop,
   locations: [],
+  MapMarkerIcon: undefined,
   showUserSettings: false
 };
 


### PR DESCRIPTION
Fixes #37. Allows passing a component as a prop to the endpoints overlay which is then used to render the map icons for the endpoints.