### PR TITLE
Fix undefined error on value.split call

### DIFF
--- a/packages/core-utils/src/__tests__/__snapshots__/query.js.snap
+++ b/packages/core-utils/src/__tests__/__snapshots__/query.js.snap
@@ -33,6 +33,24 @@ Object {
 }
 `;
 
+exports[`query parseLocationString should return location for valid input 1`] = `
+Object {
+  "lat": 33.983929829,
+  "lon": -87.3892387982,
+  "name": "123 Main St",
+}
+`;
+
+exports[`query parseLocationString should return location with coordinates as name for coordinates-only input 1`] = `
+Object {
+  "lat": 33.983929829,
+  "lon": -87.3892387982,
+  "name": "33.98393, -87.38924",
+}
+`;
+
+exports[`query parseLocationString should return null for null input 1`] = `null`;
+
 exports[`query planParamsToQuery should parse a depart at query 1`] = `
 Object {
   "bannedRoutes": "897ABC",

--- a/packages/core-utils/src/__tests__/query.js
+++ b/packages/core-utils/src/__tests__/query.js
@@ -3,7 +3,11 @@ import {
   setDefaultTestTime
 } from "../../../../test-utils/time";
 
-import { getDefaultQuery, planParamsToQuery } from "../query";
+import {
+  getDefaultQuery,
+  parseLocationString,
+  planParamsToQuery
+} from "../query";
 
 describe("query", () => {
   afterEach(restoreDateNowBehavior);
@@ -37,6 +41,24 @@ describe("query", () => {
     it("should return default query", () => {
       setDefaultTestTime();
       expect(getDefaultQuery()).toMatchSnapshot();
+    });
+  });
+
+  describe("parseLocationString", () => {
+    it("should return null for null input", () => {
+      expect(parseLocationString(null)).toMatchSnapshot();
+    });
+
+    it("should return location for valid input", () => {
+      expect(
+        parseLocationString("123 Main St::33.983929829,-87.3892387982")
+      ).toMatchSnapshot();
+    });
+
+    it("should return location with coordinates as name for coordinates-only input", () => {
+      expect(
+        parseLocationString("33.983929829,-87.3892387982")
+      ).toMatchSnapshot();
     });
   });
 });

--- a/packages/core-utils/src/query.js
+++ b/packages/core-utils/src/query.js
@@ -194,6 +194,9 @@ async function getFirstGeocodeResult(text, geocoderConfig) {
 /**
  * OTP allows passing a location in the form '123 Main St::lat,lon', so we check
  * for the double colon and parse the coordinates accordingly.
+ * @param  {string} value - query param for place described above
+ * @return {Location} - location or null if the value is falsey or the parsed
+ *                      coordinates do not result in both a lat and lon
  */
 export function parseLocationString(value) {
   if (!value) return null;

--- a/packages/core-utils/src/query.js
+++ b/packages/core-utils/src/query.js
@@ -196,6 +196,7 @@ async function getFirstGeocodeResult(text, geocoderConfig) {
  * for the double colon and parse the coordinates accordingly.
  */
 export function parseLocationString(value) {
+  if (!value) return null;
   const parts = value.split("::");
   const coordinates = parts[1]
     ? stringToCoords(parts[1])


### PR DESCRIPTION
If there is no value defined for a fromPlace/toPlace the `parseLocationString` call fails. This fixes that issue.