### PR TITLE
fix(trip-detail): Make expand/collapse icon size slightly smaller

### DIFF
--- a/packages/trip-details/src/trip-detail.js
+++ b/packages/trip-details/src/trip-detail.js
@@ -37,7 +37,7 @@ export default class TripDetail extends Component {
           {summary}
           {description && (
             <Styled.ExpandButton onClick={this.toggle}>
-              <QuestionCircle size={17} />
+              <QuestionCircle size="0.92em" />
             </Styled.ExpandButton>
           )}
           <VelocityTransitionGroup
@@ -47,7 +47,7 @@ export default class TripDetail extends Component {
             {expanded && (
               <Styled.TripDetailDescription>
                 <Styled.HideButton onClick={this.onHideClick}>
-                  <TimesCircle size={17} />
+                  <TimesCircle size="0.92em" />
                 </Styled.HideButton>
                 {description}
               </Styled.TripDetailDescription>


### PR DESCRIPTION
This PR makes a slight adjustment to expand/collapse icons of the trip detail calories description (see screenshot).

![image](https://user-images.githubusercontent.com/56846598/77961534-f8f2fb80-72a7-11ea-94c6-5cfc4e5cf9ab.png)

