### PR TITLE
Transitive improvements

### DIFF
--- a/packages/core-utils/src/map.js
+++ b/packages/core-utils/src/map.js
@@ -102,7 +102,7 @@ export function itineraryToTransitive(itin, companies) {
     place_lon: itin.legs[itin.legs.length - 1].to.lon
   });
 
-  itin.legs.forEach(leg => {
+  itin.legs.forEach((leg, idx) => {
     if (
       leg.mode === "WALK" ||
       leg.mode === "BICYCLE" ||
@@ -114,6 +114,13 @@ export function itineraryToTransitive(itin, companies) {
         fromPlaceId = `bicycle_rent_station_${leg.from.bikeShareId}`;
       } else if (leg.from.vertexType === "VEHICLERENTAL") {
         fromPlaceId = `escooter_rent_station_${leg.from.name}`;
+      } else if (
+        leg.mode === "CAR" &&
+        idx > 0 &&
+        itin.legs[idx - 1].mode === "WALK"
+      ) {
+        // create a special place ID for car legs preceeded by walking legs
+        fromPlaceId = `itin_car_${streetEdgeId}_from`;
       } else {
         fromPlaceId = `itin_street_${streetEdgeId}_from`;
       }
@@ -123,6 +130,13 @@ export function itineraryToTransitive(itin, companies) {
         toPlaceId = `bicycle_rent_station_${leg.to.bikeShareId}`;
       } else if (leg.to.vertexType === "VEHICLERENTAL") {
         toPlaceId = `escooter_rent_station_${leg.to.name}`;
+      } else if (
+        leg.mode === "CAR" &&
+        idx < itin.legs.length - 1 &&
+        itin.legs[idx + 1].mode === "WALK"
+      ) {
+        // create a special place ID for car legs followed by walking legs
+        toPlaceId = `itin_car_${streetEdgeId}_to`;
       } else {
         toPlaceId = `itin_street_${streetEdgeId}_to`;
       }
@@ -266,6 +280,10 @@ export function isBikeshareStation(place) {
 
 export function isEScooterStation(place) {
   return place.place_id.lastIndexOf("escooter_rent_station") !== -1;
+}
+
+export function isCarWalkTransition(place) {
+  return place.place_id.lastIndexOf("itin_car_") !== -1;
 }
 
 export function isValidLat(lat) {

--- a/packages/transitive-overlay/package.json
+++ b/packages/transitive-overlay/package.json
@@ -19,12 +19,13 @@
   "dependencies": {
     "@opentripplanner/base-map": "^0.0.16",
     "@opentripplanner/core-utils": "^0.0.16",
-    "@opentripplanner/endpoints-overlay": "^0.0.16",
-    "@opentripplanner/icons": "^0.0.16",
-    "@opentripplanner/itinerary-body": "^0.0.16",
     "lodash.isequal": "^4.5.0",
     "react-leaflet": "^2.6.1",
     "transitive-js": "^0.13.0"
+  },
+  "devDependencies": {
+    "@opentripplanner/endpoints-overlay": "^0.0.16",
+    "@opentripplanner/itinerary-body": "^0.0.16"
   },
   "peerDependencies": {
     "react": "^16.8.6"

--- a/packages/transitive-overlay/src/transitive-styles.js
+++ b/packages/transitive-overlay/src/transitive-styles.js
@@ -1,5 +1,6 @@
 import {
   isBikeshareStation,
+  isCarWalkTransition,
   isEScooterStation
 } from "@opentripplanner/core-utils/lib/map";
 
@@ -17,10 +18,17 @@ const STYLES = {};
  */
 STYLES.places = {
   display: (display, place) =>
-    isBikeshareStation(place) || isEScooterStation(place) ? true : "none",
+    isBikeshareStation(place) ||
+    isEScooterStation(place) ||
+    isCarWalkTransition(place)
+      ? true
+      : "none",
   fill: (display, place) => {
     if (isBikeshareStation(place)) {
       return "#f00";
+    }
+    if (isCarWalkTransition(place)) {
+      return "#888";
     }
     if (isEScooterStation(place)) {
       return "#f5a729";


### PR DESCRIPTION
This PR has a slight improvement to the display of car legs that are followed or preceded by walking legs. Before, no transitive place was shown at these transitions and the line would sort of just change from grey to blue or vice versa. Now, a node is drawn and a label is drawn. This affects P&R and TNC requests.

**Before:**
<img width="539" alt="Screen Shot 2020-03-02 at 1 50 17 PM" src="https://user-images.githubusercontent.com/3112493/75721182-c7791700-5c8c-11ea-8f43-9d1fb9ff326e.png">

**After:**
<img width="529" alt="Screen Shot 2020-03-02 at 1 49 41 PM" src="https://user-images.githubusercontent.com/3112493/75721179-c516bd00-5c8c-11ea-9141-49f995151535.png">

