### PR TITLE
Use the StandardRail icon for the rail mode

### DIFF
--- a/packages/icons/src/standard-mode-icon.js
+++ b/packages/icons/src/standard-mode-icon.js
@@ -5,6 +5,7 @@ import {
   StandardBike,
   StandardBus,
   StandardGondola,
+  StandardRail,
   StandardTram,
   StandardWalk
 } from "./standard";
@@ -39,6 +40,7 @@ function StandardModeIcon({ mode, ...props }) {
     case "micromobility_rent":
       return <ClassicMicromobility {...props} />;
     case "rail":
+      return <StandardRail {...props} />;
     case "subway":
     case "tram":
       return <StandardTram {...props} />;


### PR DESCRIPTION
The StandardRail icon wasn't used in the StandardModeIcon for the `rail` mode. This PR fixes that.