### PR TITLE
Better sort routes with zero length transit operators config

### DIFF
--- a/packages/core-utils/src/route.js
+++ b/packages/core-utils/src/route.js
@@ -98,9 +98,9 @@ const END_OF_LIST_COMPARATOR_VALUE = 999999999999;
  *   returned.
  */
 function getTransitOperatorComparatorValue(route, transitOperators) {
-  // if the transitOperators is undefined, use the route's agency name as the
-  // comparator value
-  if (!transitOperators) {
+  // if the transitOperators is undefined or has zero length, use the route's
+  // agency name as the comparator value
+  if (!transitOperators || transitOperators.length === 0) {
     // OTP Route
     if (route.agency) return route.agency.name;
     // OTP RouteShort (base OTP repo or IBI fork)


### PR DESCRIPTION
This change makes it possible to sort routes based off of agency info from OTP alone even when a zero-length array is sent as the transit operators. otp-react-redux initializes the transitOperators value to an empty array if it is not included in the config.