### PR TITLE
Trip form custom icons

### DIFF
--- a/packages/trip-form/src/ModeIcon/index.js
+++ b/packages/trip-form/src/ModeIcon/index.js
@@ -4,11 +4,25 @@ import * as Icons from "@opentripplanner/icons";
 
 /**
  * A generic icon component that displays an icon for the specified transportation mode.
+ * If `icons` are defined, then
+ * the icon will be attempted to be used from that lookup of icons. Otherwise,
+ * an icon from the OTP-UI icons package will be returned.
  */
-const ModeIcon = props => {
-  const { mode } = props;
+const ModeIcon = ({ icons, mode }) => {
   if (!mode) return null;
-  switch (mode.toLowerCase()) {
+
+  // Check if there is a custom icon
+  if (icons && mode in icons) {
+    return icons[mode];
+  }
+
+  // From OTP-RR:lib/util/itinerary.js:
+  // Custom icon not available for the given iconId. Use the ModeIcon component
+  // to show the icon based on the iconId, but always use the default car icon
+  // for any car-based modes that didn't have custom icon.
+  const finalMode = mode && mode.startsWith("CAR") ? "CAR" : mode;
+
+  switch (finalMode.toLowerCase()) {
     case "bus":
       return <Icons.Bus />;
     case "tram":
@@ -43,6 +57,13 @@ const ModeIcon = props => {
 
 ModeIcon.propTypes = {
   /**
+   * A customized lookup of icons.
+   * These are defined as part of the implementing webapp.
+   * If this lookup is not defined, then a lookup using the OPT-UI icons package will be used instead.
+   */
+  // eslint-disable-next-line react/forbid-prop-types
+  icons: PropTypes.object,
+  /**
    * One of the supported modes (case-insensitive):
    * "bus",
     "tram",
@@ -60,6 +81,10 @@ ModeIcon.propTypes = {
     "transit"
    */
   mode: PropTypes.string.isRequired
+};
+
+ModeIcon.defaultProps = {
+  icons: null
 };
 
 export default ModeIcon;

--- a/packages/trip-form/src/ModeIcon/index.js
+++ b/packages/trip-form/src/ModeIcon/index.js
@@ -6,23 +6,21 @@ import * as Icons from "@opentripplanner/icons";
  * A generic icon component that displays an icon for the specified transportation mode.
  * If `icons` are defined, then
  * the icon will be attempted to be used from that lookup of icons. Otherwise,
- * an icon from the OTP-UI icons package will be returned.
+ * an icon from the OTP-UI icons package will be returned if available.
  */
 const ModeIcon = ({ icons, mode }) => {
   if (!mode) return null;
 
-  // Check if there is a custom icon
+  // Check if there is a custom icon (exact match required).
   if (icons && mode in icons) {
     return icons[mode];
   }
 
-  // From OTP-RR:lib/util/itinerary.js:
-  // Custom icon not available for the given iconId. Use the ModeIcon component
-  // to show the icon based on the iconId, but always use the default car icon
-  // for any car-based modes that didn't have custom icon.
-  const finalMode = mode && mode.startsWith("CAR") ? "CAR" : mode;
+  // If the custom icon is not available for the given mode,
+  // then use the OTP-UI icons package.
+  const modeLowerCase = mode.toLowerCase();
 
-  switch (finalMode.toLowerCase()) {
+  switch (modeLowerCase) {
     case "bus":
       return <Icons.Bus />;
     case "tram":
@@ -41,6 +39,7 @@ const ModeIcon = ({ icons, mode }) => {
       return <Icons.Ferry />;
     case "gondola":
       return <Icons.AerialTram />;
+    case "car":
     case "car_park":
       return <Icons.Car />;
     case "car_hail":
@@ -51,6 +50,11 @@ const ModeIcon = ({ icons, mode }) => {
     case "transit":
       return <Icons.TriMet />;
     default:
+      // From https://github.com/opentripplanner/otp-react-redux/blob/dev/lib/util/itinerary.js#L216:
+      // "Always use the default car icon
+      // for any car-based modes that didn't have custom icon"
+      // (and that are not listed above).
+      if (modeLowerCase.startsWith("car")) return <Icons.Car />;
       return null;
   }
 };

--- a/packages/trip-form/src/SettingsSelectorPanel/index.js
+++ b/packages/trip-form/src/SettingsSelectorPanel/index.js
@@ -161,11 +161,17 @@ export default class SettingsSelectorPanel extends Component {
   };
 
   render() {
-    const { className, supportedModes, supportedCompanies, style } = this.props;
+    const {
+      className,
+      icons,
+      supportedModes,
+      supportedCompanies,
+      style
+    } = this.props;
     const { defaultAccessModeCompany, queryParams } = this.state;
     const selectedModes = this.getSelectedModes();
 
-    const modeOptions = getModeOptions(supportedModes, selectedModes);
+    const modeOptions = getModeOptions(icons, supportedModes, selectedModes);
     const transitModes = getTransitSubmodeOptions(
       supportedModes,
       selectedModes
@@ -253,6 +259,13 @@ SettingsSelectorPanel.propTypes = {
    */
   className: PropTypes.string,
   /**
+   * A customized lookup of icons.
+   * These are defined as part of the implementing webapp.
+   * If this lookup is not defined, then a lookup using the OPT-UI icons package will be used instead.
+   */
+  // eslint-disable-next-line react/forbid-prop-types
+  icons: PropTypes.object,
+  /**
    * Triggered when a query parameter is changed.
    * @param params An object that contains the new values for the parameter(s) that has (have) changed.
    */
@@ -275,6 +288,7 @@ SettingsSelectorPanel.propTypes = {
 
 SettingsSelectorPanel.defaultProps = {
   className: null,
+  icons: null,
   onQueryParamChange: null,
   queryParams: null,
   supportedCompanies: []

--- a/packages/trip-form/src/SettingsSelectorPanel/index.js
+++ b/packages/trip-form/src/SettingsSelectorPanel/index.js
@@ -173,6 +173,7 @@ export default class SettingsSelectorPanel extends Component {
 
     const modeOptions = getModeOptions(icons, supportedModes, selectedModes);
     const transitModes = getTransitSubmodeOptions(
+      icons,
       supportedModes,
       selectedModes
     );
@@ -185,10 +186,12 @@ export default class SettingsSelectorPanel extends Component {
       this.getSelectedCompanies()
     );
     const bikeModes = getBicycleOrMicromobilityModeOptions(
+      icons,
       supportedModes.bicycleModes,
       selectedModes
     );
     const scooterModes = getBicycleOrMicromobilityModeOptions(
+      icons,
       supportedModes.micromobilityModes,
       selectedModes
     );

--- a/packages/trip-form/src/__mocks__/custom-icons.js
+++ b/packages/trip-form/src/__mocks__/custom-icons.js
@@ -1,6 +1,12 @@
 import React from "react";
 import * as Icons from "@opentripplanner/icons";
 
+/**
+ * The custom icons you pass to the SettingsSelectorPanel icons prop
+ * is a custom map between standard OTP mode IDs and icons you wish to use for these IDs.
+ * This map doesn't have to be complete, and, for missing modes,
+ * an icon from OTP-UI icons package will be used when necessary.
+ */
 const customIcons = {
   TRANSIT: <Icons.Ferry />,
   RAIL: <Icons.Max />,

--- a/packages/trip-form/src/__mocks__/custom-icons.js
+++ b/packages/trip-form/src/__mocks__/custom-icons.js
@@ -1,0 +1,11 @@
+import React from "react";
+import * as Icons from "@opentripplanner/icons";
+
+const customIcons = {
+  TRANSIT: <Icons.Ferry />,
+  RAIL: <Icons.Max />,
+  TRAM: <Icons.AerialTram />,
+  BUS: <Icons.Car />
+};
+
+export default customIcons;

--- a/packages/trip-form/src/__mocks__/custom-icons.js
+++ b/packages/trip-form/src/__mocks__/custom-icons.js
@@ -5,7 +5,8 @@ const customIcons = {
   TRANSIT: <Icons.Ferry />,
   RAIL: <Icons.Max />,
   TRAM: <Icons.AerialTram />,
-  BUS: <Icons.Car />
+  BUS: <Icons.Car />,
+  BICYCLE: <Icons.Accessible />
 };
 
 export default customIcons;

--- a/packages/trip-form/src/components.story.js
+++ b/packages/trip-form/src/components.story.js
@@ -7,10 +7,10 @@ import * as Icons from "@opentripplanner/icons";
 import * as Core from ".";
 import ModeIcon from "./ModeIcon";
 
-import ModeIconWrap from "./__mocks__/mode-icon-wrap";
-import modeOptions from "./__mocks__/mode-options";
 import commonModes from "./__mocks__/modes";
 import customIcons from "./__mocks__/custom-icons";
+import modeOptions from "./__mocks__/mode-options";
+import ModeIconWrap from "./__mocks__/mode-icon-wrap";
 import submodeOptions from "./__mocks__/submode-options";
 import trimet from "./__mocks__/trimet.styled";
 

--- a/packages/trip-form/src/components.story.js
+++ b/packages/trip-form/src/components.story.js
@@ -10,6 +10,7 @@ import ModeIcon from "./ModeIcon";
 import ModeIconWrap from "./__mocks__/mode-icon-wrap";
 import modeOptions from "./__mocks__/mode-options";
 import commonModes from "./__mocks__/modes";
+import customIcons from "./__mocks__/custom-icons";
 import submodeOptions from "./__mocks__/submode-options";
 import trimet from "./__mocks__/trimet.styled";
 
@@ -69,6 +70,12 @@ export const generalSettingsPanelStyled = () => trimet(generalSettingsPanel());
 export const modeIcon = () => (
   <ModeIconWrap>
     <ModeIcon mode={object("mode", "BICYCLE")} />
+  </ModeIconWrap>
+);
+
+export const modeIconWithCustomIcons = () => (
+  <ModeIconWrap>
+    <ModeIcon icons={customIcons} mode={object("mode", "TRANSIT")} />
   </ModeIconWrap>
 );
 

--- a/packages/trip-form/src/components.story.js
+++ b/packages/trip-form/src/components.story.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
 import { withInfo } from "@storybook/addon-info";
-import { withKnobs, object, boolean } from "@storybook/addon-knobs";
+import { withKnobs, boolean, text } from "@storybook/addon-knobs";
 import * as Icons from "@opentripplanner/icons";
 
 import * as Core from ".";
@@ -58,7 +58,7 @@ export const dropdownSelectorStyled = () => trimet(dropdownSelector());
 export const generalSettingsPanel = () => (
   <Core.GeneralSettingsPanel
     query={{
-      mode: object("mode", "WALK,BUS,TRAM,SUBWAY"),
+      mode: text("mode", "WALK,BUS,TRAM,SUBWAY"),
       routingType: "ITINERARY"
     }}
     onQueryParamChange={onQueryParamChange}
@@ -69,13 +69,13 @@ export const generalSettingsPanelStyled = () => trimet(generalSettingsPanel());
 
 export const modeIcon = () => (
   <ModeIconWrap>
-    <ModeIcon mode={object("mode", "BICYCLE")} />
+    <ModeIcon mode={text("mode", "BICYCLE")} />
   </ModeIconWrap>
 );
 
 export const modeIconWithCustomIcons = () => (
   <ModeIconWrap>
-    <ModeIcon icons={customIcons} mode={object("mode", "TRANSIT")} />
+    <ModeIcon icons={customIcons} mode={text("mode", "TRANSIT")} />
   </ModeIconWrap>
 );
 

--- a/packages/trip-form/src/settings-selector-panel.story.js
+++ b/packages/trip-form/src/settings-selector-panel.story.js
@@ -3,9 +3,11 @@ import { action } from "@storybook/addon-actions";
 import { withInfo } from "@storybook/addon-info";
 
 import SettingsSelectorPanel from "./SettingsSelectorPanel";
+
 import commonCompanies from "./__mocks__/companies";
 import commonModes from "./__mocks__/modes";
 import commonModesEmpty from "./__mocks__/modes-empty";
+import customIcons from "./__mocks__/custom-icons";
 import trimet from "./__mocks__/trimet.styled";
 
 const onQueryParamChange = action("onQueryParamChange");
@@ -30,6 +32,16 @@ export const settingsSelectorPanel = () => (
 );
 export const settingsSelectorPanelStyled = () =>
   trimet(settingsSelectorPanel());
+
+export const settingsSelectorPanelWithCustomIcons = () => (
+  <SettingsSelectorPanel
+    icons={customIcons}
+    queryParams={queryParams}
+    supportedModes={commonModes}
+    supportedCompanies={commonCompanies}
+    onQueryParamChange={onQueryParamChange}
+  />
+);
 
 export const settingsSelectorPanelUndefinedParams = () => (
   <SettingsSelectorPanel

--- a/packages/trip-form/src/util.js
+++ b/packages/trip-form/src/util.js
@@ -49,7 +49,7 @@ export function getModeString(modeObj) {
   return modeObj.mode || modeObj;
 }
 
-export function getTransitSubmodeOptions(modes, selectedModes) {
+export function getTransitSubmodeOptions(icons, modes, selectedModes) {
   const { transitModes } = modes;
 
   // FIXME: If only one transit mode is available, select it.
@@ -60,7 +60,7 @@ export function getTransitSubmodeOptions(modes, selectedModes) {
       selected: selectedModes.includes(modeStr),
       text: (
         <span>
-          <ModeIcon mode={modeStr} />
+          <ModeIcon icons={icons} mode={modeStr} />
           {modeObj.label}
         </span>
       ),
@@ -98,7 +98,7 @@ function getTransitCombinedModeOptions(icons, modes, selectedModes) {
         text: (
           <span>
             <ModeIcon icons={icons} mode="TRANSIT" />+
-            <ModeIcon mode={modeStr} />
+            <ModeIcon icons={icons} mode={modeStr} />
           </span>
         ),
         title: modeObj.label
@@ -183,7 +183,11 @@ export function getCompaniesOptions(companies, modes, selectedCompanies) {
  * @param {*} selectedModes The modes to render selected from the UI.
  * @returns An array of UI options, or undefined if modes is undefined.
  */
-export function getBicycleOrMicromobilityModeOptions(modes, selectedModes) {
+export function getBicycleOrMicromobilityModeOptions(
+  icons,
+  modes,
+  selectedModes
+) {
   return (
     modes &&
     modes.map(mode => {
@@ -192,7 +196,7 @@ export function getBicycleOrMicromobilityModeOptions(modes, selectedModes) {
         selected: selectedModes.includes(mode.mode),
         text: (
           <span>
-            <ModeIcon mode={mode.mode} /> {mode.label}
+            <ModeIcon icons={icons} mode={mode.mode} /> {mode.label}
           </span>
         ),
         title: mode.label

--- a/packages/trip-form/src/util.js
+++ b/packages/trip-form/src/util.js
@@ -69,14 +69,14 @@ export function getTransitSubmodeOptions(modes, selectedModes) {
   });
 }
 
-function getPrimaryModeOption(selectedModes) {
+function getPrimaryModeOption(icons, selectedModes) {
   return {
     id: "TRANSIT",
     selected: selectedModes.some(isTransit) && selectedModes.includes("WALK"),
     showTitle: false,
     text: (
       <span>
-        <ModeIcon mode="transit" />
+        <ModeIcon icons={icons} mode="TRANSIT" />
         Take Transit
       </span>
     ),
@@ -84,7 +84,7 @@ function getPrimaryModeOption(selectedModes) {
   };
 }
 
-function getTransitCombinedModeOptions(modes, selectedModes) {
+function getTransitCombinedModeOptions(icons, modes, selectedModes) {
   const { accessModes } = modes;
   const modesHaveTransit = selectedModes.some(isTransit);
 
@@ -97,7 +97,8 @@ function getTransitCombinedModeOptions(modes, selectedModes) {
         selected: modesHaveTransit && selectedModes.includes(modeStr),
         text: (
           <span>
-            <ModeIcon mode="transit" />+<ModeIcon mode={modeStr} />
+            <ModeIcon icons={icons} mode="TRANSIT" />+
+            <ModeIcon mode={modeStr} />
           </span>
         ),
         title: modeObj.label
@@ -106,7 +107,7 @@ function getTransitCombinedModeOptions(modes, selectedModes) {
   );
 }
 
-function getExclusiveModeOptions(modes, selectedModes) {
+function getExclusiveModeOptions(icons, modes, selectedModes) {
   const { exclusiveModes } = modes;
 
   return supportedExclusiveModes
@@ -118,7 +119,7 @@ function getExclusiveModeOptions(modes, selectedModes) {
       showTitle: false,
       text: (
         <span>
-          <ModeIcon mode={modeObj.mode} /> {modeObj.label}
+          <ModeIcon icons={icons} mode={modeObj.mode} /> {modeObj.label}
         </span>
       ),
       title: modeObj.label
@@ -130,11 +131,11 @@ function getExclusiveModeOptions(modes, selectedModes) {
  * @param {*} modes The modes defined in config.yaml.
  * @param {*} selectedModes An array of string that lists the modes selected for a trip query.
  */
-export function getModeOptions(modes, selectedModes) {
+export function getModeOptions(icons, modes, selectedModes) {
   return {
-    primary: getPrimaryModeOption(selectedModes),
-    secondary: getTransitCombinedModeOptions(modes, selectedModes),
-    tertiary: getExclusiveModeOptions(modes, selectedModes)
+    primary: getPrimaryModeOption(icons, selectedModes),
+    secondary: getTransitCombinedModeOptions(icons, modes, selectedModes),
+    tertiary: getExclusiveModeOptions(icons, modes, selectedModes)
   };
 }
 


### PR DESCRIPTION
This PR addresses #87 by allowing implements to pass custom icons into `SettingsSelectorPanel` the way OTP-react-redux does, so implementers can optionally use icons in the mode selection pane other than the ones from the OTP-UI icons package. In particular, in OTP-UI icons, the "Take Transit" icon is the TriMet's logo, so with this PR, implementers will be able to change it.

This PR also fixes improper knob types used in some storybook stories.
