### PR TITLE
Support missing OTP configuration data.

### DIFF
--- a/packages/trip-form/src/CheckboxSelector/index.js
+++ b/packages/trip-form/src/CheckboxSelector/index.js
@@ -49,7 +49,7 @@ CheckboxSelector.propTypes = {
   /**
    * The initial value for the contained <input> control.
    */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   /**
    * The contents of the contained <label> control.
    */

--- a/packages/trip-form/src/SettingsSelectorPanel/index.js
+++ b/packages/trip-form/src/SettingsSelectorPanel/index.js
@@ -93,9 +93,13 @@ export default class SettingsSelectorPanel extends Component {
       // If there are multiple (scooter | bikeshare) providers,
       // then if one is specified by the mode button, select it,
       // othewise select all providers.
+      // selectedCompanies is at least an empty array.
       const selectedCompanies =
         defaultCompany ||
-        getCompanies(supportedCompanies, nonTransitModes).map(comp => comp.id);
+        getCompanies(supportedCompanies, nonTransitModes).map(
+          comp => comp.id
+        ) ||
+        [];
 
       this.handleQueryParamChange({
         mode: finalModes.join(","),
@@ -169,9 +173,10 @@ export default class SettingsSelectorPanel extends Component {
     );
     const nonTransitModes = selectedModes.filter(m => !isTransit(m));
     const companies = getCompaniesOptions(
-      supportedCompanies.filter(comp =>
-        defaultCompany ? comp.id === defaultCompany : true
-      ),
+      supportedCompanies &&
+        supportedCompanies.filter(comp =>
+          defaultCompany ? comp.id === defaultCompany : true
+        ),
       nonTransitModes,
       this.getSelectedCompanies()
     );
@@ -226,7 +231,7 @@ export default class SettingsSelectorPanel extends Component {
           )}
 
         {/* This order is probably better. */}
-        {companies.length >= 2 && (
+        {companies && companies.length >= 2 && (
           <SubmodeSelector
             label="Use companies"
             modes={companies}

--- a/packages/trip-form/src/__mocks__/modes-empty.js
+++ b/packages/trip-form/src/__mocks__/modes-empty.js
@@ -1,0 +1,10 @@
+const commonModesEmpty = {
+  transitModes: [
+    {
+      mode: "BUS",
+      label: "Bus"
+    }
+  ]
+};
+
+export default commonModesEmpty;

--- a/packages/trip-form/src/settings-selector-panel.story.js
+++ b/packages/trip-form/src/settings-selector-panel.story.js
@@ -3,8 +3,9 @@ import { action } from "@storybook/addon-actions";
 import { withInfo } from "@storybook/addon-info";
 
 import SettingsSelectorPanel from "./SettingsSelectorPanel";
-import commonModes from "./__mocks__/modes";
 import commonCompanies from "./__mocks__/companies";
+import commonModes from "./__mocks__/modes";
+import commonModesEmpty from "./__mocks__/modes-empty";
 import trimet from "./__mocks__/trimet.styled";
 
 const onQueryParamChange = action("onQueryParamChange");
@@ -29,3 +30,12 @@ export const settingsSelectorPanel = () => (
 );
 export const settingsSelectorPanelStyled = () =>
   trimet(settingsSelectorPanel());
+
+export const settingsSelectorPanelUndefinedParams = () => (
+  <SettingsSelectorPanel
+    queryParams={queryParams}
+    supportedModes={commonModesEmpty}
+    supportedCompanies={undefined}
+    onQueryParamChange={onQueryParamChange}
+  />
+);

--- a/packages/trip-form/src/util.js
+++ b/packages/trip-form/src/util.js
@@ -88,26 +88,29 @@ function getTransitCombinedModeOptions(modes, selectedModes) {
   const { accessModes } = modes;
   const modesHaveTransit = selectedModes.some(isTransit);
 
-  return accessModes.map(modeObj => {
-    const modeStr = getModeString(modeObj);
-    return {
-      id: `TRANSIT+${modeStr}${modeObj.company ? `+${modeObj.company}` : ""}`,
-      selected: modesHaveTransit && selectedModes.includes(modeStr),
-      text: (
-        <span>
-          <ModeIcon mode="transit" />+<ModeIcon mode={modeStr} />
-        </span>
-      ),
-      title: modeObj.label
-    };
-  });
+  return (
+    accessModes &&
+    accessModes.map(modeObj => {
+      const modeStr = getModeString(modeObj);
+      return {
+        id: `TRANSIT+${modeStr}${modeObj.company ? `+${modeObj.company}` : ""}`,
+        selected: modesHaveTransit && selectedModes.includes(modeStr),
+        text: (
+          <span>
+            <ModeIcon mode="transit" />+<ModeIcon mode={modeStr} />
+          </span>
+        ),
+        title: modeObj.label
+      };
+    })
+  );
 }
 
 function getExclusiveModeOptions(modes, selectedModes) {
   const { exclusiveModes } = modes;
 
   return supportedExclusiveModes
-    .filter(mode => exclusiveModes.includes(mode.mode))
+    .filter(mode => exclusiveModes && exclusiveModes.includes(mode.mode))
     .map(modeObj => ({
       id: modeObj.mode,
       selected:
@@ -135,42 +138,71 @@ export function getModeOptions(modes, selectedModes) {
   };
 }
 
+/**
+ * Of the specified companies, returns those that operate the specified modes.
+ * @param {*} companies The supported companies per OTP configuration.
+ * @param {*} modes The desired modes for which to get the operating companies.
+ * @returns An array of companies that operate the specified modes, or undefined if companies is undefined.
+ */
 export function getCompanies(companies, modes) {
-  return companies
-    .filter(
-      comp => comp.modes.split(",").filter(m => modes.includes(m)).length > 0
-    )
-    .filter(comp => hasRental(comp.modes) || hasHail(comp.modes));
+  return (
+    companies &&
+    companies
+      .filter(
+        comp => comp.modes.split(",").filter(m => modes.includes(m)).length > 0
+      )
+      .filter(comp => hasRental(comp.modes) || hasHail(comp.modes))
+  );
 }
 
+/**
+ * Returns the UI options for the specified companies, modes, and selection.
+ * @param {*} companies The supported companies per OTP configuration.
+ * @param {*} modes The desired modes for which to get the operating companies.
+ * @param {*} selectedCompanies The companies to render selected from the UI.
+ * @returns An array of UI options, or undefined if companies is undefined.
+ */
 export function getCompaniesOptions(companies, modes, selectedCompanies) {
-  return getCompanies(companies, modes).map(comp => {
-    const CompanyIcon = getCompanyIcon(comp.id);
+  const comps = getCompanies(companies, modes);
+  return (
+    comps &&
+    comps.map(comp => {
+      const CompanyIcon = getCompanyIcon(comp.id);
 
-    return {
-      id: comp.id,
-      selected: selectedCompanies.includes(comp.id),
-      text: (
-        <span>
-          <CompanyIcon /> {comp.label}
-        </span>
-      ),
-      title: comp.label
-    };
-  });
+      return {
+        id: comp.id,
+        selected: selectedCompanies.includes(comp.id),
+        text: (
+          <span>
+            <CompanyIcon /> {comp.label}
+          </span>
+        ),
+        title: comp.label
+      };
+    })
+  );
 }
 
+/**
+ * Returns the UI options for the specified bike/micromobility modes and selection.
+ * @param {*} modes The supported bike or micromobility modes.
+ * @param {*} selectedModes The modes to render selected from the UI.
+ * @returns An array of UI options, or undefined if modes is undefined.
+ */
 export function getBicycleOrMicromobilityModeOptions(modes, selectedModes) {
-  return modes.map(mode => {
-    return {
-      id: mode.mode,
-      selected: selectedModes.includes(mode.mode),
-      text: (
-        <span>
-          <ModeIcon mode={mode.mode} /> {mode.label}
-        </span>
-      ),
-      title: mode.label
-    };
-  });
+  return (
+    modes &&
+    modes.map(mode => {
+      return {
+        id: mode.mode,
+        selected: selectedModes.includes(mode.mode),
+        text: (
+          <span>
+            <ModeIcon mode={mode.mode} /> {mode.label}
+          </span>
+        ),
+        title: mode.label
+      };
+    })
+  );
 }


### PR DESCRIPTION
There are some instances where OTP configuration is incomplete (e.g. no micromobility entries), and
we want to handle that gracefully.