### PR TITLE
Itinerary Body: TimeColumnContent slot

### DIFF
--- a/packages/itinerary-body/src/ItineraryBody.story.js
+++ b/packages/itinerary-body/src/ItineraryBody.story.js
@@ -16,6 +16,7 @@ import DefaultTransitLegSummary from "./defaults/transit-leg-summary";
 import {
   CustomPlaceName,
   customToRouteAbbreviation,
+  CustomTimeColumnContent,
   CustomTransitLegSummary,
   StyledItineraryBody,
   WrappedOtpRRTransitLegSubheader
@@ -63,6 +64,7 @@ class ItineraryBodyDefaultsWrapper extends Component {
       showMapButtonColumn,
       showViewTripButton,
       styledItinerary,
+      TimeColumnContent,
       toRouteAbbreviation,
       TransitLegSubheader,
       TransitLegSummary
@@ -98,6 +100,7 @@ class ItineraryBodyDefaultsWrapper extends Component {
         showLegIcon={showLegIcon}
         showMapButtonColumn={showMapButtonColumn}
         showViewTripButton={showViewTripButton}
+        TimeColumnContent={TimeColumnContent}
         toRouteAbbreviation={toRouteAbbreviation}
         TransitLegSubheader={TransitLegSubheader}
         TransitLegSummary={TransitLegSummary || DefaultTransitLegSummary}
@@ -117,6 +120,7 @@ ItineraryBodyDefaultsWrapper.propTypes = {
   showMapButtonColumn: PropTypes.bool,
   showViewTripButton: PropTypes.bool,
   styledItinerary: PropTypes.string,
+  TimeColumnContent: PropTypes.elementType,
   toRouteAbbreviation: PropTypes.func,
   TransitLegSubheader: PropTypes.elementType,
   TransitLegSummary: PropTypes.elementType
@@ -132,12 +136,13 @@ ItineraryBodyDefaultsWrapper.defaultProps = {
   showMapButtonColumn: true,
   showViewTripButton: false,
   styledItinerary: null,
+  TimeColumnContent: undefined,
   toRouteAbbreviation: r => r.toString().substr(0, 2),
   TransitLegSubheader: undefined,
   TransitLegSummary: undefined
 };
 
-function OtpRRItineraryBodyWrapper({ itinerary }) {
+function OtpRRItineraryBodyWrapper({ itinerary, TimeColumnContent }) {
   return (
     <ItineraryBodyDefaultsWrapper
       itinerary={itinerary}
@@ -150,13 +155,18 @@ function OtpRRItineraryBodyWrapper({ itinerary }) {
       showMapButtonColumn={false}
       showViewTripButton
       styledItinerary="otp-rr"
+      TimeColumnContent={TimeColumnContent}
       TransitLegSubheader={WrappedOtpRRTransitLegSubheader}
     />
   );
 }
 
 OtpRRItineraryBodyWrapper.propTypes = {
-  itinerary: itineraryType.isRequired
+  itinerary: itineraryType.isRequired,
+  TimeColumnContent: PropTypes.elementType
+};
+OtpRRItineraryBodyWrapper.defaultProps = {
+  TimeColumnContent: undefined
 };
 
 storiesOf("ItineraryBody", module)
@@ -308,4 +318,10 @@ storiesOf("ItineraryBody", module)
   .add(
     "ItineraryBody with TNC + transit itinerary with OTP-RR styling and customizations",
     () => <OtpRRItineraryBodyWrapper itinerary={tncTransitTncItinerary} />
-  );
+  )
+  .add("ItineraryBody with OTP-RR styling and custom TimeColumnContent", () => (
+    <OtpRRItineraryBodyWrapper
+      itinerary={tncTransitTncItinerary}
+      TimeColumnContent={CustomTimeColumnContent}
+    />
+  ));

--- a/packages/itinerary-body/src/defaults/time-column-content.js
+++ b/packages/itinerary-body/src/defaults/time-column-content.js
@@ -4,13 +4,11 @@ import {
   timeOptionsType
 } from "@opentripplanner/core-utils/lib/types";
 import PropTypes from "prop-types";
-import React from "react";
 
-const TimeColumnContent = ({ isDestination, leg, timeOptions }) => {
+export default function TimeColumnContent({ isDestination, leg, timeOptions }) {
   const time = isDestination ? leg.endTime : leg.startTime;
-
-  return <>{time && formatTime(time, timeOptions)}</>;
-};
+  return time && formatTime(time, timeOptions);
+}
 
 TimeColumnContent.propTypes = {
   /** Whether this place row represents the destination */
@@ -24,5 +22,3 @@ TimeColumnContent.propTypes = {
 TimeColumnContent.defaultProps = {
   timeOptions: null
 };
-
-export default TimeColumnContent;

--- a/packages/itinerary-body/src/defaults/time-column-content.js
+++ b/packages/itinerary-body/src/defaults/time-column-content.js
@@ -1,0 +1,28 @@
+import { formatTime } from "@opentripplanner/core-utils/lib/time";
+import {
+  legType,
+  timeOptionsType
+} from "@opentripplanner/core-utils/lib/types";
+import PropTypes from "prop-types";
+import React from "react";
+
+const TimeColumnContent = ({ isDestination, leg, timeOptions }) => {
+  const time = isDestination ? leg.endTime : leg.startTime;
+
+  return <>{time && formatTime(time, timeOptions)}</>;
+};
+
+TimeColumnContent.propTypes = {
+  /** Whether this place row represents the destination */
+  isDestination: PropTypes.bool.isRequired,
+  /** Contains details about leg object that is being displayed */
+  leg: legType.isRequired,
+  /** Contains the preferred format string for time display and a timezone offset */
+  timeOptions: timeOptionsType
+};
+
+TimeColumnContent.defaultProps = {
+  timeOptions: null
+};
+
+export default TimeColumnContent;

--- a/packages/itinerary-body/src/defaults/time-column-content.js
+++ b/packages/itinerary-body/src/defaults/time-column-content.js
@@ -5,6 +5,10 @@ import {
 } from "@opentripplanner/core-utils/lib/types";
 import PropTypes from "prop-types";
 
+/**
+ * This is the default component for displaying the time with the specified format
+ * of the given leg in the time column of the ItineraryBody -> PlaceRow component.
+ */
 export default function TimeColumnContent({ isDestination, leg, timeOptions }) {
   const time = isDestination ? leg.endTime : leg.startTime;
   return time && formatTime(time, timeOptions);

--- a/packages/itinerary-body/src/demos/index.js
+++ b/packages/itinerary-body/src/demos/index.js
@@ -21,6 +21,10 @@ export function CustomPlaceName({ place }) {
   return `🎉✨🎊 ${place.name} 🎉✨🎊`;
 }
 
+/**
+ * Custom example component for displaying the time and other info
+ * of the given leg in the time column of the ItineraryBody -> PlaceRow component.
+ */
 export function CustomTimeColumnContent({ isDestination, leg, timeOptions }) {
   const time = isDestination ? leg.endTime : leg.startTime;
 

--- a/packages/itinerary-body/src/demos/index.js
+++ b/packages/itinerary-body/src/demos/index.js
@@ -1,8 +1,13 @@
-import { formatDuration } from "@opentripplanner/core-utils/lib/time";
+import {
+  formatDuration,
+  formatTime
+} from "@opentripplanner/core-utils/lib/time";
 import {
   languageConfigType,
-  legType
+  legType,
+  timeOptionsType
 } from "@opentripplanner/core-utils/lib/types";
+import { Transittracker } from "@opentripplanner/icons";
 import PropTypes from "prop-types";
 import React from "react";
 import { action } from "@storybook/addon-actions";
@@ -15,6 +20,34 @@ import * as ItineraryBodyClasses from "../styled";
 export function CustomPlaceName({ place }) {
   return `🎉✨🎊 ${place.name} 🎉✨🎊`;
 }
+
+export function CustomTimeColumnContent({ isDestination, leg, timeOptions }) {
+  const time = isDestination ? leg.endTime : leg.startTime;
+
+  return (
+    <>
+      <div>
+        <Transittracker style={{ height: "1em" }} />
+        <span style={{ color: "red" }}>
+          {time && formatTime(time, timeOptions)}
+        </span>
+      </div>
+      <div style={{ fontSize: "80%" }}>
+        Delayed {leg.departureDelay}&nbsp;min.
+      </div>
+    </>
+  );
+}
+
+CustomTimeColumnContent.propTypes = {
+  isDestination: PropTypes.bool.isRequired,
+  leg: legType.isRequired,
+  timeOptions: timeOptionsType
+};
+
+CustomTimeColumnContent.defaultProps = {
+  timeOptions: null
+};
 
 export function customToRouteAbbreviation(route) {
   if (route.toString().length < 3) {

--- a/packages/itinerary-body/src/demos/index.js
+++ b/packages/itinerary-body/src/demos/index.js
@@ -7,11 +7,11 @@ import {
   legType,
   timeOptionsType
 } from "@opentripplanner/core-utils/lib/types";
-import { Transittracker } from "@opentripplanner/icons";
 import PropTypes from "prop-types";
 import React from "react";
 import { action } from "@storybook/addon-actions";
 import styled from "styled-components";
+import { ExclamationTriangle } from "styled-icons/fa-solid";
 
 import ItineraryBody from "..";
 import OtpRRTransitLegSubheader from "../otp-react-redux/transit-leg-subheader";
@@ -22,7 +22,7 @@ export function CustomPlaceName({ place }) {
 }
 
 /**
- * Custom example component for displaying the time and other info
+ * Custom component, for illustration purposes only, for displaying the time and other info
  * of the given leg in the time column of the ItineraryBody -> PlaceRow component.
  */
 export function CustomTimeColumnContent({ isDestination, leg, timeOptions }) {
@@ -31,13 +31,12 @@ export function CustomTimeColumnContent({ isDestination, leg, timeOptions }) {
   return (
     <>
       <div>
-        <Transittracker style={{ height: "1em", marginRight: "6px" }} />
         <span style={{ color: "red" }}>
           {time && formatTime(time, timeOptions)}
         </span>
       </div>
-      <div style={{ fontSize: "80%" }}>
-        Delayed {leg.departureDelay}&nbsp;min.
+      <div style={{ fontSize: "80%", lineHeight: "1em" }}>
+        <ExclamationTriangle style={{ height: "1em" }} /> Delayed xx&nbsp;min.
       </div>
     </>
   );

--- a/packages/itinerary-body/src/demos/index.js
+++ b/packages/itinerary-body/src/demos/index.js
@@ -31,7 +31,7 @@ export function CustomTimeColumnContent({ isDestination, leg, timeOptions }) {
   return (
     <>
       <div>
-        <Transittracker style={{ height: "1em" }} />
+        <Transittracker style={{ height: "1em", marginRight: "6px" }} />
         <span style={{ color: "red" }}>
           {time && formatTime(time, timeOptions)}
         </span>

--- a/packages/itinerary-body/src/index.js
+++ b/packages/itinerary-body/src/index.js
@@ -29,6 +29,7 @@ const ItineraryBody = ({
   showLegIcon,
   showMapButtonColumn,
   showViewTripButton,
+  TimeColumnContent,
   timeOptions,
   toRouteAbbreviation,
   TransitLegSubheader,
@@ -70,6 +71,7 @@ const ItineraryBody = ({
           showLegIcon={showLegIcon}
           showMapButtonColumn={showMapButtonColumn}
           showViewTripButton={showViewTripButton}
+          TimeColumnContent={TimeColumnContent}
           timeOptions={timeOptions}
           toRouteAbbreviation={toRouteAbbreviation}
           TransitLegSubheader={TransitLegSubheader}
@@ -170,6 +172,14 @@ ItineraryBody.propTypes = {
   showMapButtonColumn: PropTypes.bool,
   /** If true, shows the view trip button in transit leg bodies */
   showViewTripButton: PropTypes.bool,
+  /**
+   * A slot for a component that can render the content in the time column.
+   * This component is sent the following props:
+   * - isDestination - whether this place is the destination
+   * - leg - the current leg
+   * - timeOptions - options for formatting time.
+   */
+  TimeColumnContent: PropTypes.elementType,
   /** Contains the preferred format string for time display and a timezone offset */
   timeOptions: timeOptionsType,
   /** Converts a route's ID to its accepted badge abbreviation */
@@ -202,6 +212,7 @@ ItineraryBody.defaultProps = {
   showLegIcon: false,
   showMapButtonColumn: true,
   showViewTripButton: false,
+  TimeColumnContent: PlaceRow.defaultProps.TimeColumnContent,
   timeOptions: null,
   toRouteAbbreviation: noop,
   TransitLegSubheader: undefined

--- a/packages/itinerary-body/src/place-row.js
+++ b/packages/itinerary-body/src/place-row.js
@@ -60,6 +60,7 @@ const PlaceRow = ({
   return (
     <Styled.PlaceRowWrapper key={legIndex || "destination-place"}>
       <Styled.TimeColumn>
+        {/* Custom rendering of the departure/arrival time of the specified leg. */}
         <TimeColumnContent
           isDestination={isDestination}
           leg={leg}

--- a/packages/itinerary-body/src/place-row.js
+++ b/packages/itinerary-body/src/place-row.js
@@ -1,4 +1,3 @@
-import { formatTime } from "@opentripplanner/core-utils/lib/time";
 import {
   configType,
   legType,
@@ -7,6 +6,7 @@ import {
 import PropTypes from "prop-types";
 import React from "react";
 
+import DefaultTimeColumnContent from "./defaults/time-column-content";
 import AccessLegBody from "./AccessLegBody";
 import * as Styled from "./styled";
 import TransitLegBody from "./TransitLegBody";
@@ -41,6 +41,7 @@ const PlaceRow = ({
   showLegIcon,
   showMapButtonColumn,
   showViewTripButton,
+  TimeColumnContent,
   timeOptions,
   toRouteAbbreviation,
   TransitLegSubheader,
@@ -54,13 +55,16 @@ const PlaceRow = ({
   const interline = !!(!isDestination && leg.interlineWithPreviousLeg);
   const hideBorder = interline || !legIndex;
   const place = isDestination ? leg.to : leg.from;
-  const time = isDestination ? leg.endTime : leg.startTime;
 
   const { longDateFormat, timeFormat } = config.dateTime;
   return (
     <Styled.PlaceRowWrapper key={legIndex || "destination-place"}>
       <Styled.TimeColumn>
-        {time && formatTime(time, timeOptions)}
+        <TimeColumnContent
+          isDestination={isDestination}
+          leg={leg}
+          timeOptions={timeOptions}
+        />
       </Styled.TimeColumn>
       <Styled.LineColumn>
         <LineColumnContent
@@ -169,6 +173,7 @@ PlaceRow.propTypes = {
   showLegIcon: PropTypes.bool.isRequired,
   showMapButtonColumn: PropTypes.bool.isRequired,
   showViewTripButton: PropTypes.bool.isRequired,
+  TimeColumnContent: PropTypes.elementType,
   timeOptions: timeOptionsType,
   toRouteAbbreviation: PropTypes.func.isRequired,
   TransitLegSubheader: PropTypes.elementType,
@@ -180,6 +185,7 @@ PlaceRow.defaultProps = {
   followsTransit: false,
   // can be null if this is the origin place
   lastLeg: null,
+  TimeColumnContent: DefaultTimeColumnContent,
   timeOptions: null,
   TransitLegSubheader: undefined
 };


### PR DESCRIPTION
This PR fixes #191 and introduces a slot for custom rendering of the contents in the time column of the itinerary component. 
