### PR TITLE
Hide zero-capacity bike rental stations

### DIFF
--- a/packages/vehicle-rental-overlay/src/DefaultMarkers/index.js
+++ b/packages/vehicle-rental-overlay/src/DefaultMarkers/index.js
@@ -73,9 +73,9 @@ export const HubAndFloatingBike = ({ children, entity: station }) => {
   if (station.isFloatingBike) {
     icon = floatingBikeIcon;
   } else {
-    const pctFull =
-      station.bikesAvailable /
-      (station.bikesAvailable + station.spacesAvailable);
+    const capacity = station.bikesAvailable + station.spacesAvailable;
+    if (capacity === 0) return null;
+    const pctFull = station.bikesAvailable / capacity;
     const i = Math.round(pctFull * 9);
     icon = hubIcons[i];
   }


### PR DESCRIPTION
This prevents a white-screen-of-death error when a bike rental station has 0 bikes available and 0 spaces available.