### PR TITLE
feat(query.js): override query params w/ config#defaultQueryParams

### DIFF
--- a/packages/core-utils/src/__tests__/__mocks__/config.json
+++ b/packages/core-utils/src/__tests__/__mocks__/config.json
@@ -1,0 +1,55 @@
+{
+  "homeTimezone": "America/New_York",
+  "routingTypes": [
+    {
+      "key": "ITINERARY",
+      "text": "Exact Time"
+    }
+  ],
+  "modes": {
+    "transitModes": [
+      {
+        "mode": "BUS",
+        "label": "Bus"
+      },
+      {
+        "mode": "RAIL",
+        "label": "Rail"
+      },
+      {
+        "mode": "SUBWAY",
+        "label": "Subway"
+      },
+      {
+        "mode": "TRAM",
+        "label": "Trolleys"
+      }
+    ],
+    "accessModes": [
+      {
+        "mode": "BICYCLE",
+        "label": "Transit + Personal bike"
+      },
+      {
+        "mode": "BICYCLE_RENT",
+        "label": "Transit + Bikeshare"
+      }
+    ],
+    "exclusiveModes": ["WALK", "BICYCLE"],
+    "bicycleModes": [
+      {
+        "mode": "BICYCLE",
+        "label": "Own Bike"
+      },
+      {
+        "mode": "BICYCLE_RENT",
+        "label": "Bikeshare"
+      }
+    ]
+  },
+  "dateTime": {
+    "timeFormat": "h:mm a",
+    "dateFormat": "MM/DD/YYYY",
+    "longDateFormat": "MMMM D, YYYY"
+  }
+}

--- a/packages/core-utils/src/__tests__/__snapshots__/query.js.snap
+++ b/packages/core-utils/src/__tests__/__snapshots__/query.js.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`query getDefaultQuery should allow config overrides for default query 1`] = `
+Object {
+  "bannedRoutes": "",
+  "bikeSpeed": 3.58,
+  "companies": null,
+  "date": "2019-08-04",
+  "departArrive": "NOW",
+  "endTime": "09:00",
+  "from": null,
+  "ignoreRealtimeUpdates": false,
+  "intermediatePlaces": Array [],
+  "maxBikeDistance": 4828,
+  "maxBikeTime": 20,
+  "maxEScooterDistance": 4828,
+  "maxWalkDistance": 3219,
+  "maxWalkTime": 15,
+  "mode": "WALK,TRANSIT",
+  "numItineraries": 3,
+  "optimize": "QUICK",
+  "optimizeBike": "SAFE",
+  "otherThanPreferredRoutesPenalty": 900,
+  "preferredRoutes": "",
+  "routingType": "ITINERARY",
+  "showIntermediateStops": true,
+  "startTime": "07:00",
+  "time": "19:34",
+  "to": null,
+  "walkSpeed": 1.34,
+  "watts": 250,
+  "wheelchair": false,
+}
+`;
+
 exports[`query getDefaultQuery should return default query 1`] = `
 Object {
   "bannedRoutes": "",

--- a/packages/core-utils/src/__tests__/query.js
+++ b/packages/core-utils/src/__tests__/query.js
@@ -132,6 +132,14 @@ describe("query", () => {
       query.maxWalkDistance *= 2;
       expect(isNotDefaultQuery(query, config)).toBe(true);
     });
+
+    it("should return true for query with non-default mode", () => {
+      setDefaultTestTime();
+      const query = getDefaultQuery(config);
+      // Set the mode to walk
+      query.mode = "WALK";
+      expect(isNotDefaultQuery(query, config)).toBe(true);
+    });
   });
 
   describe("parseLocationString", () => {

--- a/packages/core-utils/src/query.js
+++ b/packages/core-utils/src/query.js
@@ -171,29 +171,23 @@ export function isNotDefaultQuery(query, config) {
     if (!modesEqual) return true;
   }
   // If modes are equal, check the remaining params.
-  let queryIsDifferent = false;
-  defaultParams.forEach(param => {
-    const paramInfo = queryParams.find(qp => qp.name === param);
-    const { applicable, routingTypes } = paramInfo;
-    // Check that the parameter applies to the specified routingType
-    if (!routingTypes.includes(query.routingType)) return;
-    // Check that the applicability test (if provided) is satisfied
-    if (typeof applicable === "function" && !applicable(query, config)) {
-      return;
-    }
-    // Set default value based on query-params.js.
-    let defaultValue = getDefaultQueryParamValue(paramInfo);
-    // Apply config query param overrides if it exists.
-    if (config && config.defaultQueryParams) {
-      if (param in config.defaultQueryParams) {
-        defaultValue = config.defaultQueryParams[param];
+  const defaultQuery = getDefaultQuery(config);
+  for (let i = 0; i < defaultParams.length; i++) {
+    const param = defaultParams[i];
+    const { applicable, routingTypes } = queryParams.find(
+      qp => qp.name === param
+    );
+    // Check that the parameter applies to the specified routingType and that
+    // the applicability test (if not missing) is satisfied.
+    const appliesToQuery =
+      typeof applicable !== "function" || applicable(query, config);
+    if (appliesToQuery && routingTypes.includes(query.routingType)) {
+      if (query[param] !== defaultQuery[param]) {
+        return true;
       }
     }
-    if (query[param] !== defaultValue) {
-      queryIsDifferent = true;
-    }
-  });
-  return queryIsDifferent;
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
This PR closes #243 by modifying `getDefaultQuery` and `isNotDefaultQuery` to handle overriding default query params with values from `config#defaultQueryParams`.