### PR TITLE
Stop viewer overlay rename stopdata

### DIFF
--- a/packages/stop-viewer-overlay/src/StopViewerOverlay.story.js
+++ b/packages/stop-viewer-overlay/src/StopViewerOverlay.story.js
@@ -21,14 +21,12 @@ const fakeStop = {
   name: "Fake Stop"
 };
 
-function CustomMarker({ stopData }) {
-  return (
-    <CircleMarker center={[stopData.lat, stopData.lon]} key={stopData.id} />
-  );
+function CustomMarker({ stop }) {
+  return <CircleMarker center={[stop.lat, stop.lon]} key={stop.id} />;
 }
 
 CustomMarker.propTypes = {
-  stopData: stopLayerStopType.isRequired
+  stop: stopLayerStopType.isRequired
 };
 
 storiesOf("StopViewerOverlay", module)
@@ -37,7 +35,7 @@ storiesOf("StopViewerOverlay", module)
   .add("StopViewerOverlay", () => (
     <BaseMap center={center} zoom={zoom}>
       <StopViewerOverlay
-        stopData={fakeStop}
+        stop={fakeStop}
         StopMarker={DefaultStopMarker}
         visible
       />
@@ -45,10 +43,6 @@ storiesOf("StopViewerOverlay", module)
   ))
   .add("StopViewerOverlay with custom marker", () => (
     <BaseMap center={center} zoom={zoom}>
-      <StopViewerOverlay
-        stopData={fakeStop}
-        StopMarker={CustomMarker}
-        visible
-      />
+      <StopViewerOverlay stop={fakeStop} StopMarker={CustomMarker} visible />
     </BaseMap>
   ));

--- a/packages/stop-viewer-overlay/src/default-stop-marker.js
+++ b/packages/stop-viewer-overlay/src/default-stop-marker.js
@@ -6,17 +6,17 @@ import PropTypes from "prop-types";
 import React from "react";
 import { Popup, CircleMarker } from "react-leaflet";
 
-export default function DefaultStopMarker({ leafletPath, radius, stopData }) {
+export default function DefaultStopMarker({ leafletPath, radius, stop }) {
   return (
     <CircleMarker
       /* eslint-disable-next-line react/jsx-props-no-spreading */
       {...leafletPath}
-      center={[stopData.lat, stopData.lon]}
-      key={stopData.id}
+      center={[stop.lat, stop.lon]}
+      key={stop.id}
       radius={radius}
     >
       <Popup>
-        <div>{stopData.name}</div>
+        <div>{stop.name}</div>
       </Popup>
     </CircleMarker>
   );
@@ -25,7 +25,7 @@ export default function DefaultStopMarker({ leafletPath, radius, stopData }) {
 DefaultStopMarker.propTypes = {
   leafletPath: leafletPathType,
   radius: PropTypes.number,
-  stopData: stopLayerStopType.isRequired
+  stop: stopLayerStopType.isRequired
 };
 
 DefaultStopMarker.defaultProps = {

--- a/packages/stop-viewer-overlay/src/index.js
+++ b/packages/stop-viewer-overlay/src/index.js
@@ -19,8 +19,8 @@ class StopViewerOverlay extends MapLayer {
    * in the viewer.
    */
   componentDidUpdate(prevProps) {
-    const nextStop = this.props.stopData;
-    const oldStopId = prevProps.stopData && prevProps.stopData.id;
+    const nextStop = this.props.stop;
+    const oldStopId = prevProps.stop && prevProps.stop.id;
     const hasNewStopId = nextStop && nextStop.id !== oldStopId;
     if (hasNewStopId)
       this.props.leaflet.map.setView([nextStop.lat, nextStop.lon]);
@@ -31,13 +31,13 @@ class StopViewerOverlay extends MapLayer {
   updateLeafletElement() {}
 
   render() {
-    const { stopData, StopMarker } = this.props;
+    const { stop, StopMarker } = this.props;
 
-    if (!stopData) return <FeatureGroup />;
+    if (!stop) return <FeatureGroup />;
 
     return (
       <FeatureGroup>
-        <StopMarker stopData={stopData} />
+        <StopMarker stop={stop} />
       </FeatureGroup>
     );
   }
@@ -47,12 +47,12 @@ StopViewerOverlay.props = {
   /**
    * An object representing a transit stop
    */
-  stopData: stopLayerStopType,
+  stop: stopLayerStopType,
   StopMarker: PropTypes.elementType.isRequired
 };
 
 StopViewerOverlay.defaultProps = {
-  stopData: null
+  stop: null
 };
 
 export default withLeaflet(StopViewerOverlay);


### PR DESCRIPTION
This PR renames all occurrences of `stopData` to `stop` to have consistency with other packages. Fixes #93.