### PR TITLE
Provide a helpful warning for missing company icon

### DIFF
--- a/packages/icons/src/companies/index.js
+++ b/packages/icons/src/companies/index.js
@@ -31,7 +31,11 @@ const companyLookup = {
 };
 
 function getCompanyIcon(name) {
-  return companyLookup[name.toLowerCase()];
+  const icon = companyLookup[name.toLowerCase()];
+  if (!icon) {
+    console.warn(`No Company Icon found for: '${name}'!`);
+  }
+  return icon;
 }
 
 export {


### PR DESCRIPTION
This change provides a helpful warning message in the event that a company icon is not found.