### PR TITLE
refactor(callIfValid): Move callIfValid to core-utils

### DIFF
--- a/packages/base-map/__mocks__/SelectVehicles.js
+++ b/packages/base-map/__mocks__/SelectVehicles.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { FeatureGroup, MapLayer, withLeaflet } from "react-leaflet";
 
-import callIfValid from "../src/util";
+import { callIfValid } from "@opentripplanner/core-utils/src/functions";
 
 import VehicleMarker from "./VehicleMarker";
 

--- a/packages/base-map/src/index.js
+++ b/packages/base-map/src/index.js
@@ -1,10 +1,9 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { LayersControl, Map, Popup, TileLayer } from "react-leaflet";
+import { callIfValid } from "@opentripplanner/core-utils/src/functions";
 import { latlngType } from "@opentripplanner/core-utils/src/types";
 import L from "leaflet";
-
-import callIfValid from "./util";
 
 /**
  * panToOffset will allow you to pan the map and adjust for something like a floating

--- a/packages/core-utils/src/functions.js
+++ b/packages/core-utils/src/functions.js
@@ -3,7 +3,8 @@
  * @param {*} fn The function to call.
  * @returns fn if fn is a function, or a dummy function.
  */
-export default function callIfValid(fn) {
+// eslint-disable-next-line import/prefer-default-export
+export function callIfValid(fn) {
   if (typeof fn === "function") return fn;
   return () => {};
 }

--- a/packages/core-utils/src/index.js
+++ b/packages/core-utils/src/index.js
@@ -1,3 +1,4 @@
+import * as functions from "./functions";
 import * as itinerary from "./itinerary";
 import * as map from "./map";
 import * as profile from "./profile";
@@ -8,6 +9,7 @@ import * as types from "./types";
 import * as ui from "./ui";
 
 const core = {
+  functions,
   itinerary,
   map,
   profile,

--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -1,3 +1,4 @@
+import { callIfValid } from "@opentripplanner/core-utils/lib/functions";
 import {
   currentPositionToLocation,
   formatStoredPlaceName
@@ -170,7 +171,7 @@ class LocationField extends Component {
       nearbyStops,
       onTextInputClick
     } = this.props;
-    if (typeof onTextInputClick === "function") onTextInputClick();
+    callIfValid(onTextInputClick)();
     this.setState({ menuVisible: true });
     if (nearbyStops.length === 0 && currentPosition && currentPosition.coords) {
       findNearbyStops({

--- a/packages/transit-vehicle-overlay/src/index.js
+++ b/packages/transit-vehicle-overlay/src/index.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { MapLayer, FeatureGroup, withLeaflet } from "react-leaflet";
 
 import { leafletPathType } from "@opentripplanner/core-utils/src/types";
-import callIfValid from "@opentripplanner/base-map/src/util";
+import { callIfValid } from "@opentripplanner/core-utils/src/functions";
 import { throttle } from "throttle-debounce";
 
 import VehicleLayer from "./VehicleLayer";
@@ -144,9 +144,7 @@ class Vehicles extends MapLayer {
 
     // step 2: share the vehicle list with a registered callback
     const { onVehicleListUpdate } = this.props;
-    if (onVehicleListUpdate && typeof onVehicleListUpdate === "function") {
-      onVehicleListUpdate(vehicleList);
-    }
+    callIfValid(onVehicleListUpdate)(vehicleList);
 
     // step 3: update the tracked vehicle
     this.setTrackedVehicle(trackedId, true);
@@ -165,12 +163,7 @@ class Vehicles extends MapLayer {
 
       // step 4: share tracked vehicle record with a registered callback
       const { onTrackedVehicleUpdate } = this.props;
-      if (
-        onTrackedVehicleUpdate &&
-        typeof onTrackedVehicleUpdate === "function"
-      ) {
-        onTrackedVehicleUpdate(vehicle);
-      }
+      callIfValid(onTrackedVehicleUpdate)(vehicle);
 
       // step 5: recenter map
       this.recenterMap();

--- a/packages/trip-form/src/CheckboxSelector/index.js
+++ b/packages/trip-form/src/CheckboxSelector/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { callIfValid } from "@opentripplanner/core-utils/lib/functions";
 
 import * as Styled from "../styled";
 
@@ -9,12 +10,9 @@ import * as Styled from "../styled";
 class CheckboxSelector extends Component {
   handleChange = evt => {
     const { name, onChange } = this.props;
-
-    if (typeof onChange === "function") {
-      onChange({
-        [name]: evt.target.checked
-      });
-    }
+    callIfValid(onChange)({
+      [name]: evt.target.checked
+    });
   };
 
   render() {

--- a/packages/trip-form/src/DateTimeSelector/index.js
+++ b/packages/trip-form/src/DateTimeSelector/index.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import moment from "moment";
 
+import { callIfValid } from "@opentripplanner/core-utils/lib/functions";
 import {
   OTP_API_DATE_FORMAT,
   OTP_API_TIME_FORMAT
@@ -83,10 +84,7 @@ class DateTimeSelector extends Component {
 
   raiseOnQueryParamChange = queryParam => {
     const { onQueryParamChange } = this.props;
-
-    if (typeof onQueryParamChange === "function") {
-      onQueryParamChange(queryParam);
-    }
+    callIfValid(onQueryParamChange)(queryParam);
   };
 
   handleQueryParamChange = queryParam => {

--- a/packages/trip-form/src/DropdownSelector/index.js
+++ b/packages/trip-form/src/DropdownSelector/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { callIfValid } from "@opentripplanner/core-utils/lib/functions";
 
 import * as Styled from "../styled";
 
@@ -10,13 +11,10 @@ class DropdownSelector extends Component {
   handleChange = evt => {
     const val = evt.target.value;
     const { name, onChange } = this.props;
-
-    if (typeof onChange === "function") {
-      const floatVal = parseFloat(val);
-      onChange({
-        [name]: Number.isNaN(floatVal) ? val : floatVal
-      });
-    }
+    const floatVal = parseFloat(val);
+    callIfValid(onChange)({
+      [name]: Number.isNaN(floatVal) ? val : floatVal
+    });
   };
 
   render() {

--- a/packages/trip-form/src/GeneralSettingsPanel/index.js
+++ b/packages/trip-form/src/GeneralSettingsPanel/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { callIfValid } from "@opentripplanner/core-utils/lib/functions";
 import queryParams from "@opentripplanner/core-utils/lib/query-params";
 import {
   defaultParams,
@@ -20,10 +21,7 @@ import * as Styled from "../styled";
 class GeneralSettingsPanel extends Component {
   handleChange = queryParam => {
     const { onQueryParamChange } = this.props;
-
-    if (typeof onQueryParamChange === "function") {
-      onQueryParamChange(queryParam);
-    }
+    callIfValid(onQueryParamChange)(queryParam);
   };
 
   render() {

--- a/packages/trip-form/src/ModeSelector/index.js
+++ b/packages/trip-form/src/ModeSelector/index.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { callIfValid } from "@opentripplanner/core-utils/lib/functions";
 import { modeSelectorOptionsType } from "@opentripplanner/core-utils/lib/types";
 
 import * as Styled from "../styled";
@@ -18,8 +19,8 @@ const ModeSelector = props => {
   };
 
   const handleClick = option => {
-    if (!option.selected && typeof onChange === "function") {
-      onChange(option.id);
+    if (!option.selected) {
+      callIfValid(onChange)(option.id);
     }
   };
 

--- a/packages/trip-form/src/SettingsSelectorPanel/index.js
+++ b/packages/trip-form/src/SettingsSelectorPanel/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { callIfValid } from "@opentripplanner/core-utils/lib/functions";
 import {
   isMicromobility,
   isTransit
@@ -59,9 +60,7 @@ export default class SettingsSelectorPanel extends Component {
 
   raiseOnQueryParamChange = queryParam => {
     const { onQueryParamChange } = this.props;
-    if (typeof onQueryParamChange === "function") {
-      onQueryParamChange(queryParam);
-    }
+    callIfValid(onQueryParamChange)(queryParam);
   };
 
   handleMainModeChange = id => {


### PR DESCRIPTION
This PR moves `callIfValid` function (was duplicate at one point) to core-utils and applies it in simple cases.
 