### PR TITLE
Make absoluteDirection prop optional on stepsType

### DIFF
--- a/packages/core-utils/src/types.js
+++ b/packages/core-utils/src/types.js
@@ -198,7 +198,7 @@ const alertType = PropTypes.shape({
  */
 export const stepsType = PropTypes.arrayOf(
   PropTypes.shape({
-    absoluteDirection: PropTypes.string.isRequired,
+    absoluteDirection: PropTypes.string,
     alerts: PropTypes.arrayOf(alertType),
     area: PropTypes.bool.isRequired,
     bogusName: PropTypes.bool.isRequired,


### PR DESCRIPTION
There is at least one type of step for which the OTP engine doesn't return the absoluteDirection attribute for a step: riding an elevator. This change prevents a prop type error from being raised for those types of steps.  See the payload of an elevator step below:

![elevator-step](https://user-images.githubusercontent.com/1002875/121970149-c0173900-cd2a-11eb-9cdb-828175718bac.PNG)

I looked over the code base to see if making this prop optional had any other implications and it doesn't seem to, its only used when the step is a `DEPART` type and the `ELEVATOR` type has its own handling in the only [section](https://github.com/opentripplanner/otp-ui/blob/master/packages/core-utils/src/itinerary.js#L132) that its referenced