### PR TITLE
Stop layer marker customization

### DIFF
--- a/packages/core-utils/src/types.js
+++ b/packages/core-utils/src/types.js
@@ -350,6 +350,13 @@ export const transitIndexStopWithRoutes = PropTypes.shape({
   )
 });
 
+export const stopLayerStopType = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  lat: PropTypes.number.isRequired,
+  lon: PropTypes.number.isRequired
+});
+
 const transitivePlaceType = PropTypes.shape({
   place_id: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired

--- a/packages/stop-viewer-overlay/src/StopViewerOverlay.story.js
+++ b/packages/stop-viewer-overlay/src/StopViewerOverlay.story.js
@@ -1,9 +1,12 @@
 import BaseMap from "@opentripplanner/base-map";
+import { stopLayerStopType } from "@opentripplanner/core-utils/lib/types";
 import React from "react";
+import { CircleMarker } from "react-leaflet";
 import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { storiesOf } from "@storybook/react";
 
+import DefaultStopMarker from "./default-stop-marker";
 import StopViewerOverlay from ".";
 
 import "@opentripplanner/base-map/assets/map.css";
@@ -11,19 +14,21 @@ import "@opentripplanner/base-map/assets/map.css";
 const center = [45.518092, -122.671202];
 const zoom = 13;
 
-const stopData = {
+const fakeStop = {
   id: "stop-id",
   lat: 45.518,
   lon: -122.671,
   name: "Fake Stop"
 };
 
-const leafletPath = {
-  color: "purple",
-  dasharray: "4 1 2",
-  fillColor: "#00ff11",
-  fillOpacity: 1,
-  weight: 5
+function CustomMarker({ stopData }) {
+  return (
+    <CircleMarker center={[stopData.lat, stopData.lon]} key={stopData.id} />
+  );
+}
+
+CustomMarker.propTypes = {
+  stopData: stopLayerStopType.isRequired
 };
 
 storiesOf("StopViewerOverlay", module)
@@ -31,15 +36,18 @@ storiesOf("StopViewerOverlay", module)
   .addDecorator(withInfo)
   .add("StopViewerOverlay", () => (
     <BaseMap center={center} zoom={zoom}>
-      <StopViewerOverlay stopData={stopData} visible />
+      <StopViewerOverlay
+        stopData={fakeStop}
+        StopMarker={DefaultStopMarker}
+        visible
+      />
     </BaseMap>
   ))
-  .add("StopViewerOverlay with custom marker styling", () => (
+  .add("StopViewerOverlay with custom marker", () => (
     <BaseMap center={center} zoom={zoom}>
       <StopViewerOverlay
-        leafletPath={leafletPath}
-        radius={12}
-        stopData={stopData}
+        stopData={fakeStop}
+        StopMarker={CustomMarker}
         visible
       />
     </BaseMap>

--- a/packages/stop-viewer-overlay/src/default-stop-marker.js
+++ b/packages/stop-viewer-overlay/src/default-stop-marker.js
@@ -1,0 +1,39 @@
+import {
+  leafletPathType,
+  stopLayerStopType
+} from "@opentripplanner/core-utils/lib/types";
+import PropTypes from "prop-types";
+import React from "react";
+import { Popup, CircleMarker } from "react-leaflet";
+
+export default function DefaultStopMarker({ leafletPath, radius, stopData }) {
+  return (
+    <CircleMarker
+      /* eslint-disable-next-line react/jsx-props-no-spreading */
+      {...leafletPath}
+      center={[stopData.lat, stopData.lon]}
+      key={stopData.id}
+      radius={radius}
+    >
+      <Popup>
+        <div>{stopData.name}</div>
+      </Popup>
+    </CircleMarker>
+  );
+}
+
+DefaultStopMarker.propTypes = {
+  leafletPath: leafletPathType,
+  radius: PropTypes.number,
+  stopData: stopLayerStopType.isRequired
+};
+
+DefaultStopMarker.defaultProps = {
+  leafletPath: {
+    color: "#000",
+    fillColor: "cyan",
+    fillOpacity: 1,
+    weight: 3
+  },
+  radius: 9
+};

--- a/packages/stop-viewer-overlay/src/index.js
+++ b/packages/stop-viewer-overlay/src/index.js
@@ -1,13 +1,7 @@
-import { leafletPathType } from "@opentripplanner/core-utils/lib/types";
+import { stopLayerStopType } from "@opentripplanner/core-utils/lib/types";
 import PropTypes from "prop-types";
 import React from "react";
-import {
-  FeatureGroup,
-  MapLayer,
-  Popup,
-  CircleMarker,
-  withLeaflet
-} from "react-leaflet";
+import { FeatureGroup, MapLayer, withLeaflet } from "react-leaflet";
 
 /**
  * This overlay is intended to highlight a specific stop on a map typically in
@@ -37,23 +31,13 @@ class StopViewerOverlay extends MapLayer {
   updateLeafletElement() {}
 
   render() {
-    const { leafletPath, radius, stopData } = this.props;
+    const { stopData, StopMarker } = this.props;
 
     if (!stopData) return <FeatureGroup />;
 
     return (
       <FeatureGroup>
-        <CircleMarker
-          /* eslint-disable-next-line react/jsx-props-no-spreading */
-          {...leafletPath}
-          center={[stopData.lat, stopData.lon]}
-          key={stopData.id}
-          radius={radius}
-        >
-          <Popup>
-            <div>{stopData.name}</div>
-          </Popup>
-        </CircleMarker>
+        <StopMarker stopData={stopData} />
       </FeatureGroup>
     );
   }
@@ -61,35 +45,14 @@ class StopViewerOverlay extends MapLayer {
 
 StopViewerOverlay.props = {
   /**
-   * Leaflet path properties to use to style the marker that represents the
-   * stop.
-   *
-   * See https://leafletjs.com/reference-1.6.0.html#path
-   */
-  leafletPath: leafletPathType,
-  /**
-   * The radius in pixels for the stop marker
-   */
-  radius: PropTypes.number,
-  /**
    * An object representing a transit stop
    */
-  stopData: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    lat: PropTypes.number.isRequired,
-    lon: PropTypes.number.isRequired,
-    name: PropTypes.string.isRequired
-  })
+  stopData: stopLayerStopType,
+  StopMarker: PropTypes.elementType.isRequired
 };
 
 StopViewerOverlay.defaultProps = {
-  leafletPath: {
-    color: "#000",
-    fillColor: "cyan",
-    fillOpacity: 1,
-    weight: 3
-  },
-  radius: 9
+  stopData: null
 };
 
 export default withLeaflet(StopViewerOverlay);

--- a/packages/stops-overlay/package.json
+++ b/packages/stops-overlay/package.json
@@ -21,6 +21,9 @@
     "@opentripplanner/core-utils": "^0.0.15",
     "@opentripplanner/from-to-location-picker": "^0.0.15"
   },
+  "devDependencies": {
+    "styled-icons": "^9.1.0"
+  },
   "peerDependencies": {
     "prop-types": "^15.7.2",
     "react": "^16.8.6",

--- a/packages/stops-overlay/src/StopsOverlay.story.js
+++ b/packages/stops-overlay/src/StopsOverlay.story.js
@@ -1,19 +1,38 @@
+import { divIcon } from "leaflet";
 import BaseMap from "@opentripplanner/base-map";
-import { leafletPathType } from "@opentripplanner/core-utils/lib/types";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
+import ReactDOMServer from "react-dom/server";
+import { Marker } from "react-leaflet";
 import { action } from "@storybook/addon-actions";
 import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { storiesOf } from "@storybook/react";
+import { Bus, Subway } from "styled-icons/fa-solid";
 
 import StopsOverlay from ".";
 import mockStops from "../__mocks__/stops.json";
+import DefaultStopMarker, { stopLayerStopType } from "./stop-marker";
 
 import "@opentripplanner/base-map/assets/map.css";
 
 const center = [45.523092, -122.671202];
 const languageConfig = { stopViewer: "View Stop" };
+
+function ExampleMarker({ stop }) {
+  return (
+    <DefaultStopMarker
+      languageConfig={languageConfig}
+      setLocation={action("setLocation")}
+      setViewedStop={action("setViewedStop")}
+      stop={stop}
+    />
+  );
+}
+
+ExampleMarker.propTypes = {
+  stop: stopLayerStopType.isRequired
+};
 
 class Example extends Component {
   constructor() {
@@ -35,18 +54,14 @@ class Example extends Component {
   };
 
   render() {
-    const { stopMarkerPath, stopMarkerRadius } = this.props;
+    const { StopMarker } = this.props;
     const { stops } = this.state;
     return (
       <BaseMap center={center}>
         <StopsOverlay
-          languageConfig={languageConfig}
           name="Transit Stops"
           refreshStops={this.refreshStops}
-          setLocation={action("setLocation")}
-          setViewedStop={action("setViewedStop")}
-          stopMarkerPath={stopMarkerPath}
-          stopMarkerRadius={stopMarkerRadius}
+          StopMarker={StopMarker}
           stops={stops}
           visible
         />
@@ -56,26 +71,33 @@ class Example extends Component {
 }
 
 Example.propTypes = {
-  stopMarkerPath: leafletPathType,
-  stopMarkerRadius: PropTypes.number
+  StopMarker: PropTypes.elementType
 };
 
 Example.defaultProps = {
-  stopMarkerPath: undefined,
-  stopMarkerRadius: undefined
+  StopMarker: ExampleMarker
 };
 
-const stopMarkerPath = {
-  color: "purple",
-  fillColor: "#00ff11",
-  fillOpacity: 1,
-  weight: 3
+function CustomMarker({ stop }) {
+  const iconHtml = ReactDOMServer.renderToStaticMarkup(
+    stop.name.indexOf("MAX") > -1 ? <Subway /> : <Bus color="grey" />
+  );
+  return (
+    <Marker
+      icon={divIcon({ html: iconHtml, className: "" })}
+      position={[stop.lat, stop.lon]}
+    />
+  );
+}
+
+CustomMarker.propTypes = {
+  stop: stopLayerStopType.isRequired
 };
 
 storiesOf("StopsOverlay", module)
   .addDecorator(withA11y)
   .addDecorator(withInfo)
-  .add("StopsOverlay", () => <Example />)
-  .add("StopsOverlay with custom marker styling", () => (
-    <Example stopMarkerPath={stopMarkerPath} stopMarkerRadius={10} />
+  .add("StopsOverlay with default marker", () => <Example />)
+  .add("StopsOverlay with custom marker", () => (
+    <Example StopMarker={CustomMarker} />
   ));

--- a/packages/stops-overlay/src/StopsOverlay.story.js
+++ b/packages/stops-overlay/src/StopsOverlay.story.js
@@ -1,5 +1,6 @@
 import { divIcon } from "leaflet";
 import BaseMap from "@opentripplanner/base-map";
+import { stopLayerStopType } from "@opentripplanner/core-utils/src/types";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import ReactDOMServer from "react-dom/server";
@@ -12,7 +13,7 @@ import { Bus, Subway } from "styled-icons/fa-solid";
 
 import StopsOverlay from ".";
 import mockStops from "../__mocks__/stops.json";
-import DefaultStopMarker, { stopLayerStopType } from "./stop-marker";
+import DefaultStopMarker from "./stop-marker";
 
 import "@opentripplanner/base-map/assets/map.css";
 

--- a/packages/stops-overlay/src/index.js
+++ b/packages/stops-overlay/src/index.js
@@ -1,8 +1,7 @@
+import { stopLayerStopType } from "@opentripplanner/core-utils/src/types";
 import PropTypes from "prop-types";
 import React from "react";
 import { FeatureGroup, MapLayer, withLeaflet } from "react-leaflet";
-
-import { stopLayerStopType } from "./stop-marker";
 
 /**
  * An overlay to view a collection of stops.

--- a/packages/stops-overlay/src/index.js
+++ b/packages/stops-overlay/src/index.js
@@ -1,12 +1,8 @@
-import {
-  languageConfigType,
-  leafletPathType
-} from "@opentripplanner/core-utils/lib/types";
 import PropTypes from "prop-types";
 import React from "react";
 import { FeatureGroup, MapLayer, withLeaflet } from "react-leaflet";
 
-import StopMarker, { stopLayerStopType } from "./stop-marker";
+import { stopLayerStopType } from "./stop-marker";
 
 /**
  * An overlay to view a collection of stops.
@@ -57,17 +53,7 @@ class StopsOverlay extends MapLayer {
   updateLeafletElement() {}
 
   render() {
-    const {
-      languageConfig,
-      leaflet,
-      minZoom,
-      setLocation,
-      setMainPanelContent,
-      setViewedStop,
-      stopMarkerPath,
-      stopMarkerRadius,
-      stops
-    } = this.props;
+    const { leaflet, minZoom, StopMarker, stops } = this.props;
 
     // Don't render if below zoom threshold or no stops visible
     if (
@@ -81,18 +67,7 @@ class StopsOverlay extends MapLayer {
     }
 
     // Helper to create StopMarker from stop
-    const createStopMarker = stop => (
-      <StopMarker
-        key={stop.id}
-        languageConfig={languageConfig}
-        leafletPath={stopMarkerPath}
-        radius={stopMarkerRadius}
-        setLocation={setLocation}
-        setMainPanelContent={setMainPanelContent}
-        setViewedStop={setViewedStop}
-        stop={stop}
-      />
-    );
+    const createStopMarker = stop => <StopMarker key={stop.id} stop={stop} />;
 
     // Singleton case; return FeatureGroup with single StopMarker
     if (stops.length === 1) {
@@ -107,7 +82,6 @@ class StopsOverlay extends MapLayer {
 }
 
 StopsOverlay.propTypes = {
-  languageConfig: languageConfigType.isRequired,
   /** the leaflet reference as obtained from the withLeaflet wrapper */
   /* eslint-disable-next-line react/forbid-prop-types */
   leaflet: PropTypes.object.isRequired,
@@ -121,44 +95,10 @@ StopsOverlay.propTypes = {
    */
   refreshStops: PropTypes.func.isRequired,
   /**
-   * A callback for when a user clicks on setting this stop as either the from
-   * or to location of a new search.
-   *
-   * This will be dispatched with the following argument:
-   *
-   * ```js
-   *  {
-   *    location: {
-   *      lat: number,
-   *      lon: number,
-   *      name: string
-   *    },
-   *    locationType: "from" or "to"
-   *  }
-   * ```
+   * A react component that can be used to render a stop marker. The component
+   * will be sent a single prop of stop which will be a stopLayerStopType.
    */
-  setLocation: PropTypes.func.isRequired,
-  /**
-   * A callback for when a user wants to open the stop viewer for this stop.
-   *
-   * This will be dispatched with the following argument:
-   *
-   * ```js
-   * { stopId: string }
-   * ```
-   */
-  setViewedStop: PropTypes.func.isRequired,
-  /**
-   * Leaflet path properties to use to style each stop marker that represents a
-   * stop.
-   *
-   * See https://leafletjs.com/reference-1.6.0.html#path
-   */
-  stopMarkerPath: leafletPathType,
-  /**
-   * The radius in pixels to draw each stop marker.
-   */
-  stopMarkerRadius: PropTypes.number,
+  StopMarker: PropTypes.elementType.isRequired,
   /**
    * The list of stops to create stop markers for.
    */

--- a/packages/stops-overlay/src/stop-marker.js
+++ b/packages/stops-overlay/src/stop-marker.js
@@ -1,7 +1,8 @@
 import * as BaseMapStyled from "@opentripplanner/base-map/lib/styled";
 import {
   languageConfigType,
-  leafletPathType
+  leafletPathType,
+  stopLayerStopType
 } from "@opentripplanner/core-utils/lib/types";
 import FromToLocationPicker from "@opentripplanner/from-to-location-picker";
 import PropTypes from "prop-types";
@@ -9,13 +10,6 @@ import React, { Component } from "react";
 import { CircleMarker, Popup } from "react-leaflet";
 
 import * as Styled from "./styled";
-
-export const stopLayerStopType = PropTypes.shape({
-  id: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
-  lat: PropTypes.number.isRequired,
-  lon: PropTypes.number.isRequired
-});
 
 export default class StopMarker extends Component {
   onClickView = () => {


### PR DESCRIPTION
This PR adds a slot to the StopOverlay component to allow for the full customization of marker that is used to render stops on the map. The story has been modified to show how to use the default marker if desired.

Fixes #62 

This PR is built on top of #72.