### PR TITLE
Make alert icons on itinerary configurable

### DIFF
--- a/packages/itinerary-body/README.md
+++ b/packages/itinerary-body/README.md
@@ -1,3 +1,5 @@
+Includes components for rendering a narrative view for an OpenTripPlanner itinerary.
+
 ## Usage
 
 ```

--- a/packages/itinerary-body/src/TransitLegBody/alerts-body.js
+++ b/packages/itinerary-body/src/TransitLegBody/alerts-body.js
@@ -1,11 +1,15 @@
 import moment from "moment";
 import PropTypes from "prop-types";
 import React from "react";
-import { ExclamationTriangle } from "styled-icons/fa-solid";
 
 import * as Styled from "../styled";
 
-export default function AlertsBody({ alerts, longDateFormat, timeFormat }) {
+export default function AlertsBody({
+  alerts,
+  longDateFormat,
+  timeFormat,
+  AlertIcon
+}) {
   return (
     <Styled.TransitAlerts>
       {alerts
@@ -27,7 +31,7 @@ export default function AlertsBody({ alerts, longDateFormat, timeFormat }) {
           return (
             <Styled.TransitAlert key={i} href={alert.alertUrl}>
               <Styled.TransitAlertIconContainer>
-                <ExclamationTriangle size={18} />
+                <AlertIcon />
               </Styled.TransitAlertIconContainer>
               {alert.alertHeaderText ? (
                 <Styled.TransitAlertHeader>
@@ -50,5 +54,10 @@ export default function AlertsBody({ alerts, longDateFormat, timeFormat }) {
 AlertsBody.propTypes = {
   alerts: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   longDateFormat: PropTypes.string.isRequired,
-  timeFormat: PropTypes.string.isRequired
+  timeFormat: PropTypes.string.isRequired,
+  AlertIcon: PropTypes.elementType
+};
+
+AlertsBody.defaultProps = {
+  AlertIcon: Styled.DefaultAlertBodyIcon
 };

--- a/packages/itinerary-body/src/TransitLegBody/index.js
+++ b/packages/itinerary-body/src/TransitLegBody/index.js
@@ -1,7 +1,6 @@
 import coreUtils from "@opentripplanner/core-utils";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
-import { ExclamationTriangle } from "styled-icons/fa-solid";
 import { VelocityTransitionGroup } from "velocity-react";
 
 import AlertsBody from "./alerts-body";
@@ -64,7 +63,9 @@ export default class TransitLegBody extends Component {
       timeFormat,
       TransitLegSubheader,
       TransitLegSummary,
-      transitOperator
+      transitOperator,
+      AlertToggleIcon,
+      AlertBodyIcon
     } = this.props;
     const { language: languageConfig } = config;
     const { agencyBrandingUrl, agencyName, agencyUrl, alerts } = leg;
@@ -111,8 +112,7 @@ export default class TransitLegBody extends Component {
           {/* Alerts toggle */}
           {alerts && alerts.length > 2 && (
             <Styled.TransitAlertToggle onClick={this.onToggleAlertsClick}>
-              <ExclamationTriangle size={15} /> {alerts.length}{" "}
-              {pluralize("alert", alerts)}{" "}
+              <AlertToggleIcon /> {alerts.length} {pluralize("alert", alerts)}{" "}
               <Styled.CaretToggle expanded={alertsExpanded} />
             </Styled.TransitAlertToggle>
           )}
@@ -127,6 +127,7 @@ export default class TransitLegBody extends Component {
                 alerts={leg.alerts}
                 longDateFormat={longDateFormat}
                 timeFormat={timeFormat}
+                AlertIcon={AlertBodyIcon}
               />
             )}
           </VelocityTransitionGroup>
@@ -196,11 +197,15 @@ TransitLegBody.propTypes = {
   timeFormat: PropTypes.string.isRequired,
   TransitLegSubheader: PropTypes.elementType,
   TransitLegSummary: PropTypes.elementType.isRequired,
-  transitOperator: coreUtils.types.transitOperatorType
+  transitOperator: coreUtils.types.transitOperatorType,
+  AlertToggleIcon: PropTypes.elementType,
+  AlertBodyIcon: PropTypes.elementType
 };
 
 TransitLegBody.defaultProps = {
   fare: null,
   TransitLegSubheader: undefined,
-  transitOperator: null
+  transitOperator: null,
+  AlertToggleIcon: Styled.DefaultAlertToggleIcon,
+  AlertBodyIcon: undefined
 };

--- a/packages/itinerary-body/src/index.js
+++ b/packages/itinerary-body/src/index.js
@@ -29,7 +29,9 @@ const ItineraryBody = ({
   timeOptions,
   toRouteAbbreviation,
   TransitLegSubheader,
-  TransitLegSummary
+  TransitLegSummary,
+  AlertToggleIcon,
+  AlertBodyIcon
 }) => {
   /*
     TODO: replace component should update logic? companies is simply used to
@@ -77,6 +79,8 @@ const ItineraryBody = ({
           toRouteAbbreviation={toRouteAbbreviation}
           TransitLegSubheader={TransitLegSubheader}
           TransitLegSummary={TransitLegSummary}
+          AlertToggleIcon={AlertToggleIcon}
+          AlertBodyIcon={AlertBodyIcon}
         />
       );
     }
@@ -200,7 +204,17 @@ ItineraryBody.propTypes = {
    * - leg: the transit leg
    * - stopsExpanded: whether the intermediate stop display is currently expanded
    */
-  TransitLegSummary: PropTypes.elementType.isRequired
+  TransitLegSummary: PropTypes.elementType.isRequired,
+  /**
+   * A custom icon component inserted into the transit alert toggle button
+   * within a transit leg, if this prop is not supplied a default icon is used
+   */
+  AlertToggleIcon: PropTypes.elementType,
+  /**
+   * A custom icon component inserted into the transit alert body component
+   * within a transit leg, if this prop is not supplied a default icon is used
+   */
+  AlertBodyIcon: PropTypes.elementType
 };
 
 function noop() {}
@@ -219,7 +233,9 @@ ItineraryBody.defaultProps = {
   TimeColumnContent: PlaceRow.defaultProps.TimeColumnContent,
   timeOptions: null,
   toRouteAbbreviation: noop,
-  TransitLegSubheader: undefined
+  TransitLegSubheader: undefined,
+  AlertToggleIcon: undefined,
+  AlertBodyIcon: undefined
 };
 
 export default ItineraryBody;

--- a/packages/itinerary-body/src/place-row.js
+++ b/packages/itinerary-body/src/place-row.js
@@ -38,7 +38,9 @@ const PlaceRow = ({
   timeOptions,
   toRouteAbbreviation,
   TransitLegSubheader,
-  TransitLegSummary
+  TransitLegSummary,
+  AlertToggleIcon,
+  AlertBodyIcon
 }) => {
   // NOTE: Previously there was a check for itineraries that changed vehicles
   // at a single stop, which would render the stop place the same as the
@@ -108,6 +110,8 @@ const PlaceRow = ({
                   leg,
                   config.transitOperators
                 )}
+                AlertToggleIcon={AlertToggleIcon}
+                AlertBodyIcon={AlertBodyIcon}
               />
             ) : (
               /* This is an access (e.g. walk/bike/etc.) leg */
@@ -179,7 +183,9 @@ PlaceRow.propTypes = {
   timeOptions: coreUtils.types.timeOptionsType,
   toRouteAbbreviation: PropTypes.func.isRequired,
   TransitLegSubheader: PropTypes.elementType,
-  TransitLegSummary: PropTypes.elementType.isRequired
+  TransitLegSummary: PropTypes.elementType.isRequired,
+  AlertToggleIcon: PropTypes.elementType,
+  AlertBodyIcon: PropTypes.elementType
 };
 
 PlaceRow.defaultProps = {
@@ -193,7 +199,9 @@ PlaceRow.defaultProps = {
   },
   TimeColumnContent: DefaultTimeColumnContent,
   timeOptions: null,
-  TransitLegSubheader: undefined
+  TransitLegSubheader: undefined,
+  AlertToggleIcon: undefined,
+  AlertBodyIcon: undefined
 };
 
 export default PlaceRow;

--- a/packages/itinerary-body/src/stories/OtpUiItineraryBody.story.js
+++ b/packages/itinerary-body/src/stories/OtpUiItineraryBody.story.js
@@ -2,6 +2,8 @@ import coreUtils from "@opentripplanner/core-utils";
 import { ClassicLegIcon } from "@opentripplanner/icons";
 import PropTypes from "prop-types";
 import React from "react";
+import { Bomb, Bolt } from "styled-icons/fa-solid";
+import styled from "styled-components";
 
 import ItineraryBody from "..";
 import {
@@ -15,7 +17,7 @@ import OtpRRLineColumnContent from "../otp-react-redux/line-column-content";
 import OtpRRPlaceName from "../otp-react-redux/place-name";
 import OtpRRRouteDescription from "../otp-react-redux/route-description";
 
-// import mock itinaries. These are all trip plan outputs from OTP.
+// import mock itineraries. These are all trip plan outputs from OTP.
 const bikeOnlyItinerary = require("../__mocks__/itineraries/bike-only.json");
 const bikeRentalItinerary = require("../__mocks__/itineraries/bike-rental.json");
 const bikeRentalTransitBikeRentalItinerary = require("../__mocks__/itineraries/bike-rental-transit-bike-rental.json");
@@ -156,4 +158,12 @@ export const EScooterRentalTransitItinerary = () => (
 
 export const TncTransitItinerary = () => (
   <ItineraryBodyDefaultsWrapper itinerary={tncTransitTncItinerary} />
+);
+
+export const CustomAlertIconsItinerary = () => (
+  <ItineraryBodyDefaultsWrapper
+    itinerary={walkTransitWalkItinerary}
+    AlertToggleIcon={styled(Bolt).attrs({ size: 15 })``}
+    AlertBodyIcon={styled(Bomb).attrs({ size: 18 })``}
+  />
 );

--- a/packages/itinerary-body/src/stories/itinerary-body-defaults-wrapper.js
+++ b/packages/itinerary-body/src/stories/itinerary-body-defaults-wrapper.js
@@ -40,7 +40,9 @@ export default class ItineraryBodyDefaultsWrapper extends Component {
       TimeColumnContent,
       toRouteAbbreviation,
       TransitLegSubheader,
-      TransitLegSummary
+      TransitLegSummary,
+      AlertToggleIcon,
+      AlertBodyIcon
     } = this.props;
     const { diagramVisible } = this.state;
     let ItineraryBodyComponent;
@@ -78,6 +80,8 @@ export default class ItineraryBodyDefaultsWrapper extends Component {
         toRouteAbbreviation={toRouteAbbreviation}
         TransitLegSubheader={TransitLegSubheader}
         TransitLegSummary={TransitLegSummary || DefaultTransitLegSummary}
+        AlertToggleIcon={AlertToggleIcon}
+        AlertBodyIcon={AlertBodyIcon}
       />
     );
   }
@@ -98,7 +102,9 @@ ItineraryBodyDefaultsWrapper.propTypes = {
   TimeColumnContent: PropTypes.elementType,
   toRouteAbbreviation: PropTypes.func,
   TransitLegSubheader: PropTypes.elementType,
-  TransitLegSummary: PropTypes.elementType
+  TransitLegSummary: PropTypes.elementType,
+  AlertToggleIcon: PropTypes.elementType,
+  AlertBodyIcon: PropTypes.elementType
 };
 
 ItineraryBodyDefaultsWrapper.defaultProps = {
@@ -115,5 +121,7 @@ ItineraryBodyDefaultsWrapper.defaultProps = {
   TimeColumnContent: undefined,
   toRouteAbbreviation: r => r.toString().substr(0, 2),
   TransitLegSubheader: undefined,
-  TransitLegSummary: undefined
+  TransitLegSummary: undefined,
+  AlertToggleIcon: undefined,
+  AlertBodyIcon: undefined
 };

--- a/packages/itinerary-body/src/styled.js
+++ b/packages/itinerary-body/src/styled.js
@@ -2,7 +2,7 @@ import { Map } from "@opentripplanner/icons";
 import PropTypes from "prop-types";
 import React from "react";
 import styled from "styled-components";
-import { CaretDown, CaretUp } from "styled-icons/fa-solid";
+import { CaretDown, CaretUp, ExclamationTriangle } from "styled-icons/fa-solid";
 
 import { toModeBorder, toModeColor, toSafeRouteColor } from "./util";
 
@@ -606,3 +606,11 @@ export const TransitLegFare = styled.div`
 export const TransitLegSummary = styled(TransparentButton)`
   padding: 0;
 `;
+
+export const DefaultAlertToggleIcon = styled(ExclamationTriangle).attrs({
+  size: 15
+})``;
+
+export const DefaultAlertBodyIcon = styled(ExclamationTriangle).attrs({
+  size: 18
+})``;


### PR DESCRIPTION
New story: http://localhost:5555/?path=/story/itinerarybody-otp-ui--custom-alert-icons-itinerary
* Add props to the itinerary body component for the two alert icons and
  pass them down through the itinerary tree to the appropriate child
  components
* Reconfigure the existing icon components to be overrideable prop
  defaults
* Add a story to the itinerary storybook to illustrate this new
  functionality