### PR TITLE
Add missing null check before rendering company icon.

### DIFF
--- a/packages/trip-form/src/__mocks__/companies.js
+++ b/packages/trip-form/src/__mocks__/companies.js
@@ -28,6 +28,13 @@ const commonCompanies = [
     id: "LYFT",
     label: "Lyft",
     modes: "CAR_HAIL"
+  },
+  // The company below does not have an icon in @opentripplanner/icons
+  // but that should not cause a UI crash or prevent anything else from rendering.
+  {
+    id: "UNKNOWN_BIKESHARE",
+    label: "Unknown Bikeshare",
+    modes: "BICYCLE_RENT"
   }
 ];
 

--- a/packages/trip-form/src/util.js
+++ b/packages/trip-form/src/util.js
@@ -275,7 +275,7 @@ export function getCompaniesOptions(companies, modes, selectedCompanies) {
       selected: selectedCompanies.includes(comp.id),
       text: (
         <span>
-          <CompanyIcon /> {comp.label}
+          {CompanyIcon && <CompanyIcon />} {comp.label}
         </span>
       ),
       title: comp.label


### PR DESCRIPTION
This PR fixes #196 by adding a missing null check before rendering rental vehicle company icons.

To test in Storybook:
1. Click the first story for `SettingsSelectorPanel`
2. Click "Transit+Biketown"
3. There should not be an error message filling the canvas.


~To test in OTP-RR locally:~
- ~In OTP-RR's `package.json`, replace the version of `@opentripplanner/trip-form` with the path to local version.~
- ~Try adding a rental company to OTP-RR's config as suggested in #196.~
- ~launch OTP-RR, click Travel Preferences > Bikeshare.~
~The MOD UI screen should not go blank.~

