### PR TITLE
LocationField: Add autoFocus prop.

### DIFF
--- a/packages/location-field/src/LocationField.story.js
+++ b/packages/location-field/src/LocationField.story.js
@@ -239,4 +239,33 @@ storiesOf("LocationField", module)
       userLocationsAndRecentPlaces={userLocationsAndRecentPlaces}
       UserLocationIconComponent={UserLocationIconComponent}
     />
+  ))
+  .add("LocationField no auto-focus with multiple controls", () => (
+    <div>
+      <input id="example" value="Enter text" />
+      <button type="button">Click me!</button>
+      <LocationField
+        currentPosition={currentPosition}
+        geocoderConfig={geocoderConfig}
+        getCurrentPosition={getCurrentPosition}
+        inputPlaceholder="Select from location"
+        locationType="from"
+        onLocationSelected={onLocationSelected}
+      />
+    </div>
+  ))
+  .add("LocationField auto-focus with multiple controls", () => (
+    <div>
+      <input id="example" value="Enter text" />
+      <button type="button">Click me!</button>
+      <LocationField
+        autoFocus
+        currentPosition={currentPosition}
+        geocoderConfig={geocoderConfig}
+        getCurrentPosition={getCurrentPosition}
+        inputPlaceholder="Select from location"
+        locationType="from"
+        onLocationSelected={onLocationSelected}
+      />
+    </div>
   ));

--- a/packages/location-field/src/LocationField.story.js
+++ b/packages/location-field/src/LocationField.story.js
@@ -242,7 +242,7 @@ storiesOf("LocationField", module)
   ))
   .add("LocationField no auto-focus with multiple controls", () => (
     <div>
-      <input id="example" value="Enter text" />
+      <input id="example" defaultValue="Enter text" />
       <button type="button">Click me!</button>
       <LocationField
         currentPosition={currentPosition}
@@ -256,7 +256,7 @@ storiesOf("LocationField", module)
   ))
   .add("LocationField auto-focus with multiple controls", () => (
     <div>
-      <input id="example" value="Enter text" />
+      <input id="example" defaultValue="Enter text" />
       <button type="button">Click me!</button>
       <LocationField
         autoFocus

--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -290,6 +290,7 @@ class LocationField extends Component {
   render() {
     const {
       addLocationSearch,
+      autoFocus,
       className,
       currentPosition,
       currentPositionIcon,
@@ -538,6 +539,7 @@ class LocationField extends Component {
         ref={ref => {
           this.inputRef = ref;
         }}
+        autoFocus={autoFocus}
         className={this.getFormControlClassname()}
         value={value}
         placeholder={placeholder}
@@ -613,6 +615,10 @@ LocationField.propTypes = {
    * ```
    */
   addLocationSearch: PropTypes.func,
+  /**
+   * Determines whether the input field of this component should auto-focus on first display.
+   */
+  autoFocus: PropTypes.bool,
   /**
    * Used for additional styling with styled components for example.
    */
@@ -813,6 +819,7 @@ LocationField.propTypes = {
 };
 
 LocationField.defaultProps = {
+  autoFocus: false,
   addLocationSearch: () => {},
   className: null,
   clearLocation: () => {},


### PR DESCRIPTION
This PR fixes #133. To use, set the `autoFocus` prop of the control that has the initial focus to `true` as you would do with other HTML input controls.