### PR TITLE
Hide Vehicle Overlay When Appropriate 

### DIFF
--- a/packages/vehicle-rental-overlay/package.json
+++ b/packages/vehicle-rental-overlay/package.json
@@ -18,7 +18,6 @@
     "url": "git+https://github.com/opentripplanner/otp-ui.git"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^1.1.0",
     "@opentripplanner/core-utils": "^3.0.4",
     "@opentripplanner/from-to-location-picker": "^1.0.3",
     "@opentripplanner/zoom-based-markers": "^1.0.1",
@@ -27,6 +26,7 @@
     "styled-icons": "^9.1.0"
   },
   "peerDependencies": {
+    "@opentripplanner/base-map": "^1.1.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-leaflet": "^2.6.1",

--- a/packages/vehicle-rental-overlay/package.json
+++ b/packages/vehicle-rental-overlay/package.json
@@ -27,7 +27,6 @@
     "styled-icons": "^9.1.0"
   },
   "peerDependencies": {
-    "@opentripplanner/base-map": "^1.0.4",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-leaflet": "^2.6.1",

--- a/packages/vehicle-rental-overlay/package.json
+++ b/packages/vehicle-rental-overlay/package.json
@@ -18,6 +18,7 @@
     "url": "git+https://github.com/opentripplanner/otp-ui.git"
   },
   "dependencies": {
+    "@opentripplanner/base-map": "^1.1.0",
     "@opentripplanner/core-utils": "^3.0.4",
     "@opentripplanner/from-to-location-picker": "^1.0.3",
     "@opentripplanner/zoom-based-markers": "^1.0.1",

--- a/packages/vehicle-rental-overlay/src/index.js
+++ b/packages/vehicle-rental-overlay/src/index.js
@@ -149,7 +149,7 @@ class VehicleRentalOverlay extends MapLayer {
   };
 
   render() {
-    const { companies, mapSymbols, stations } = this.props;
+    const { companies, mapSymbols, stations, visible } = this.props;
     let filteredStations = stations;
     if (companies) {
       filteredStations = stations.filter(
@@ -158,7 +158,7 @@ class VehicleRentalOverlay extends MapLayer {
       );
     }
 
-    if (!filteredStations || filteredStations.length === 0) {
+    if (!visible || !filteredStations || filteredStations.length === 0) {
       return <FeatureGroup />;
     }
 

--- a/packages/vehicle-rental-overlay/src/index.js
+++ b/packages/vehicle-rental-overlay/src/index.js
@@ -150,6 +150,9 @@ class VehicleRentalOverlay extends MapLayer {
 
   render() {
     const { companies, mapSymbols, stations, visible } = this.props;
+    // Don't render anything if we're not visible
+    if (!visible) return null;
+
     let filteredStations = stations;
     if (companies) {
       filteredStations = stations.filter(
@@ -158,7 +161,7 @@ class VehicleRentalOverlay extends MapLayer {
       );
     }
 
-    if (!visible || !filteredStations || filteredStations.length === 0) {
+    if (!filteredStations || filteredStations.length === 0) {
       return <FeatureGroup />;
     }
 


### PR DESCRIPTION
Closes opentripplanner/otp-react-redux#414

The issue was the `VehicleRentalOverlay` component taking a `visible` prop, but doing nothing with it...