### PR TITLE
Revert to old transitOperator lookup

### DIFF
--- a/packages/itinerary-body/src/__mocks__/config.json
+++ b/packages/itinerary-body/src/__mocks__/config.json
@@ -21,8 +21,7 @@
   },
   "transitOperators": [
     {
-      "agencyId": "TRIMET",
-      "feedId": "TriMet",
+      "id": "TRIMET",
       "name": "TriMet",
       "logo": "http://news.trimet.org/wordpress/wp-content/uploads/2019/04/TriMet-logo-300x300.png"
     }

--- a/packages/itinerary-body/src/place-row.js
+++ b/packages/itinerary-body/src/place-row.js
@@ -7,6 +7,11 @@ import AccessLegBody from "./AccessLegBody";
 import * as Styled from "./styled";
 import TransitLegBody from "./TransitLegBody";
 
+/** Looks up an operator from the provided configuration */
+const getTransitOperatorFromConfig = (id, config) =>
+  config.transitOperators.find(transitOperator => transitOperator.id === id) ||
+  null;
+
 /*
   TODO: Wondering if it's possible for us to destructure the time
   preferences from the config object and avoid making the props list so long
@@ -103,10 +108,10 @@ const PlaceRow = ({
                 timeFormat={timeFormat}
                 TransitLegSubheader={TransitLegSubheader}
                 TransitLegSummary={TransitLegSummary}
-                transitOperator={coreUtils.route.getTransitOperatorFromLeg(
-                  leg,
-                  config.transitOperators
-                )}
+                transitOperator={
+                  leg.agencyId &&
+                  getTransitOperatorFromConfig(leg.agencyId, config)
+                }
               />
             ) : (
               /* This is an access (e.g. walk/bike/etc.) leg */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2746,6 +2746,20 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@opentripplanner/core-utils@^2.1.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-2.1.2.tgz#a19d5d788704f0a6c2aece5206a2c8997c251d16"
+  integrity sha512-i+ADDdHhC+oJNYPrk7o9eu3F/2IMMZ5YAOXR2QGBJbS97kQOYeTAN4pVGfWKTm7ClTTIBG9/NDnVyQMzGuYInw==
+  dependencies:
+    "@mapbox/polyline" "^1.1.0"
+    "@turf/along" "^6.0.1"
+    bowser "^2.7.0"
+    lodash.isequal "^4.5.0"
+    moment "^2.24.0"
+    moment-timezone "^0.5.27"
+    prop-types "^15.7.2"
+    qs "^6.9.1"
+
 "@opentripplanner/core-utils@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-2.1.1.tgz#4ed039593fb54c0de1c1370a2c85c88de3e5d3c5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2746,21 +2746,7 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@opentripplanner/core-utils@^2.1.0":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-2.1.2.tgz#a19d5d788704f0a6c2aece5206a2c8997c251d16"
-  integrity sha512-i+ADDdHhC+oJNYPrk7o9eu3F/2IMMZ5YAOXR2QGBJbS97kQOYeTAN4pVGfWKTm7ClTTIBG9/NDnVyQMzGuYInw==
-  dependencies:
-    "@mapbox/polyline" "^1.1.0"
-    "@turf/along" "^6.0.1"
-    bowser "^2.7.0"
-    lodash.isequal "^4.5.0"
-    moment "^2.24.0"
-    moment-timezone "^0.5.27"
-    prop-types "^15.7.2"
-    qs "^6.9.1"
-
-"@opentripplanner/core-utils@^2.1.1":
+"@opentripplanner/core-utils@^2.1.0", "@opentripplanner/core-utils@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-2.1.1.tgz#4ed039593fb54c0de1c1370a2c85c88de3e5d3c5"
   integrity sha512-IHxY+QjXdWgWNUPUxI00P01MJ1DRHov8vO597qNEw5ZYzOZHFyYJTU7MiywDMSsY/0Jtty5yG+fKxTSrfc4zJA==


### PR DESCRIPTION
Changes were added in #189 that resulted in a new v3 release of core-utils and some releases on other packages. One of those packages was the itinerary-body package, but it hadn't yet been updated to have an official dependency on core-utils v3. Therefore, this introduced code in the 1.x.x pipeline of the itinerary-body package that is now a bug. This PR reverts changes that assumed core-utils v3 within the itinerary-body package to maintain consistency with coreUtils 2.x and the previous way of defining transitOperators in the config. This PR will create a patch release of the itinerary-body package.

Another PR will change this code back again to the v3 style transit operators config and will contain a commit with a breaking change that will make sure the itinerary-body package gets a proper bump. That will result in a itinerary-body v2.x.x bump to comply with semver.