### PR TITLE
Handle error response from geocoder

### DIFF
--- a/packages/location-field/src/LocationField.story.js
+++ b/packages/location-field/src/LocationField.story.js
@@ -28,6 +28,21 @@ import * as LocationFieldClasses from "./styled";
 const currentPosition = {
   coords: { latitude: 45.508246, longitude: -122.711574 }
 };
+const invalidKeyGeocoderConfig = {
+  apiKey: "ge-invalid-key",
+  baseUrl: "https://api.geocode.earth/v1", // TriMet-specific default
+  boundary: {
+    // TriMet-specific default
+    rect: {
+      minLon: -123.2034,
+      maxLon: -122.135,
+      minLat: 45.273,
+      maxLat: 45.7445
+    }
+  },
+  maxNearbyStops: 4,
+  type: "PELIAS"
+};
 const geocoderConfig = {
   baseUrl: "https://ws-st.trimet.org/pelias/v1", // TriMet-specific default
   boundary: {
@@ -268,4 +283,14 @@ storiesOf("LocationField", module)
         onLocationSelected={onLocationSelected}
       />
     </div>
+  ))
+  .add("LocationField with bad API key handles bad autocomplete", () => (
+    <LocationField
+      currentPosition={currentPosition}
+      geocoderConfig={invalidKeyGeocoderConfig}
+      getCurrentPosition={getCurrentPosition}
+      inputPlaceholder="Select from location"
+      locationType="from"
+      onLocationSelected={onLocationSelected}
+    />
   ));


### PR DESCRIPTION
This PR fixes #183 by correctly handling when there are no features returned from a geocode response. It also adds a message if there is an error communicating with the geocoder or if no results are found, which I think is useful behavior (otherwise there is no indication that a search completed). Curious to have @fpurcell's thoughts on that behavior though.

A new story with a bad API key configured for geocode.earth is at http://localhost:5555/?path=/story/locationfield--locationfield-with-bad-api-key-handles-bad-autocomplete