### PR TITLE
Invoke getCurrentTime/getCurrentDate correctly

### DIFF
--- a/packages/core-utils/src/query.js
+++ b/packages/core-utils/src/query.js
@@ -185,7 +185,7 @@ function parseLocationString(value) {
  *    params.
  * @param config the config in the otp-rr store.
  */
-export function planParamsToQuery(params, config) {
+export function planParamsToQuery(params) {
   const query = {};
   Object.keys(params).forEach(key => {
     switch (key) {
@@ -204,10 +204,10 @@ export function planParamsToQuery(params, config) {
             : "NOW";
         break;
       case "date":
-        query.date = params.date || getCurrentDate(config);
+        query.date = params.date || getCurrentDate();
         break;
       case "time":
-        query.time = params.time || getCurrentTime(config);
+        query.time = params.time || getCurrentTime();
         break;
       default: {
         const maybeNumber = Number(params[key]);

--- a/packages/core-utils/src/query.js
+++ b/packages/core-utils/src/query.js
@@ -183,7 +183,6 @@ function parseLocationString(value) {
  *
  * @param  {Object} params An object representing the parsed querystring of url
  *    params.
- * @param config the config in the otp-rr store.
  */
 export function planParamsToQuery(params) {
   const query = {};


### PR DESCRIPTION
Removes config arg from these method calls and from `planParamsToQuery`.