### PR TITLE
build(deps): Bump core-utils to 2.1.0

### DIFF
--- a/packages/base-map/package.json
+++ b/packages/base-map/package.json
@@ -8,7 +8,7 @@
   "main": "lib/index.js",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^1.2.0",
+    "@opentripplanner/core-utils": "^2.1.0",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/endpoints-overlay/package.json
+++ b/packages/endpoints-overlay/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/core-utils": "^1.2.0",
+    "@opentripplanner/core-utils": "^2.1.0",
     "@opentripplanner/location-icon": "^1.0.1",
     "prop-types": "^15.7.2",
     "styled-icons": "^9.1.0"

--- a/packages/from-to-location-picker/package.json
+++ b/packages/from-to-location-picker/package.json
@@ -8,7 +8,7 @@
   "main": "lib/index.js",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^1.2.0",
+    "@opentripplanner/core-utils": "^2.1.0",
     "@opentripplanner/location-icon": "^1.0.0",
     "prop-types": "^15.7.2"
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^1.2.0",
+    "@opentripplanner/core-utils": "^2.1.0",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/itinerary-body/package.json
+++ b/packages/itinerary-body/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^1.2.0",
+    "@opentripplanner/core-utils": "^2.1.0",
     "@opentripplanner/humanize-distance": "^0.0.22",
     "@opentripplanner/icons": "^1.0.0",
     "@opentripplanner/location-icon": "^1.0.0",

--- a/packages/location-field/package.json
+++ b/packages/location-field/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^1.2.0",
+    "@opentripplanner/core-utils": "^2.1.0",
     "@opentripplanner/geocoder": "^1.0.2",
     "@opentripplanner/humanize-distance": "^0.0.22",
     "@opentripplanner/location-icon": "^1.0.0",

--- a/packages/park-and-ride-overlay/package.json
+++ b/packages/park-and-ride-overlay/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/core-utils": "^1.2.0",
+    "@opentripplanner/core-utils": "^2.1.0",
     "@opentripplanner/from-to-location-picker": "^1.0.0",
     "prop-types": "^15.7.2"
   },

--- a/packages/printable-itinerary/package.json
+++ b/packages/printable-itinerary/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^1.2.0",
+    "@opentripplanner/core-utils": "^2.1.0",
     "@opentripplanner/humanize-distance": "^0.0.22",
     "prop-types": "^15.7.2"
   },

--- a/packages/route-viewer-overlay/package.json
+++ b/packages/route-viewer-overlay/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.0",
-    "@opentripplanner/core-utils": "^1.2.0",
+    "@opentripplanner/core-utils": "^2.1.0",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/stop-viewer-overlay/package.json
+++ b/packages/stop-viewer-overlay/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/core-utils": "^1.2.0",
+    "@opentripplanner/core-utils": "^2.1.0",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/stops-overlay/package.json
+++ b/packages/stops-overlay/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/core-utils": "^1.2.0",
+    "@opentripplanner/core-utils": "^2.1.0",
     "@opentripplanner/from-to-location-picker": "^1.0.0",
     "@opentripplanner/zoom-based-markers": "^1.0.0"
   },

--- a/packages/transit-vehicle-overlay/package.json
+++ b/packages/transit-vehicle-overlay/package.json
@@ -9,7 +9,7 @@
   "private": false,
   "dependencies": {
     "@opentripplanner/base-map": "^1.0.0",
-    "@opentripplanner/core-utils": "^1.2.0",
+    "@opentripplanner/core-utils": "^2.1.0",
     "@opentripplanner/icons": "^1.0.0",
     "@opentripplanner/zoom-based-markers": "^1.0.0",
     "@turf/nearest-point-on-line": "^6.0.1",

--- a/packages/transitive-overlay/package.json
+++ b/packages/transitive-overlay/package.json
@@ -17,7 +17,7 @@
     "url": "git+https://github.com/opentripplanner/otp-ui.git"
   },
   "dependencies": {
-    "@opentripplanner/core-utils": "^1.2.0",
+    "@opentripplanner/core-utils": "^2.1.0",
     "lodash.isequal": "^4.5.0",
     "transitive-js": "^0.13.3"
   },

--- a/packages/trip-details/package.json
+++ b/packages/trip-details/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^1.2.0",
+    "@opentripplanner/core-utils": "^2.1.0",
     "@opentripplanner/humanize-distance": "^0.0.22",
     "moment": "^2.24.0",
     "prop-types": "^15.7.2",

--- a/packages/trip-form/package.json
+++ b/packages/trip-form/package.json
@@ -8,7 +8,7 @@
   "main": "lib/index.js",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^1.2.0",
+    "@opentripplanner/core-utils": "^2.1.0",
     "@opentripplanner/icons": "^1.0.0",
     "moment": "^2.17.1"
   },

--- a/packages/trip-viewer-overlay/package.json
+++ b/packages/trip-viewer-overlay/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.0",
-    "@opentripplanner/core-utils": "^1.2.0",
+    "@opentripplanner/core-utils": "^2.1.0",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/vehicle-rental-overlay/package.json
+++ b/packages/vehicle-rental-overlay/package.json
@@ -17,7 +17,7 @@
     "url": "git+https://github.com/opentripplanner/otp-ui.git"
   },
   "dependencies": {
-    "@opentripplanner/core-utils": "^1.2.0",
+    "@opentripplanner/core-utils": "^2.1.0",
     "@opentripplanner/from-to-location-picker": "^1.0.0",
     "@opentripplanner/zoom-based-markers": "^1.0.0",
     "lodash.memoize": "^4.1.2",

--- a/packages/zoom-based-markers/package.json
+++ b/packages/zoom-based-markers/package.json
@@ -16,6 +16,9 @@
   "bugs": {
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
+  "dependencies": {
+    "@opentripplanner/core-utils": "^2.1.0"
+  },
   "peerDependencies": {
     "@opentripplanner/base-map": "^1.0.1",
     "prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2746,20 +2746,6 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@opentripplanner/core-utils@^1.2.0":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-1.2.2.tgz#c943983d92c67b1aba2ad7b47f199fb46bbedc02"
-  integrity sha512-xISq454TA/mTu5wjMVvNRszHmeAKppS+jk5E3LRl+TaMWas5ovaNdKwlOXU62djGb41VOty4KYTnECliDPYDJw==
-  dependencies:
-    "@mapbox/polyline" "^1.1.0"
-    "@turf/along" "^6.0.1"
-    bowser "^2.7.0"
-    lodash.isequal "^4.5.0"
-    moment "^2.24.0"
-    moment-timezone "^0.5.27"
-    prop-types "^15.7.2"
-    qs "^6.9.1"
-
 "@reach/router@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.2.1.tgz#34ae3541a5ac44fa7796e5506a5d7274a162be4e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2746,6 +2746,20 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@opentripplanner/core-utils@^1.2.0":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-1.2.2.tgz#c943983d92c67b1aba2ad7b47f199fb46bbedc02"
+  integrity sha512-xISq454TA/mTu5wjMVvNRszHmeAKppS+jk5E3LRl+TaMWas5ovaNdKwlOXU62djGb41VOty4KYTnECliDPYDJw==
+  dependencies:
+    "@mapbox/polyline" "^1.1.0"
+    "@turf/along" "^6.0.1"
+    bowser "^2.7.0"
+    lodash.isequal "^4.5.0"
+    moment "^2.24.0"
+    moment-timezone "^0.5.27"
+    prop-types "^15.7.2"
+    qs "^6.9.1"
+
 "@reach/router@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.2.1.tgz#34ae3541a5ac44fa7796e5506a5d7274a162be4e"


### PR DESCRIPTION
This PR fixes #201. It made sense to bump core-utils in all other packages at the same time.
