### PR TITLE
Add slot for custom route description component

### DIFF
--- a/packages/itinerary-body/src/AccessLegBody/index.js
+++ b/packages/itinerary-body/src/AccessLegBody/index.js
@@ -254,13 +254,13 @@ function AccessLegSummary({ config, leg, /* LegIcon, */ onSummaryClick }) {
       </div> */}
 
       {/* Leg description, e.g. "Walk 0.5 mi to..." */}
-      <div>
+      <Styled.LegDescription>
         {getLegModeLabel(leg)}{" "}
         {leg.distance > 0 && (
           <span> {humanizeDistanceString(leg.distance)}</span>
         )}
         {` to ${getPlaceName(leg.to, config.companies)}`}
-      </div>
+      </Styled.LegDescription>
     </Styled.LegClickable>
   );
 }

--- a/packages/itinerary-body/src/AccessLegBody/leg-diagram-preview.js
+++ b/packages/itinerary-body/src/AccessLegBody/leg-diagram-preview.js
@@ -81,16 +81,16 @@ class LegDiagramPreview extends Component {
           role="button"
           onClick={this.onExpandClick}
         >
-          <div className="diagram-title text-center">
+          <Styled.PreviewDiagramTitle>
             Elevation chart{" "}
-            <span style={{ fontSize: "xx-small", color: "red" }}>
+            <Styled.PreviewDiagramElevationGain>
               ↑{this.formatElevation(profile.gain * METERS_TO_FEET)}
               {"  "}
-            </span>
-            <span style={{ fontSize: "xx-small", color: "green" }}>
+            </Styled.PreviewDiagramElevationGain>
+            <Styled.PreviewDiagramElevationLoss>
               ↓{this.formatElevation(-profile.loss * METERS_TO_FEET)}
-            </span>
-          </div>
+            </Styled.PreviewDiagramElevationLoss>
+          </Styled.PreviewDiagramTitle>
           {profile.points.length > 0
             ? generateSvg(profile, width)
             : "No elevation data available."}

--- a/packages/itinerary-body/src/ItineraryBody.story.js
+++ b/packages/itinerary-body/src/ItineraryBody.story.js
@@ -33,6 +33,27 @@ const StyledItineraryBody = styled(ItineraryBody)`
   }
 `;
 
+const OtpRRStyledItineraryBody = styled(ItineraryBody)`
+  ${ItineraryBodyClasses.LegDescriptionRouteShortName} {
+    background-color: rgb(15, 106, 172);
+    border-color: white;
+    border-image: initial;
+    border-radius: 12px;
+    border-style: solid;
+    border-width: 1px;
+    box-shadow: rgb(0, 0, 0) 0px 0px 0.25em;
+    color: white;
+    display: inline-block;
+    font-size: 14px;
+    font-weight: 500;
+    height: 21px;
+    margin-right: 8px;
+    padding-top: 2px;
+    text-align: center;
+    width: 24px;
+  }
+`;
+
 class ItineraryBodyDefaultsWrapper extends Component {
   constructor() {
     super();
@@ -47,36 +68,32 @@ class ItineraryBodyDefaultsWrapper extends Component {
     const {
       itinerary,
       PlaceName,
+      RouteDescription,
       showAgencyInfo,
       TransitLegSummary,
-      useStyled
+      styledItinerary
     } = this.props;
     const { diagramVisible } = this.state;
-    return useStyled ? (
-      <StyledItineraryBody
+    let ItineraryBodyComponent;
+    switch (styledItinerary) {
+      case "pink-legs":
+        ItineraryBodyComponent = StyledItineraryBody;
+        break;
+      case "otp-rr":
+        ItineraryBodyComponent = OtpRRStyledItineraryBody;
+        break;
+      default:
+        ItineraryBodyComponent = ItineraryBody;
+    }
+    return (
+      <ItineraryBodyComponent
         config={config}
         diagramVisible={diagramVisible}
         frameLeg={action("frameLeg")}
         itinerary={itinerary}
         LegIcon={TriMetLegIcon}
         PlaceName={PlaceName}
-        routingType="ITINERARY"
-        setActiveLeg={action("setActiveLeg")}
-        setLegDiagram={this.setLegDiagram}
-        setViewedTrip={action("setViewedTrip")}
-        showAgencyInfo={showAgencyInfo}
-        showElevationProfile
-        toRouteAbbreviation={r => r.toString().substr(0, 2)}
-        TransitLegSummary={TransitLegSummary}
-      />
-    ) : (
-      <ItineraryBody
-        config={config}
-        diagramVisible={diagramVisible}
-        frameLeg={action("frameLeg")}
-        itinerary={itinerary}
-        LegIcon={TriMetLegIcon}
-        PlaceName={PlaceName}
+        RouteDescription={RouteDescription}
         routingType="ITINERARY"
         setActiveLeg={action("setActiveLeg")}
         setLegDiagram={this.setLegDiagram}
@@ -93,16 +110,18 @@ class ItineraryBodyDefaultsWrapper extends Component {
 ItineraryBodyDefaultsWrapper.propTypes = {
   itinerary: itineraryType.isRequired,
   PlaceName: PropTypes.elementType,
+  RouteDescription: PropTypes.elementType,
   showAgencyInfo: PropTypes.bool,
   TransitLegSummary: PropTypes.elementType,
-  useStyled: PropTypes.bool
+  styledItinerary: PropTypes.string
 };
 
 ItineraryBodyDefaultsWrapper.defaultProps = {
   showAgencyInfo: false,
   PlaceName: undefined,
+  RouteDescription: undefined,
   TransitLegSummary: undefined,
-  useStyled: false
+  styledItinerary: null
 };
 
 function CustomPlaceName({ place }) {
@@ -116,6 +135,47 @@ function CustomTransitLegSummary({ leg }) {
 }
 
 CustomTransitLegSummary.propTypes = {
+  leg: legType.isRequired
+};
+
+const TriMetLegIconContainer = styled.div`
+  float: left;
+  height: 24px;
+  margin-right: 6px;
+  width: 24px;
+`;
+
+function OtpRRRouteDescription({ leg }) {
+  const { headsign, routeLongName, routeShortName } = leg;
+  return (
+    <ItineraryBodyClasses.LegDescriptionForTransit>
+      <TriMetLegIconContainer>
+        <TriMetLegIcon leg={leg} />
+      </TriMetLegIconContainer>
+      {routeShortName && (
+        <div>
+          <ItineraryBodyClasses.LegDescriptionRouteShortName>
+            {routeShortName}
+          </ItineraryBodyClasses.LegDescriptionRouteShortName>
+        </div>
+      )}
+      <ItineraryBodyClasses.LegDescriptionRouteLongName>
+        {routeLongName}
+        {headsign && (
+          <span>
+            {" "}
+            <ItineraryBodyClasses.LegDescriptionHeadsignPrefix>
+              to
+            </ItineraryBodyClasses.LegDescriptionHeadsignPrefix>{" "}
+            {headsign}
+          </span>
+        )}
+      </ItineraryBodyClasses.LegDescriptionRouteLongName>
+    </ItineraryBodyClasses.LegDescriptionForTransit>
+  );
+}
+
+OtpRRRouteDescription.propTypes = {
   leg: legType.isRequired
 };
 
@@ -134,7 +194,7 @@ storiesOf("ItineraryBody", module)
   .add("Styled ItineraryBody with walk-transit-walk itinerary", () => (
     <ItineraryBodyDefaultsWrapper
       itinerary={walkTransitWalkItinerary}
-      useStyled
+      styledItinerary="pink-legs"
     />
   ))
   .add(
@@ -194,6 +254,16 @@ storiesOf("ItineraryBody", module)
       itinerary={eScooterRentalTransiteScooterRentalItinerary}
     />
   ))
+  .add(
+    "ItineraryBody with E-scooter rental + transit itinerary with OTP-RR styling and customizations",
+    () => (
+      <ItineraryBodyDefaultsWrapper
+        itinerary={eScooterRentalTransiteScooterRentalItinerary}
+        RouteDescription={OtpRRRouteDescription}
+        styledItinerary="otp-rr"
+      />
+    )
+  )
   .add("ItineraryBody with TNC + transit itinerary", () => (
     <ItineraryBodyDefaultsWrapper itinerary={tncTransitTncItinerary} />
   ));

--- a/packages/itinerary-body/src/TransitLegBody/index.js
+++ b/packages/itinerary-body/src/TransitLegBody/index.js
@@ -54,10 +54,9 @@ function DefaultRouteDescription({ leg }) {
         {routeLongName}
         {headsign && (
           <span>
-            {" "}
             <Styled.LegDescriptionHeadsignPrefix>
-              to
-            </Styled.LegDescriptionHeadsignPrefix>{" "}
+              {" to "}
+            </Styled.LegDescriptionHeadsignPrefix>
             {headsign}
           </span>
         )}

--- a/packages/itinerary-body/src/TransitLegBody/index.js
+++ b/packages/itinerary-body/src/TransitLegBody/index.js
@@ -39,6 +39,37 @@ DefaultTransitLegSummary.propTypes = {
   stopsExpanded: PropTypes.bool.isRequired
 };
 
+function DefaultRouteDescription({ leg }) {
+  const { headsign, routeLongName, routeShortName } = leg;
+  return (
+    <Styled.LegDescriptionForTransit>
+      {routeShortName && (
+        <div>
+          <Styled.LegDescriptionRouteShortName>
+            {routeShortName}
+          </Styled.LegDescriptionRouteShortName>
+        </div>
+      )}
+      <Styled.LegDescriptionRouteLongName>
+        {routeLongName}
+        {headsign && (
+          <span>
+            {" "}
+            <Styled.LegDescriptionHeadsignPrefix>
+              to
+            </Styled.LegDescriptionHeadsignPrefix>{" "}
+            {headsign}
+          </span>
+        )}
+      </Styled.LegDescriptionRouteLongName>
+    </Styled.LegDescriptionForTransit>
+  );
+}
+
+DefaultRouteDescription.propTypes = {
+  leg: legType.isRequired
+};
+
 class TransitLegBody extends Component {
   constructor(props) {
     super(props);
@@ -67,21 +98,14 @@ class TransitLegBody extends Component {
     const {
       leg,
       longDateFormat,
+      RouteDescription,
       setViewedTrip,
       showAgencyInfo,
       timeFormat,
       TransitLegSummary,
       transitOperator
     } = this.props;
-    const {
-      agencyBrandingUrl,
-      agencyName,
-      agencyUrl,
-      alerts,
-      routeShortName,
-      routeLongName,
-      headsign
-    } = leg;
+    const { agencyBrandingUrl, agencyName, agencyUrl, alerts } = leg;
     const { alertsExpanded, stopsExpanded } = this.state;
 
     // If the config contains an operator with a logo URL, prefer that over the
@@ -97,24 +121,8 @@ class TransitLegBody extends Component {
     return (
       <Styled.LegBody>
         {/* The Route Icon/Name Bar; clickable to set as active leg */}
-        {/* eslint-disable-next-line */}
         <Styled.LegClickable onClick={this.onSummaryClick}>
-          <div className="route-name leg-description">
-            {routeShortName && (
-              <div>
-                <span className="route-short-name">{routeShortName}</span>
-              </div>
-            )}
-            <div className="route-long-name">
-              {routeLongName}
-              {headsign && (
-                <span>
-                  {" "}
-                  <span style={{ fontWeight: "200" }}>to</span> {headsign}
-                </span>
-              )}
-            </div>
-          </div>
+          <RouteDescription leg={leg} transitOperator={transitOperator} />
         </Styled.LegClickable>
 
         {/* Agency information */}
@@ -124,12 +132,7 @@ class TransitLegBody extends Component {
             <a href={agencyUrl} rel="noopener noreferrer" target="_blank">
               {agencyName}
               {logoUrl && (
-                <img
-                  alt={`${agencyName} logo`}
-                  src={logoUrl}
-                  height={25}
-                  style={{ marginLeft: "5px" }}
-                />
+                <img alt={`${agencyName} logo`} src={logoUrl} height={25} />
               )}
             </a>
           </Styled.AgencyInfo>
@@ -197,6 +200,7 @@ TransitLegBody.propTypes = {
   leg: legType.isRequired,
   legIndex: PropTypes.number.isRequired,
   longDateFormat: PropTypes.string.isRequired,
+  RouteDescription: PropTypes.elementType,
   setActiveLeg: PropTypes.func.isRequired,
   setViewedTrip: PropTypes.func.isRequired,
   showAgencyInfo: PropTypes.bool.isRequired,
@@ -206,6 +210,7 @@ TransitLegBody.propTypes = {
 };
 
 TransitLegBody.defaultProps = {
+  RouteDescription: DefaultRouteDescription,
   TransitLegSummary: DefaultTransitLegSummary,
   transitOperator: null
 };

--- a/packages/itinerary-body/src/index.js
+++ b/packages/itinerary-body/src/index.js
@@ -18,6 +18,7 @@ const ItineraryBody = ({
   frameLeg,
   itinerary,
   PlaceName,
+  RouteDescription,
   routingType,
   setActiveLeg,
   setLegDiagram,
@@ -50,6 +51,7 @@ const ItineraryBody = ({
         legIndex={i}
         place={leg.from}
         PlaceName={PlaceName}
+        RouteDescription={RouteDescription}
         routingType={routingType}
         setActiveLeg={setActiveLeg}
         setLegDiagram={setLegDiagram}
@@ -75,6 +77,7 @@ const ItineraryBody = ({
           LegIcon={LegIcon}
           place={leg.to}
           PlaceName={PlaceName}
+          RouteDescription={RouteDescription}
           routingType={routingType}
           setActiveLeg={setActiveLeg}
           setLegDiagram={setLegDiagram}
@@ -124,6 +127,14 @@ ItineraryBody.propTypes = {
    *   could also be the to place if it is the destination of the itinerary.
    */
   PlaceName: PropTypes.elementType,
+  /**
+   * An optional component to render the name of a route.
+   *
+   * The component is sent 2 props:
+   * - leg: the itinerary leg with the transit information
+   * - transitOperator: the transit operator associated with the route if available
+   */
+  RouteDescription: PropTypes.elementType,
   /** TODO: Routing Type is usually 'ITINERARY' but we should get more details on what this does */
   routingType: PropTypes.string,
   /**
@@ -156,6 +167,7 @@ ItineraryBody.defaultProps = {
   className: null,
   diagramVisible: null,
   PlaceName: undefined,
+  RouteDescription: undefined,
   routingType: "ITINERARY",
   showAgencyInfo: false,
   showElevationProfile: false,

--- a/packages/itinerary-body/src/place-row.js
+++ b/packages/itinerary-body/src/place-row.js
@@ -143,6 +143,7 @@ const PlaceRow = ({
   legIndex,
   place,
   PlaceName,
+  RouteDescription,
   routingType,
   setActiveLeg,
   setLegDiagram,
@@ -229,6 +230,7 @@ const PlaceRow = ({
                 legIndex={legIndex}
                 setActiveLeg={setActiveLeg}
                 longDateFormat={longDateFormat}
+                RouteDescription={RouteDescription}
                 setViewedTrip={setViewedTrip}
                 showAgencyInfo={showAgencyInfo}
                 timeFormat={timeFormat}
@@ -299,6 +301,14 @@ PlaceRow.propTypes = {
    *   could also be the to place if it is the destination of the itinerary.
    */
   PlaceName: PropTypes.elementType,
+  /**
+   * An optional component to render the name of a route.
+   *
+   * The component is sent 2 props:
+   * - leg: the itinerary leg with the transit information
+   * - transitOperator: the transit operator associated with the route if available
+   */
+  RouteDescription: PropTypes.elementType,
   /** TODO: Routing Type is usually 'ITINERARY' but we should get more details on what this does */
   routingType: PropTypes.string.isRequired,
   /**
@@ -337,6 +347,7 @@ PlaceRow.defaultProps = {
   // can be null if this is the destination place
   legIndex: null,
   PlaceName: DefaultPlaceName,
+  RouteDescription: undefined,
   showAgencyInfo: false,
   showElevationProfile: false,
   timeOptions: null,

--- a/packages/itinerary-body/src/styled.js
+++ b/packages/itinerary-body/src/styled.js
@@ -86,6 +86,7 @@ export const AgencyInfo = styled.div`
   }
 
   img {
+    margin-left: 5px;
     vertical-align: middle;
   }
 `;
@@ -213,6 +214,37 @@ export const LegClickable = styled(TransparentButton)`
   display: table;
 `;
 
+export const LegDescription = styled.div`
+  display: table;
+
+  > div {
+    display: table-cell;
+    vertical-align: middle;
+  }
+`;
+
+export const LegDescriptionHeadsignPrefix = styled.span`
+  font-weight: 200;
+`;
+
+export const LegDescriptionRouteLongName = styled.div`
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 16px;
+`;
+
+export const LegDescriptionRouteShortName = styled.div`
+  font-size: 14px;
+  font-weight: 800;
+  line-height: 16px;
+  margin-right: 6px;
+`;
+
+export const LegDescriptionForTransit = styled(LegDescription)`
+  color: rgb(153, 153, 153);
+  margin-top: 5px;
+`;
+
 export const LegIconContainer = styled.div`
   height: 24px;
   width: 24px;
@@ -336,6 +368,26 @@ export const PlaceSubheader = styled.div`
 export const PreviewDiagram = styled(TransparentButton)`
   padding: 2px;
   width: 100%;
+`;
+
+export const PreviewDiagramElevationChange = styled.span`
+  font-size: xx-small;
+`;
+
+export const PreviewDiagramElevationGain = styled(
+  PreviewDiagramElevationChange
+)`
+  color: red;
+`;
+
+export const PreviewDiagramElevationLoss = styled(
+  PreviewDiagramElevationChange
+)`
+  color: green;
+`;
+
+export const PreviewDiagramTitle = styled.div`
+  font-size: small;
 `;
 
 export const RouteBadge = styled.div`


### PR DESCRIPTION
This PR adds a slot to the ItineraryBody component for a custom component that can render the route description. See a new story titled `ItineraryBody with E-scooter rental + transit itinerary with OTP-RR styling and customizations` for an example implementation.

Refs #18.