### PR TITLE
fix(package.json): fixes #54 -- remove 'module' from project.json

### DIFF
--- a/packages/from-to-location-picker/package.json
+++ b/packages/from-to-location-picker/package.json
@@ -6,7 +6,6 @@
   "homepage": "https://github.com/opentripplanner/otp-ui/#readme",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "src/index.js",
   "private": false,
   "dependencies": {
     "@opentripplanner/core-utils": "^0.0.12",

--- a/packages/trip-form/package.json
+++ b/packages/trip-form/package.json
@@ -5,8 +5,7 @@
   "author": "@binh-dam-ibigroup",
   "homepage": "https://github.com/opentripplanner/otp-ui/#readme",
   "license": "MIT",
-  "main": "index.js",
-  "module": "src/index.js",
+  "main": "lib/index.js",
   "private": false,
   "dependencies": {
     "@opentripplanner/core-utils": "^0.0.12",


### PR DESCRIPTION
The 'module' (set to src/index.js) in project.json is problematic.  Removing a couple of instances.  Fixes #54 