### PR TITLE
Update opentripplanner dependencies to latest versions (core-utils v3 update part 2)

### DIFF
--- a/packages/endpoints-overlay/package.json
+++ b/packages/endpoints-overlay/package.json
@@ -17,13 +17,13 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/core-utils": "^2.1.0",
+    "@opentripplanner/core-utils": "^3.0.0",
     "@opentripplanner/location-icon": "^1.0.1",
     "prop-types": "^15.7.2",
     "styled-icons": "^9.1.0"
   },
   "peerDependencies": {
-    "@opentripplanner/base-map": "^1.0.0",
+    "@opentripplanner/base-map": "^1.0.4",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-leaflet": "^2.6.1",

--- a/packages/itinerary-body/package.json
+++ b/packages/itinerary-body/package.json
@@ -9,10 +9,10 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^2.1.1",
+    "@opentripplanner/core-utils": "^3.0.0",
     "@opentripplanner/humanize-distance": "^0.0.22",
-    "@opentripplanner/icons": "^1.0.0",
-    "@opentripplanner/location-icon": "^1.0.0",
+    "@opentripplanner/icons": "^1.0.4",
+    "@opentripplanner/location-icon": "^1.0.1",
     "currency-formatter": "^1.5.5",
     "moment": "^2.24.0",
     "prop-types": "^15.7.2",

--- a/packages/itinerary-body/src/__mocks__/config.json
+++ b/packages/itinerary-body/src/__mocks__/config.json
@@ -21,7 +21,8 @@
   },
   "transitOperators": [
     {
-      "id": "TRIMET",
+      "agencyId": "TRIMET",
+      "feedId": "TriMet",
       "name": "TriMet",
       "logo": "http://news.trimet.org/wordpress/wp-content/uploads/2019/04/TriMet-logo-300x300.png"
     }

--- a/packages/itinerary-body/src/place-row.js
+++ b/packages/itinerary-body/src/place-row.js
@@ -7,11 +7,6 @@ import AccessLegBody from "./AccessLegBody";
 import * as Styled from "./styled";
 import TransitLegBody from "./TransitLegBody";
 
-/** Looks up an operator from the provided configuration */
-const getTransitOperatorFromConfig = (id, config) =>
-  config.transitOperators.find(transitOperator => transitOperator.id === id) ||
-  null;
-
 /*
   TODO: Wondering if it's possible for us to destructure the time
   preferences from the config object and avoid making the props list so long
@@ -108,10 +103,10 @@ const PlaceRow = ({
                 timeFormat={timeFormat}
                 TransitLegSubheader={TransitLegSubheader}
                 TransitLegSummary={TransitLegSummary}
-                transitOperator={
-                  leg.agencyId &&
-                  getTransitOperatorFromConfig(leg.agencyId, config)
-                }
+                transitOperator={coreUtils.route.getTransitOperatorFromLeg(
+                  leg,
+                  config.transitOperators
+                )}
               />
             ) : (
               /* This is an access (e.g. walk/bike/etc.) leg */

--- a/packages/park-and-ride-overlay/package.json
+++ b/packages/park-and-ride-overlay/package.json
@@ -17,12 +17,12 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/core-utils": "^2.1.0",
-    "@opentripplanner/from-to-location-picker": "^1.0.0",
+    "@opentripplanner/core-utils": "^3.0.0",
+    "@opentripplanner/from-to-location-picker": "^1.0.3",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "@opentripplanner/base-map": "^1.0.0",
+    "@opentripplanner/base-map": "^1.0.4",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-leaflet": "^2.6.1",

--- a/packages/printable-itinerary/package.json
+++ b/packages/printable-itinerary/package.json
@@ -9,13 +9,13 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^2.1.0",
+    "@opentripplanner/core-utils": "^3.0.0",
     "@opentripplanner/humanize-distance": "^0.0.22",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {
-    "@opentripplanner/icons": "^1.0.0",
-    "@opentripplanner/itinerary-body": "^1.0.1"
+    "@opentripplanner/icons": "^1.0.4",
+    "@opentripplanner/itinerary-body": "^1.2.2"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/packages/route-viewer-overlay/package.json
+++ b/packages/route-viewer-overlay/package.json
@@ -18,11 +18,11 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.0",
-    "@opentripplanner/core-utils": "^2.1.0",
+    "@opentripplanner/core-utils": "^3.0.0",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "@opentripplanner/base-map": "^1.0.0",
+    "@opentripplanner/base-map": "^1.0.4",
     "react": "^16.8.6",
     "react-leaflet": "^2.6.1"
   },

--- a/packages/stop-viewer-overlay/package.json
+++ b/packages/stop-viewer-overlay/package.json
@@ -17,11 +17,11 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/core-utils": "^2.1.0",
+    "@opentripplanner/core-utils": "^3.0.0",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "@opentripplanner/base-map": "^1.0.0",
+    "@opentripplanner/base-map": "^1.0.4",
     "react": "^16.8.6",
     "react-leaflet": "^2.6.1"
   }

--- a/packages/trip-form/package.json
+++ b/packages/trip-form/package.json
@@ -8,8 +8,8 @@
   "main": "lib/index.js",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^2.1.0",
-    "@opentripplanner/icons": "^1.0.0",
+    "@opentripplanner/core-utils": "^3.0.0",
+    "@opentripplanner/icons": "^1.0.4",
     "moment": "^2.17.1"
   },
   "repository": {

--- a/packages/trip-viewer-overlay/package.json
+++ b/packages/trip-viewer-overlay/package.json
@@ -18,11 +18,11 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.0",
-    "@opentripplanner/core-utils": "^2.1.0",
+    "@opentripplanner/core-utils": "^3.0.0",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "@opentripplanner/base-map": "^1.0.0",
+    "@opentripplanner/base-map": "^1.0.4",
     "react": "^16.8.6",
     "react-leaflet": "^2.6.1"
   },

--- a/packages/zoom-based-markers/package.json
+++ b/packages/zoom-based-markers/package.json
@@ -17,10 +17,10 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/core-utils": "^2.1.0"
+    "@opentripplanner/core-utils": "^3.0.0"
   },
   "peerDependencies": {
-    "@opentripplanner/base-map": "^1.0.1",
+    "@opentripplanner/base-map": "^1.0.4",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-leaflet": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2746,7 +2746,7 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@opentripplanner/core-utils@^2.1.0", "@opentripplanner/core-utils@^2.1.1":
+"@opentripplanner/core-utils@^2.1.0":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-2.1.1.tgz#4ed039593fb54c0de1c1370a2c85c88de3e5d3c5"
   integrity sha512-IHxY+QjXdWgWNUPUxI00P01MJ1DRHov8vO597qNEw5ZYzOZHFyYJTU7MiywDMSsY/0Jtty5yG+fKxTSrfc4zJA==


### PR DESCRIPTION
This is part 2 of 3 to update internal packages to use core-utils v3. This updates all packages that have indirect dependencies on core-utils via other packages. The zoom-based-markers package is still depended on by other packages, so those packages will be included in part 3.

This PR also includes a breaking change commit to the itinerary-body package to reflect the requirement for changing the config of the transit operators to include the feed and agency IDs.