### PR TITLE
Make from-to-location-picker and endpoints-overlay return consistent data structures and one other thing

### DIFF
--- a/packages/base-map/src/index.js
+++ b/packages/base-map/src/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { LayersControl, Map, Popup, TileLayer } from "react-leaflet";
-import { latlngType } from "@opentripplanner/core-utils/src/types";
+import utils from "@opentripplanner/core-utils";
 import L from "leaflet";
 
 import callIfValid from "./util";
@@ -268,7 +268,7 @@ BaseMap.propTypes = {
   /**
    * The center of the map, as a [lat, lng] array.
    */
-  center: latlngType.isRequired,
+  center: utils.types.latlngType.isRequired,
   /**
    * The maximum zoom level allowed on the map.
    */
@@ -310,7 +310,7 @@ BaseMap.propTypes = {
    */
   popup: PropTypes.shape({
     contents: PropTypes.node.isRequired,
-    location: latlngType.isRequired
+    location: utils.types.latlngType.isRequired
   }),
   /**
    * The zoom level of the map.

--- a/packages/endpoints-overlay/src/endpoint.js
+++ b/packages/endpoints-overlay/src/endpoint.js
@@ -87,7 +87,7 @@ export default class Endpoint extends Component {
   onDragEnd = e => {
     const { setLocation, type } = this.props;
     const location = constructLocation(e.target.getLatLng());
-    setLocation({ type, location, reverseGeocode: true });
+    setLocation({ locationType: type, location, reverseGeocode: true });
   };
 
   render() {

--- a/packages/from-to-location-picker/src/index.js
+++ b/packages/from-to-location-picker/src/index.js
@@ -15,8 +15,8 @@ class FromToLocationPicker extends Component {
       return;
     }
     setLocation({
-      type: "from",
       location,
+      locationType: "from",
       reverseGeocode: false
     });
   };
@@ -28,8 +28,8 @@ class FromToLocationPicker extends Component {
       return;
     }
     setLocation({
-      type: "to",
       location,
+      locationType: "to",
       reverseGeocode: false
     });
   };
@@ -78,7 +78,7 @@ FromToLocationPicker.propTypes = {
    * are no from/to specific handler functions defined as props.
    *
    * Passes an argument as follows:
-   * { type: "from/to", location, reverseGeocode: false }
+   * { locationType: "from/to", location, reverseGeocode: false }
    */
   setLocation: PropTypes.func,
   /**

--- a/packages/from-to-location-picker/src/index.story.js
+++ b/packages/from-to-location-picker/src/index.story.js
@@ -19,7 +19,7 @@ export const fromTo = () => (
 );
 
 export const smallTextSansSerif = () => (
-  <span style={{ "font-size": "75%", "font-family": "sans-serif" }}>
+  <span style={{ fontSize: "75%", fontFamily: "sans-serif" }}>
     Plan a trip:
     <FromToLocationPicker onFromClick={onFromClick} onToClick={onToClick} />
   </span>

--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -53,8 +53,7 @@ class LocationField extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      value:
-        props.location && !props.hideExistingValue ? props.location.name : "",
+      value: this.getValueFromLocation(),
       menuVisible: false,
       geocodedFeatures: [],
       activeIndex: null
@@ -81,6 +80,14 @@ class LocationField extends Component {
     const { locationType } = this.props;
     return `${locationType}-form-control`;
   }
+
+  /**
+   * Gets the initial value to place in the input field.
+   */
+  getValueFromLocation = () => {
+    const { hideExistingValue, location } = this.props;
+    return location && !hideExistingValue ? location.name : "";
+  };
 
   setLocation(location, resultType) {
     const { onLocationSelected, locationType } = this.props;
@@ -147,13 +154,16 @@ class LocationField extends Component {
    * user having made a selection.
    */
   onBlurFormGroup = e => {
-    const { location } = this.props;
     // IE does not use relatedTarget, so this check handles cross-browser support.
     // see https://stackoverflow.com/a/49325196/915811
     const target =
       e.relatedTarget !== null ? e.relatedTarget : document.activeElement;
-    if (!location && (!target || target.getAttribute("role") !== "menuitem")) {
-      this.setState({ menuVisible: false, value: "", geocodedFeatures: [] });
+    if (!target || target.getAttribute("role") !== "menuitem") {
+      this.setState({
+        geocodedFeatures: [],
+        menuVisible: false,
+        value: this.getValueFromLocation()
+      });
     }
   };
 
@@ -240,6 +250,7 @@ class LocationField extends Component {
         evt.preventDefault();
         break;
       case "Escape":
+      case "Tab":
         // Clear selection & hide the menu
         this.setState({
           menuVisible: false,

--- a/packages/stops-overlay/src/index.js
+++ b/packages/stops-overlay/src/index.js
@@ -1,4 +1,4 @@
-import { stopLayerStopType } from "@opentripplanner/core-utils/src/types";
+import utils from "@opentripplanner/core-utils";
 import PropTypes from "prop-types";
 import React from "react";
 import { FeatureGroup, MapLayer, withLeaflet } from "react-leaflet";
@@ -101,7 +101,7 @@ StopsOverlay.propTypes = {
   /**
    * The list of stops to create stop markers for.
    */
-  stops: PropTypes.arrayOf(stopLayerStopType).isRequired
+  stops: PropTypes.arrayOf(utils.types.stopLayerStopType).isRequired
 };
 
 StopsOverlay.defaultProps = {


### PR DESCRIPTION
To be consistent with the `location-field` and the `stops-overlay` packages, this changes the `setLocation` callback in the `from-to-location-picker`and `endpoints-overlay` packages to have the same data structure.