### PR TITLE
Add Travis to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+cache:
+  yarn: true
+node_js:
+  - "12"
+script:
+  - yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ node_js:
   - "12"
 script:
   - yarn test
+# TODO: add deploy stage that updates storybook (for each branch?)


### PR DESCRIPTION
This PR adds a `.travis.yml` file to the repo root directory so that the Travis CI system can automatically execute tests each time someone pushes new commits to a pull request on GitHub.

Prerequisite: This repo needs to be linked on Travis CI.

