### PR TITLE
added in layersPosition and zoomPosition props

### DIFF
--- a/packages/base-map/src/index.js
+++ b/packages/base-map/src/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { LayersControl, Map, Popup, TileLayer } from "react-leaflet";
+import { LayersControl, Map, Popup, TileLayer, ZoomControl } from "react-leaflet";
 import utils from "@opentripplanner/core-utils";
 import L from "leaflet";
 
@@ -178,7 +178,9 @@ class BaseMap extends Component {
       popup,
       onContextMenu,
       onPopupClosed,
-      zoom
+      zoom,
+      zoomPosition,
+      layersPosition
     } = this.props;
     const { layerIndex } = this.state;
 
@@ -211,6 +213,7 @@ class BaseMap extends Component {
         onBaseLayerChange={this.handleBaseLayerChange}
         onOverlayRemove={this.handleOverlayRemoved}
         onViewportChanged={this.handleViewportChanged}
+        zoomControl={false}
       >
         {/* Add the mapbox wordmark if the current base layer's URL appears to
           be a Mapbox URL. The implementing application must include CSS that
@@ -228,7 +231,7 @@ class BaseMap extends Component {
 
         {/* Create the layers control, including base map layers and any
          * user-controlled overlays. */}
-        <LayersControl position="topright">
+        <LayersControl position={layersPosition || "topright"}>
           {/* base layers */}
           {baseLayers &&
             baseLayers.map((layer, i) => {
@@ -277,7 +280,8 @@ class BaseMap extends Component {
             </LayersControl.Overlay>
           ))}
         </LayersControl>
-
+        
+        <ZoomControl position={zoomPosition || "topleft"} />
         {/* Add the fixed, i.e. non-user-controllable, overlays (e.g., itinerary overlay) */}
         {fixedOverlays}
 


### PR DESCRIPTION
Attempt to add positioning support for ZoomControl and LayersControl to BaseMap via component props.
#215 

Was not able to test due to not knowing how to compile and test.

Not sure if the disabling zoomControl in the Map component and then enabling via ZoomControl component is the best practice, but when I did initial testing by just adding in ZoomControl component it just added another ZoomControl. As far as I know the default Map zoomControl props is just a boolean value and you have to call ZoomControl in order to access to the position setting. 

EDIT:
For reference while I was not able to compile I am using @opentripplanner via otp-react

LINKS:
ZoomControl > https://react-leaflet.js.org/docs/en/components#zoomcontrol
LayersControl > https://react-leaflet.js.org/docs/en/components#layerscontrol
Map zoomControl > https://leafletjs.com/reference-1.6.0.html#map-zoomcontrol