### PR TITLE
fix(ItineraryBody): Allow PlaceRow to take up entire width available.

### DIFF
--- a/packages/itinerary-body/src/place-row.js
+++ b/packages/itinerary-body/src/place-row.js
@@ -82,6 +82,18 @@ const PlaceRow = ({
             <Styled.PlaceName>
               <PlaceName config={config} interline={interline} place={place} />
             </Styled.PlaceName>
+
+            {showMapButtonColumn && (
+              <Styled.MapButtonColumn hideBorder={hideBorder.toString()}>
+                <Styled.MapButton
+                  onClick={() =>
+                    // eslint-disable-next-line prettier/prettier
+                    frameLeg({ isDestination, leg, legIndex, place })}
+                >
+                  <Styled.MapIcon />
+                </Styled.MapButton>
+              </Styled.MapButtonColumn>
+            )}
           </Styled.PlaceHeader>
 
           {/* Show the leg, if not rendering the destination */}
@@ -126,15 +138,6 @@ const PlaceRow = ({
             ))}
         </Styled.PlaceDetails>
       </Styled.DetailsColumn>
-      {showMapButtonColumn && (
-        <Styled.MapButtonColumn hideBorder={hideBorder.toString()}>
-          <Styled.MapButton
-            onClick={() => frameLeg({ isDestination, leg, legIndex, place })}
-          >
-            <Styled.MapIcon />
-          </Styled.MapButton>
-        </Styled.MapButtonColumn>
-      )}
     </Styled.PlaceRowWrapper>
   );
 };

--- a/packages/itinerary-body/src/styled.js
+++ b/packages/itinerary-body/src/styled.js
@@ -417,7 +417,6 @@ export const PlaceName = styled.div`
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  flex: 1 1 auto;
 `;
 
 export const PlaceSubheader = styled.div`

--- a/packages/itinerary-body/src/styled.js
+++ b/packages/itinerary-body/src/styled.js
@@ -341,7 +341,6 @@ export const LineColumn = styled.div`
 
 export const PlaceRowWrapper = styled.div`
   /* needs to be a flexbox row */
-  max-width: 500px;
   display: flex;
   flex-flow: row;
 `;


### PR DESCRIPTION
This PR partially addresses https://github.com/ibi-group/trimet-mod-otp/issues/282 by allowing `PlaceRow` to fill all the available space to the right, as shown in the screenshot below.

![image](https://user-images.githubusercontent.com/56846598/98861588-8cda9780-2433-11eb-9a3e-bbd4f2e56961.png)
 