### PR TITLE
Update call to turf-along to use updated argument format

### DIFF
--- a/packages/core-utils/src/itinerary.js
+++ b/packages/core-utils/src/itinerary.js
@@ -256,7 +256,7 @@ export function legLocationAtDistance(leg, distance) {
 
   try {
     const line = polyline.toGeoJSON(leg.legGeometry.points);
-    const pt = turfAlong(line, distance, "meters");
+    const pt = turfAlong(line, distance, { units: "meters" });
     if (pt && pt.geometry && pt.geometry.coordinates) {
       return [pt.geometry.coordinates[1], pt.geometry.coordinates[0]];
     }


### PR DESCRIPTION
When creating the core-utils package, the dependent turf packages were updated to the latest version. As a part of this, one of the arguments for a call to turf-along is now incorrect. This PR fixes it so that the argument is called with the correct format.