### PR TITLE
Fix types

### DIFF
--- a/packages/core-utils/src/types.js
+++ b/packages/core-utils/src/types.js
@@ -498,8 +498,8 @@ export const modeSelectorOptionsType = PropTypes.shape({
 });
 
 export const queryType = PropTypes.shape({
-  from: PropTypes.string,
-  to: PropTypes.string,
+  from: locationType,
+  to: locationType,
   date: PropTypes.string,
   time: PropTypes.string,
   departArrive: PropTypes.string,

--- a/packages/core-utils/src/types.js
+++ b/packages/core-utils/src/types.js
@@ -266,11 +266,16 @@ const moneyType = PropTypes.shape({
  */
 export const fareType = PropTypes.shape({
   details: PropTypes.objectOf(
-    PropTypes.shape({
-      fareId: feedScopedIdType.isRequired,
-      price: moneyType.isRequired,
-      routes: PropTypes.arrayOf(feedScopedIdType).isRequired
-    }).isRequired
+    PropTypes.arrayOf(
+      PropTypes.shape({
+        fareId: PropTypes.oneOfType([PropTypes.string, feedScopedIdType])
+          .isRequired,
+        price: moneyType.isRequired,
+        routes: PropTypes.arrayOf(
+          PropTypes.oneOfType([PropTypes.string, feedScopedIdType])
+        ).isRequired
+      })
+    ).isRequired
   ),
   fare: PropTypes.objectOf(moneyType)
 });

--- a/packages/itinerary-body/src/__mocks__/itineraries/bike-transit-bike.json
+++ b/packages/itinerary-body/src/__mocks__/itineraries/bike-transit-bike.json
@@ -22,7 +22,23 @@
         "cents": 250
       }
     },
-    "details": {}
+    "details": {
+      "regular": [
+        {
+          "fareId": "1:238",
+          "price": {
+            "currency": {
+              "symbol": "$",
+              "currency": "USD",
+              "defaultFractionDigits": 2,
+              "currencyCode": "USD"
+            },
+            "cents": 250
+          },
+          "routes": ["1:1"]
+        }
+      ]
+    }
   },
   "legs": [
     {

--- a/packages/trip-form/src/components.story.js
+++ b/packages/trip-form/src/components.story.js
@@ -83,6 +83,8 @@ export const dropdownSelector = () => (
 export const generalSettingsPanel = () => (
   <Core.GeneralSettingsPanel
     query={{
+      // The from and to params below are for testing queryType,
+      // they are not actually used by the component.
       from: {
         lat: 33.9,
         lon: -84.63,

--- a/packages/trip-form/src/components.story.js
+++ b/packages/trip-form/src/components.story.js
@@ -83,6 +83,16 @@ export const dropdownSelector = () => (
 export const generalSettingsPanel = () => (
   <Core.GeneralSettingsPanel
     query={{
+      from: {
+        lat: 33.9,
+        lon: -84.63,
+        name: "Place 1"
+      },
+      to: {
+        lat: 33.8,
+        lon: -84.62,
+        name: "Place 2"
+      },
       mode: text("mode", "WALK,BUS,TRAM,SUBWAY"),
       routingType: "ITINERARY"
     }}


### PR DESCRIPTION
This PR fixed these non-blocking issues that cause unnecessary error messages in the browser console:
* fix #103 
* fix #96 

To test on your machine until next release: in the affected components, replace `import ... from "@opentripplanner/core-utils/lib/types"` with `import ... from "../../core-utils/src/types"`.

EDIT: Affected components: `GeneralSettingsPanel` and `SettingsSelectorPanel` in package `trip-form`.