### PR TITLE
Update opentripplanner dependencies to latest versions (core-utils v3 update part 1)

### DIFF
--- a/packages/base-map/package.json
+++ b/packages/base-map/package.json
@@ -8,7 +8,7 @@
   "main": "lib/index.js",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^2.1.0",
+    "@opentripplanner/core-utils": "^3.0.0",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/from-to-location-picker/package.json
+++ b/packages/from-to-location-picker/package.json
@@ -8,8 +8,8 @@
   "main": "lib/index.js",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^2.1.0",
-    "@opentripplanner/location-icon": "^1.0.0",
+    "@opentripplanner/core-utils": "^3.0.0",
+    "@opentripplanner/location-icon": "^1.0.1",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^2.1.0",
+    "@opentripplanner/core-utils": "^3.0.0",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/location-field/package.json
+++ b/packages/location-field/package.json
@@ -8,10 +8,10 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^2.1.0",
+    "@opentripplanner/core-utils": "^3.0.0",
     "@opentripplanner/geocoder": "^1.0.2",
     "@opentripplanner/humanize-distance": "^0.0.22",
-    "@opentripplanner/location-icon": "^1.0.0",
+    "@opentripplanner/location-icon": "^1.0.1",
     "prop-types": "^15.7.2",
     "styled-icons": "^9.1.0",
     "throttle-debounce": "^2.1.0"


### PR DESCRIPTION
This is part 1 of 3 to update internal packages to use core-utils v3. This PR only updates the packages that have no dependencies on otp-ui packages that have a dependency on core-utils. If we were to include packages such as vehicle-rental-overlay in this PR, it would not be sufficient to ensure that all other packages that the vehicle-rental-overlay package depends on also have a dependency on core-utils v3. So, future PRs will bump core-utils and other relevant packages with a core-utils dependency until every package that has some kind of dependency on core-utils has been released. In doing so, there will be only one release per package which will look much cleaner than multiple releases that update a single package at a time. Hope I explained this well and this is ok.