### PR TITLE
endpoints-overlay: make from/to locations optional props

### DIFF
--- a/packages/endpoints-overlay/src/endpoint.js
+++ b/packages/endpoints-overlay/src/endpoint.js
@@ -179,11 +179,15 @@ export default class Endpoint extends Component {
 Endpoint.propTypes = {
   clearLocation: PropTypes.func.isRequired,
   forgetPlace: PropTypes.func.isRequired,
-  location: locationType.isRequired,
+  location: locationType,
   locations: PropTypes.arrayOf(locationType).isRequired,
   MapMarkerIcon: PropTypes.elementType.isRequired,
   rememberPlace: PropTypes.func.isRequired,
   setLocation: PropTypes.func.isRequired,
   showUserSettings: PropTypes.bool.isRequired,
   type: PropTypes.string.isRequired
+};
+
+Endpoint.defaultProps = {
+  location: undefined
 };

--- a/packages/endpoints-overlay/src/index.js
+++ b/packages/endpoints-overlay/src/index.js
@@ -86,7 +86,7 @@ EndpointsOverlay.propTypes = {
   /**
    * The from location.
    */
-  fromLocation: locationType.isRequired,
+  fromLocation: locationType,
   /**
    * An array of location that the user has saved. Not needed unless user
    * settings is activated.
@@ -126,7 +126,7 @@ EndpointsOverlay.propTypes = {
   /**
    * To to location
    */
-  toLocation: locationType.isRequired
+  toLocation: locationType
 };
 
 const noop = () => {};
@@ -134,10 +134,12 @@ const noop = () => {};
 EndpointsOverlay.defaultProps = {
   clearLocation: noop,
   forgetPlace: noop,
+  fromLocation: undefined,
   rememberPlace: noop,
   locations: [],
   MapMarkerIcon: DefaultMapMarkerIcon,
-  showUserSettings: false
+  showUserSettings: false,
+  toLocation: undefined
 };
 
 export default EndpointsOverlay;


### PR DESCRIPTION
This overlay doesn't need the from or to locations to be defined in order to work properly. This PR updates the prop types to match that expectation.