### PR TITLE
Relax proptypes for LocationIcon

### DIFF
--- a/packages/location-icon/src/LocationIcon.story.js
+++ b/packages/location-icon/src/LocationIcon.story.js
@@ -5,10 +5,6 @@ import { withInfo } from "@storybook/addon-info";
 import styled from "styled-components";
 import LocationIcon from ".";
 
-const StyledLocationIcon = styled(LocationIcon)`
-  color: blue;
-`;
-
 storiesOf("LocationIcon", module)
   .addDecorator(withA11y)
   .addDecorator(withInfo)
@@ -22,6 +18,9 @@ storiesOf("LocationIcon", module)
   .add("Generic Place LocationIcon", () => (
     <LocationIcon type="intermediate-place-1" size={25} />
   ))
-  .add("Custom style for 'To' LocationIcon", () => (
-    <StyledLocationIcon type="to" size={25} />
-  ));
+  .add("Custom style for 'To' LocationIcon", () => {
+    const StyledLocationIcon = styled(LocationIcon)`
+      color: blue;
+    `;
+    return <StyledLocationIcon type="to" size={25} />;
+  });

--- a/packages/location-icon/src/LocationIcon.story.js
+++ b/packages/location-icon/src/LocationIcon.story.js
@@ -17,8 +17,11 @@ storiesOf("LocationIcon", module)
       text: "A simple component used to show the from or to location icon"
     }
   })
-  .add("From LocationIcon", () => <LocationIcon type="from" size={25} />)
-  .add("To LocationIcon", () => <LocationIcon type="to" size={25} />)
-  .add("To LocationIcon test", () => (
+  .add("'From' LocationIcon", () => <LocationIcon type="from" size={25} />)
+  .add("'To' LocationIcon", () => <LocationIcon type="to" size={25} />)
+  .add("Generic Place LocationIcon", () => (
+    <LocationIcon type="intermediate-place-1" size={25} />
+  ))
+  .add("Custom style for 'To' LocationIcon", () => (
     <StyledLocationIcon type="to" size={25} />
   ));

--- a/packages/location-icon/src/index.js
+++ b/packages/location-icon/src/index.js
@@ -3,7 +3,11 @@ import PropTypes from "prop-types";
 
 import * as Styled from "./styled";
 
-const LocationIcon = ({ className, size = 10, title, type }) => {
+/**
+ * LocationIcon provides a consistent icon for rendering from, to, or generic
+ * place icons in form components like LocationField and in map overlays/popups.
+ */
+const LocationIcon = ({ className, size, title, type }) => {
   switch (type) {
     case "from":
       return (
@@ -22,7 +26,13 @@ const LocationIcon = ({ className, size = 10, title, type }) => {
         />
       );
     default:
-      throw new Error("invalid type");
+      return (
+        <Styled.PlaceIcon
+          className={className}
+          size={size}
+          title={title || "Location Icon"}
+        />
+      );
   }
 };
 
@@ -40,9 +50,16 @@ LocationIcon.propTypes = {
    */
   title: PropTypes.string,
   /**
-   * Either `from` or `to`
+   * `from` or `to` or some other string value to trigger generic place icon.
    */
-  type: PropTypes.oneOf(["from", "to"]).isRequired
+  type: PropTypes.string
+};
+
+LocationIcon.defaultProps = {
+  className: "",
+  size: 10,
+  title: "",
+  type: ""
 };
 
 export default LocationIcon;

--- a/packages/location-icon/src/styled.js
+++ b/packages/location-icon/src/styled.js
@@ -1,8 +1,12 @@
 import styled from "styled-components";
-import { DotCircle } from "styled-icons/fa-regular";
+import { Circle, DotCircle } from "styled-icons/fa-regular";
 import { MapMarkerAlt } from "styled-icons/fa-solid";
 
 const FromIcon = styled(DotCircle)`
+  color: #333;
+`;
+
+const PlaceIcon = styled(Circle)`
   color: #333;
 `;
 
@@ -10,4 +14,4 @@ const ToIcon = styled(MapMarkerAlt)`
   color: #f44256;
 `;
 
-export { FromIcon, ToIcon };
+export { FromIcon, PlaceIcon, ToIcon };


### PR DESCRIPTION
This PR relaxes proptypes for LocationIcon. If `from` or `to` is not used for `locationType`, a generic Circle icon will be rendered. This will allow for an icon to be used with IntermediatePlaces in the Call Taker module.