### PR TITLE
fix(itinerary-body (otp-rr)): Fix route label padding for transit legs

### DIFF
--- a/packages/itinerary-body/src/otp-react-redux/itinerary-body.js
+++ b/packages/itinerary-body/src/otp-react-redux/itinerary-body.js
@@ -40,7 +40,7 @@ const StyledItineraryBody = styled(ItineraryBody)`
     height: 24px;
     margin-right: 8px;
     min-width: 24px;
-    padding: 2px;
+    padding: 2px 3px;
     text-align: center;
   }
 


### PR DESCRIPTION
This mirrors
https://github.com/opentripplanner/otp-react-redux/pull/184/commits/ed5fb366e495f8bd55a792b5c69582c9ec461fc3