### PR TITLE
improvement(a11y): Add a11y props for LocationField.

### DIFF
--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -530,15 +530,17 @@ class LocationField extends Component {
     this.menuItemCount = itemIndex;
 
     /** the text input element * */
+    const defaultPlaceholder = inputPlaceholder || locationType;
     const placeholder =
       currentPosition && currentPosition.fetching
         ? "Fetching location..."
-        : inputPlaceholder || locationType;
+        : defaultPlaceholder;
     const textControl = (
       <Styled.Input
         ref={ref => {
           this.inputRef = ref;
         }}
+        aria-label={defaultPlaceholder}
         autoFocus={autoFocus}
         className={this.getFormControlClassname()}
         value={value}
@@ -554,7 +556,10 @@ class LocationField extends Component {
     const clearButton =
       showClearButton && location ? (
         <Styled.InputGroupAddon>
-          <Styled.Button onClick={this.onClearButtonClick}>
+          <Styled.Button
+            aria-label="Clear location"
+            onClick={this.onClearButtonClick}
+          >
             <Times size={13} />
           </Styled.Button>
         </Styled.InputGroupAddon>
@@ -591,6 +596,7 @@ class LocationField extends Component {
         <Styled.InputGroup>
           {/* location field icon -- also serves as dropdown anchor */}
           <Styled.Dropdown
+            locationType={locationType}
             open={menuVisible}
             onToggle={this.onDropdownToggle}
             title={<LocationIconComponent locationType={locationType} />}

--- a/packages/location-field/src/styled.js
+++ b/packages/location-field/src/styled.js
@@ -17,10 +17,13 @@ export const ClearBoth = styled.div`
   clear: both;
 `;
 
-export const Dropdown = ({ children, open, onToggle, title }) => {
+export const Dropdown = ({ children, locationType, open, onToggle, title }) => {
+  const dropdownButtonAriaLabel = `List the suggested ${locationType} locations as you type`;
   return (
     <DropdownContainer>
-      <DropdownButton onClick={onToggle}>{title}</DropdownButton>
+      <DropdownButton aria-label={dropdownButtonAriaLabel} onClick={onToggle}>
+        {title}
+      </DropdownButton>
       {open && <MenuItemList>{children}</MenuItemList>}
     </DropdownContainer>
   );
@@ -28,6 +31,7 @@ export const Dropdown = ({ children, open, onToggle, title }) => {
 
 Dropdown.propTypes = {
   children: PropTypes.node.isRequired,
+  locationType: PropTypes.string.isRequired,
   open: PropTypes.bool.isRequired,
   onToggle: PropTypes.func,
   title: PropTypes.node.isRequired


### PR DESCRIPTION
This PR fixes #199 and adds `aria-label` props for the drop-down and buttons contained in the `LocationField` component.

To test: open the stories in Storybook for `LocationField`, click on the accessibility tab below the canvas. Accessibility warnings regarding the **buttons** and **input** controls for `LocationField` should no longer appear. (Other accessibility issues listed for `LocationField` are outside of the scope of #199 and this PR.)

