### PR TITLE
Tweak map icon message

### DIFF
--- a/packages/itinerary-body/src/place-row.js
+++ b/packages/itinerary-body/src/place-row.js
@@ -23,6 +23,7 @@ const PlaceRow = ({
   LegIcon,
   legIndex,
   LineColumnContent,
+  messages,
   PlaceName,
   RouteDescription,
   setActiveLeg,
@@ -130,6 +131,7 @@ const PlaceRow = ({
         <Styled.MapButtonColumn hideBorder={hideBorder.toString()}>
           <Styled.MapButton
             onClick={() => frameLeg({ isDestination, leg, legIndex, place })}
+            title={messages.mapIconTitle}
           >
             <Styled.MapIcon />
           </Styled.MapButton>
@@ -138,6 +140,10 @@ const PlaceRow = ({
     </Styled.PlaceRowWrapper>
   );
 };
+
+const messagesType = PropTypes.shape({
+  mapIconTitle: PropTypes.string.isRequired
+});
 
 // A lot of these props are passed through from the ItineraryBody. See the
 // documentation in that component for more information.
@@ -158,6 +164,7 @@ PlaceRow.propTypes = {
   /** The index value of this specific leg within the itinerary */
   legIndex: PropTypes.number.isRequired,
   LineColumnContent: PropTypes.elementType.isRequired,
+  messages: messagesType,
   PlaceName: PropTypes.elementType.isRequired,
   RouteDescription: PropTypes.elementType.isRequired,
   setActiveLeg: PropTypes.func.isRequired,
@@ -181,6 +188,9 @@ PlaceRow.defaultProps = {
   followsTransit: false,
   // can be null if this is the origin place
   lastLeg: null,
+  messages: {
+    mapIconTitle: "View on map"
+  },
   TimeColumnContent: DefaultTimeColumnContent,
   timeOptions: null,
   TransitLegSubheader: undefined

--- a/packages/itinerary-body/src/styled.js
+++ b/packages/itinerary-body/src/styled.js
@@ -379,6 +379,9 @@ export const MapButton = styled(LinkButton)`
   margin-top: -15px;
   width: 35px;
   height: 35px;
+  &:hover {
+    cursor: pointer;
+  }
 `;
 
 export const MapButtonColumn = styled(LightBorderDiv)`
@@ -390,7 +393,7 @@ export const MapIcon = styled(BaseMapIcon).attrs(props => ({
   width: 15,
   height: 15,
   role: "img",
-  title: "Frame this Itinerary Leg"
+  title: "View on map"
 }))``;
 
 // export const ModeIcon = styled(BaseModeIcon).attrs(props => ({

--- a/packages/itinerary-body/src/styled.js
+++ b/packages/itinerary-body/src/styled.js
@@ -392,16 +392,8 @@ export const MapIcon = styled(BaseMapIcon).attrs(props => ({
   fill: props.theme.secondaryColor,
   width: 15,
   height: 15,
-  role: "img",
-  title: "View on map"
+  role: "img"
 }))``;
-
-// export const ModeIcon = styled(BaseModeIcon).attrs(props => ({
-//   width: 18,
-//   height: 18,
-//   title: props.title || "",
-//   fill: "black"
-// }))``;
 
 export const PlaceDetails = styled.div`
   /* container for Leg details */


### PR DESCRIPTION
This PR is intended to supercede #235. It provides the following tweaks:
- moves the title prop from MapIcon to MapButton (so that a hover anywhere on the button will show the alt text)
- adds a messages prop with default values (to support future/planned internationalization).