### PR TITLE
fix(TransitiveOverlay): Expose styles and labeledModes transitive props.

### DIFF
--- a/packages/transitive-overlay/package.json
+++ b/packages/transitive-overlay/package.json
@@ -17,7 +17,7 @@
     "url": "git+https://github.com/opentripplanner/otp-ui.git"
   },
   "dependencies": {
-    "@opentripplanner/core-utils": "^3.0.4",
+    "@opentripplanner/core-utils": "^3.1.1",
     "lodash.isequal": "^4.5.0",
     "transitive-js": "^0.13.7"
   },

--- a/packages/transitive-overlay/src/TransitiveOverlay.story.js
+++ b/packages/transitive-overlay/src/TransitiveOverlay.story.js
@@ -31,11 +31,6 @@ const walkTransitWalkItinerary = require("@opentripplanner/itinerary-body/src/__
 const walkTransitWalkItineraryNoIntermediateStops = require("@opentripplanner/itinerary-body/src/__mocks__/itineraries/walk-transit-walk-no-intermediate-stops.json");
 const walkTransitWalkTransitWalkItinerary = require("@opentripplanner/itinerary-body/src/__mocks__/itineraries/walk-transit-walk-transit-walk.json");
 
-// Add routeShortName to walk-transit-walk itineary here
-// to illustrate labeledModes in the transitive overlay
-// (and to not interfere with other stories that use that itinerary).
-walkTransitWalkItinerary.legs[1].routeShortName = "Blue";
-
 const companies = [
   {
     id: "RAZOR",
@@ -57,6 +52,18 @@ function getFromLocation(itinerary) {
 
 function getToLocation(itinerary) {
   return itinerary.legs[itinerary.legs.length - 1].to;
+}
+
+/**
+ * Example of a custom route label provider to pass to @opentripplanner/core-utils/map#itineraryToTransitive.
+ * @param {*} itineraryLeg The OTP itinerary leg for which to obtain a custom route label.
+ * @returns A string with the custom label to display for the given leg.
+ */
+function getCustomRouteLabel(itineraryLeg) {
+  if (itineraryLeg.mode === "TRAM") return "MAX";
+  if (itineraryLeg.mode === "RAIL") return "WES";
+  if (itineraryLeg.mode === "BUS") return itineraryLeg.routeShortName;
+  return null; // null or undefined or empty string will tell transitive-js not to render a route label
 }
 
 storiesOf("TransitiveOverlay", module)
@@ -308,7 +315,8 @@ storiesOf("TransitiveOverlay", module)
           }}
           transitiveData={itineraryToTransitive(
             walkTransitWalkItinerary,
-            companies
+            companies,
+            getCustomRouteLabel
           )}
           visible
         />

--- a/packages/transitive-overlay/src/TransitiveOverlay.story.js
+++ b/packages/transitive-overlay/src/TransitiveOverlay.story.js
@@ -11,6 +11,11 @@ import TransitiveOverlay from ".";
 
 import "../../../node_modules/leaflet/dist/leaflet.css";
 
+// Use the font-family defined by storybook <body> element,
+// so we don't need to install/import extra fonts.
+const storybookFonts =
+  '"Nunito Sans", -apple-system, ".SFNSText-Regular", "San Francisco", BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif';
+
 // import mock itinaries. These are all trip plan outputs from OTP.
 const bikeOnlyItinerary = require("@opentripplanner/itinerary-body/src/__mocks__/itineraries/bike-only.json");
 const bikeRentalItinerary = require("@opentripplanner/itinerary-body/src/__mocks__/itineraries/bike-rental.json");
@@ -25,6 +30,11 @@ const walkOnlyItinerary = require("@opentripplanner/itinerary-body/src/__mocks__
 const walkTransitWalkItinerary = require("@opentripplanner/itinerary-body/src/__mocks__/itineraries/walk-transit-walk.json");
 const walkTransitWalkItineraryNoIntermediateStops = require("@opentripplanner/itinerary-body/src/__mocks__/itineraries/walk-transit-walk-no-intermediate-stops.json");
 const walkTransitWalkTransitWalkItinerary = require("@opentripplanner/itinerary-body/src/__mocks__/itineraries/walk-transit-walk-transit-walk.json");
+
+// Add routeShortName to walk-transit-walk itineary here
+// to illustrate labeledModes in the transitive overlay
+// (and to not interfere with other stories that use that itinerary).
+walkTransitWalkItinerary.legs[1].routeShortName = "Blue";
 
 const companies = [
   {
@@ -269,4 +279,39 @@ storiesOf("TransitiveOverlay", module)
         visible
       />
     </BaseMap>
-  ));
+  ))
+  .add(
+    "TransitiveOverlay with walk-transit-walk itinerary and custom label styles",
+    () => (
+      <BaseMap center={[45.520441, -122.68302]} zoom={16}>
+        <EndpointsOverlay
+          fromLocation={getFromLocation(walkTransitWalkItinerary)}
+          setLocation={setLocation}
+          toLocation={getToLocation(walkTransitWalkItinerary)}
+          visible
+        />
+        <TransitiveOverlay
+          labeledModes={["TRAM"]}
+          styles={{
+            labels: {
+              "font-size": "14px",
+              "font-family": storybookFonts
+            },
+            segment_labels: {
+              "border-color": "#FFFFFF",
+              "border-radius": 6,
+              "border-width": 2,
+              color: "#FFE0D0",
+              "font-family": storybookFonts,
+              "font-size": "18px"
+            }
+          }}
+          transitiveData={itineraryToTransitive(
+            walkTransitWalkItinerary,
+            companies
+          )}
+          visible
+        />
+      </BaseMap>
+    )
+  );

--- a/packages/transitive-overlay/src/index.js
+++ b/packages/transitive-overlay/src/index.js
@@ -4,7 +4,6 @@ import { transitiveDataType } from "@opentripplanner/core-utils/lib/types";
 import PropTypes from "prop-types";
 import { MapLayer, withLeaflet } from "react-leaflet";
 import Transitive from "transitive-js";
-import { otpModeToGtfsType } from "transitive-js/lib/util";
 
 import transitiveStyles from "./transitive-styles";
 
@@ -22,6 +21,33 @@ function checkHiPPI(canvas) {
 
     const context = canvas.getContext("2d");
     context.scale(PIXEL_RATIO, PIXEL_RATIO);
+  }
+}
+
+/**
+ * Converts OTP mode string to GTFS mode number (copied from transitive-js).
+ * TODO: Move to util?
+ */
+function otpModeToGtfsType(otpMode) {
+  switch (otpMode) {
+    case "TRAM":
+      return 0;
+    case "SUBWAY":
+      return 1;
+    case "RAIL":
+      return 2;
+    case "BUS":
+      return 3;
+    case "FERRY":
+      return 4;
+    case "CABLE_CAR":
+      return 5;
+    case "GONDOLA":
+      return 6;
+    case "FUNICULAR":
+      return 7;
+    default:
+      return -1;
   }
 }
 

--- a/packages/transitive-overlay/src/index.js
+++ b/packages/transitive-overlay/src/index.js
@@ -172,7 +172,7 @@ class TransitiveCanvasOverlay extends MapLayer {
 TransitiveCanvasOverlay.propTypes = {
   /**
    * Optional array of OTP modes whose lines should be rendered with a label.
-   * Defaults to ['BUS'] if none sepcified.
+   * Defaults to ['BUS'] if none specified.
    */
   labeledModes: PropTypes.arrayOf(PropTypes.string),
   /**


### PR DESCRIPTION
For some reason I was convinced the transitive options were directly exposed but I was wrong... so we have to expose the new styles and labeledModes on the components.

EDIT: In response to https://github.com/opentripplanner/otp-ui/pull/246#discussion_r630499498, this PR now requires #248. To test, merge the changes from #248 into this branch and run `yarn dev`.