### PR TITLE
Properly parse and stringify intermediate places

### DIFF
--- a/packages/core-utils/src/__tests__/__snapshots__/query.js.snap
+++ b/packages/core-utils/src/__tests__/__snapshots__/query.js.snap
@@ -33,6 +33,98 @@ Object {
 }
 `;
 
+exports[`query getRoutingParams should create routing params for car rental query 1`] = `
+Object {
+  "arriveBy": false,
+  "bannedRoutes": "",
+  "companies": "FAKECOMPANY",
+  "date": "2020-08-24",
+  "fromPlace": "Steamer Lane, Santa Cruz, CA, 95060, USA::36.95471026341096,-122.0248185852425",
+  "ignoreRealtimeUpdates": false,
+  "minTransitDistance": "50%",
+  "mode": "CAR_RENT,BUS,WALK",
+  "numItineraries": 3,
+  "onlyTransitTrips": true,
+  "optimize": "QUICK",
+  "otherThanPreferredRoutesPenalty": 900,
+  "preferredRoutes": "",
+  "searchTimeout": 10000,
+  "showIntermediateStops": true,
+  "time": "21:53",
+  "toPlace": "Municipal Wharf St, Santa Cruz, CA, 95060, USA::36.961843106786766,-122.02402657342725",
+}
+`;
+
+exports[`query getRoutingParams should create routing params for intermediate places query 1`] = `
+Object {
+  "arriveBy": false,
+  "bannedRoutes": "",
+  "companies": null,
+  "date": "2020-08-24",
+  "fromPlace": "Steamer Lane, Santa Cruz, CA, 95060, USA::36.95471026341096,-122.0248185852425",
+  "ignoreRealtimeUpdates": false,
+  "intermediatePlaces": Array [
+    "Lighthouse Point Park, Santa Cruz, CA, USA::36.95145225211049,-122.02672866668283",
+    "Natural Bridges State Beach, 2531 W Cliff Dr, Santa Cruz, CA, 95060, USA::36.95028619314903,-122.05711810284686",
+  ],
+  "maxWalkDistance": 1207,
+  "mode": "WALK,TRANSIT",
+  "numItineraries": 3,
+  "optimize": "QUICK",
+  "otherThanPreferredRoutesPenalty": 900,
+  "preferredRoutes": "",
+  "showIntermediateStops": true,
+  "time": "21:53",
+  "toPlace": "Municipal Wharf St, Santa Cruz, CA, 95060, USA::36.961843106786766,-122.02402657342725",
+  "walkSpeed": 1.34,
+}
+`;
+
+exports[`query getRoutingParams should create routing params for personal micromobility query 1`] = `
+Object {
+  "arriveBy": false,
+  "bannedRoutes": "",
+  "companies": "FAKECOMPANY",
+  "date": "2020-08-24",
+  "fromPlace": "Steamer Lane, Santa Cruz, CA, 95060, USA::36.95471026341096,-122.0248185852425",
+  "ignoreRealtimeUpdates": false,
+  "maxEScooterDistance": 4828,
+  "maxWalkDistance": 4828,
+  "maximumMicromobilitySpeed": 5,
+  "mode": "MICROMOBILITY,BUS",
+  "numItineraries": 3,
+  "optimize": "QUICK",
+  "otherThanPreferredRoutesPenalty": 900,
+  "preferredRoutes": "",
+  "showIntermediateStops": true,
+  "time": "21:53",
+  "toPlace": "Municipal Wharf St, Santa Cruz, CA, 95060, USA::36.961843106786766,-122.02402657342725",
+  "watts": 250,
+  "weight": 102.5,
+}
+`;
+
+exports[`query getRoutingParams should create routing params for transit query 1`] = `
+Object {
+  "arriveBy": false,
+  "bannedRoutes": "",
+  "companies": null,
+  "date": "2020-08-24",
+  "fromPlace": "Steamer Lane, Santa Cruz, CA, 95060, USA::36.95471026341096,-122.0248185852425",
+  "ignoreRealtimeUpdates": false,
+  "maxWalkDistance": 1207,
+  "mode": "WALK,TRANSIT",
+  "numItineraries": 3,
+  "optimize": "QUICK",
+  "otherThanPreferredRoutesPenalty": 900,
+  "preferredRoutes": "",
+  "showIntermediateStops": true,
+  "time": "21:53",
+  "toPlace": "Municipal Wharf St, Santa Cruz, CA, 95060, USA::36.961843106786766,-122.02402657342725",
+  "walkSpeed": 1.34,
+}
+`;
+
 exports[`query parseLocationString should return location for valid input 1`] = `
 Object {
   "lat": 33.983929829,
@@ -63,6 +155,46 @@ Object {
     "name": "Guide Dogs for the Blind, Portland, OR, USA",
   },
   "ignoreRealtimeUpdates": "true",
+  "maxWalkDistance": 1207,
+  "mode": "BUS,TRAM,RAIL,GONDOLA,WALK",
+  "optimize": "QUICK",
+  "showIntermediateStops": "true",
+  "time": "17:45",
+  "to": Object {
+    "lat": 45.519015,
+    "lon": -122.679321,
+    "name": "Weather Machine, Portland, OR, USA",
+  },
+  "ui_activeItinerary": 0,
+  "ui_activeSearch": "irc7h4rb8",
+  "walkSpeed": 1.34,
+}
+`;
+
+exports[`query planParamsToQuery should parse a query with intermediate places 1`] = `
+Object {
+  "bannedRoutes": "897ABC",
+  "companies": "",
+  "date": "2019-10-31",
+  "departArrive": "DEPART",
+  "from": Object {
+    "lat": 45.517373,
+    "lon": -122.675601,
+    "name": "Guide Dogs for the Blind, Portland, OR, USA",
+  },
+  "ignoreRealtimeUpdates": "true",
+  "intermediatePlaces": Array [
+    Object {
+      "lat": 45.516202,
+      "lon": -122.673247,
+      "name": "Mill Ends Park, Downtown - Portland",
+    },
+    Object {
+      "lat": 45.519094,
+      "lon": -122.705692,
+      "name": "International Rose Test Garden, Portland",
+    },
+  ],
   "maxWalkDistance": 1207,
   "mode": "BUS,TRAM,RAIL,GONDOLA,WALK",
   "optimize": "QUICK",

--- a/packages/core-utils/src/__tests__/query.js
+++ b/packages/core-utils/src/__tests__/query.js
@@ -5,6 +5,7 @@ import {
 
 import {
   getDefaultQuery,
+  getRoutingParams,
   parseLocationString,
   planParamsToQuery
 } from "../query";
@@ -12,35 +13,78 @@ import {
 describe("query", () => {
   afterEach(restoreDateNowBehavior);
 
-  describe("planParamsToQuery", () => {
-    it("should parse a depart at query", async () => {
-      expect(
-        await planParamsToQuery({
-          arriveBy: "false",
-          bannedRoutes: "897ABC",
-          companies: "",
-          date: "2019-10-31",
-          fromPlace:
-            "Guide Dogs for the Blind, Portland, OR, USA::45.517373,-122.675601",
-          ignoreRealtimeUpdates: "true",
-          maxWalkDistance: "1207",
-          mode: "BUS,TRAM,RAIL,GONDOLA,WALK",
-          optimize: "QUICK",
-          showIntermediateStops: "true",
-          time: "17:45",
-          toPlace: "Weather Machine, Portland, OR, USA::45.519015,-122.679321",
-          ui_activeItinerary: "0",
-          ui_activeSearch: "irc7h4rb8",
-          walkSpeed: "1.34"
-        })
-      ).toMatchSnapshot();
-    });
-  });
-
   describe("getDefaultQuery", () => {
     it("should return default query", () => {
       setDefaultTestTime();
       expect(getDefaultQuery()).toMatchSnapshot();
+    });
+  });
+
+  describe("getRoutingParams", () => {
+    // the config isn't actually used except for some wheelchair check, so it is
+    // ok to send an empty object for most tests
+    const fakeConfig = {};
+    const makeBaseTestQuery = () => ({
+      ...getDefaultQuery(),
+      date: "2020-08-24",
+      from: {
+        lat: 36.95471026341096,
+        lon: -122.0248185852425,
+        name: "Steamer Lane, Santa Cruz, CA, 95060, USA"
+      },
+      time: "21:53",
+      to: {
+        lat: 36.961843106786766,
+        lon: -122.02402657342725,
+        name: "Municipal Wharf St, Santa Cruz, CA, 95060, USA"
+      }
+    });
+    it("should create routing params for transit query", () => {
+      expect(
+        getRoutingParams(fakeConfig, makeBaseTestQuery())
+      ).toMatchSnapshot();
+    });
+
+    it("should create routing params for car rental query", () => {
+      expect(
+        getRoutingParams(fakeConfig, {
+          ...makeBaseTestQuery(),
+          companies: "FAKECOMPANY",
+          mode: "CAR_RENT,BUS"
+        })
+      ).toMatchSnapshot();
+    });
+
+    it("should create routing params for personal micromobility query", () => {
+      expect(
+        getRoutingParams(fakeConfig, {
+          ...makeBaseTestQuery(),
+          companies: "FAKECOMPANY",
+          mode: "MICROMOBILITY,BUS",
+          watts: 250
+        })
+      ).toMatchSnapshot();
+    });
+
+    it("should create routing params for intermediate places query", () => {
+      expect(
+        getRoutingParams(fakeConfig, {
+          ...makeBaseTestQuery(),
+          intermediatePlaces: [
+            {
+              lat: 36.95145225211049,
+              lon: -122.02672866668283,
+              name: "Lighthouse Point Park, Santa Cruz, CA, USA"
+            },
+            {
+              lat: 36.95028619314903,
+              lon: -122.05711810284686,
+              name:
+                "Natural Bridges State Beach, 2531 W Cliff Dr, Santa Cruz, CA, 95060, USA"
+            }
+          ]
+        })
+      ).toMatchSnapshot();
     });
   });
 
@@ -58,6 +102,43 @@ describe("query", () => {
     it("should return location with coordinates as name for coordinates-only input", () => {
       expect(
         parseLocationString("33.983929829,-87.3892387982")
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe("planParamsToQuery", () => {
+    const makeBaseTestQuery = () => ({
+      arriveBy: "false",
+      bannedRoutes: "897ABC",
+      companies: "",
+      date: "2019-10-31",
+      fromPlace:
+        "Guide Dogs for the Blind, Portland, OR, USA::45.517373,-122.675601",
+      ignoreRealtimeUpdates: "true",
+      maxWalkDistance: "1207",
+      mode: "BUS,TRAM,RAIL,GONDOLA,WALK",
+      optimize: "QUICK",
+      showIntermediateStops: "true",
+      time: "17:45",
+      toPlace: "Weather Machine, Portland, OR, USA::45.519015,-122.679321",
+      ui_activeItinerary: "0",
+      ui_activeSearch: "irc7h4rb8",
+      walkSpeed: "1.34"
+    });
+
+    it("should parse a depart at query", () => {
+      expect(planParamsToQuery(makeBaseTestQuery())).toMatchSnapshot();
+    });
+
+    it("should parse a query with intermediate places", () => {
+      expect(
+        planParamsToQuery({
+          ...makeBaseTestQuery(),
+          intermediatePlaces: [
+            "Mill Ends Park, Downtown - Portland::45.516202,-122.673247",
+            "International Rose Test Garden, Portland::45.519094,-122.705692"
+          ]
+        })
       ).toMatchSnapshot();
     });
   });

--- a/packages/core-utils/src/query-params.js
+++ b/packages/core-utils/src/query-params.js
@@ -639,9 +639,7 @@ const queryParams = [
     itineraryRewrite: places =>
       Array.isArray(places) && places.length > 0
         ? {
-            intermediatePlaces: places
-              .map(place => formatPlace(place))
-              .join(",")
+            intermediatePlaces: places.map(place => formatPlace(place))
           }
         : undefined
   },

--- a/packages/core-utils/src/query.js
+++ b/packages/core-utils/src/query.js
@@ -271,7 +271,7 @@ export function planParamsToQuery(params) {
         // If query has intermediate places, ensure that they are parsed
         // as locations.
         query.intermediatePlaces = params.intermediatePlaces
-          ? params.intermediatePlaces.split(",").map(parseLocationString)
+          ? params.intermediatePlaces.map(parseLocationString)
           : [];
         break;
       default: {


### PR DESCRIPTION
Fixes https://github.com/opentripplanner/otp-ui/issues/203.

I marked this PR as a fix, because it's unlikely that anybody ever used this before since it couldn't have worked very well. This PR changes the assumption about how query parameters for the `intermediatePlaces` are generated in that they are not expected to be parsed from (or stringified into) a comma-separated string, but instead should be parsed from (or stringified into) an array of strings. The `query.getRoutingParams` and `query.planParamsToQuery` are both assumed to use the [qs](https://www.npmjs.com/package/qs) package to do the parsing (and stringifying) from (and to) raw URL query params. This package has a way of parsing (and stringifying into) query params that have multiple of the same parameter which is the format that OTP expects. Therefore, this change will result in properly parsing a query string such as `...&intermediatePlaces=name::###,###&intermediatePlaces=name2::###,###&...`. This util library does not have a util function for stringifying the params, but the way to do that with the `qs` package would be to write `qs.stringify(params, { arrayFormat: 'repeat' })`