### PR TITLE
Properly render vehicle rental layer with 0 stations

### DIFF
--- a/packages/vehicle-rental-overlay/src/VehicleRentalOverlay.story.js
+++ b/packages/vehicle-rental-overlay/src/VehicleRentalOverlay.story.js
@@ -10,6 +10,7 @@ import bikeRentalStations from "../__mocks__/bike-rental-stations.json";
 import carRentalStations from "../__mocks__/car-rental-stations.json";
 import eScooterStations from "../__mocks__/e-scooter-rental-stations.json";
 import { HubAndFloatingBike } from "./DefaultMarkers";
+import LeafletLayerControlInterface from "./leaflet-layer-control-interface";
 
 import "../../../node_modules/leaflet/dist/leaflet.css";
 
@@ -34,7 +35,7 @@ const MyCircle = ({ fillColor = "gray", pixels, strokeColor }) => {
       {children}
     </CircleMarker>
   );
-  GeneratedCircle.coreUtils.types.propTypes = {
+  GeneratedCircle.propTypes = {
     children: PropTypes.node,
     entity: coreUtils.types.stationType.isRequired
   };
@@ -182,7 +183,8 @@ class ZoomControlledMapWithVehicleRentalOverlay extends Component {
       getStationName,
       mapSymbols,
       refreshVehicles,
-      stations
+      stations,
+      visible
     } = this.props;
     const { zoom } = this.state;
     return (
@@ -191,15 +193,16 @@ class ZoomControlledMapWithVehicleRentalOverlay extends Component {
         onViewportChanged={this.onViewportChanged}
         zoom={zoom}
       >
-        <VehicleRentalOverlay
+        <LeafletLayerControlInterface
           configCompanies={configCompanies}
           companies={companies}
           getStationName={getStationName}
           setLocation={setLocation}
           mapSymbols={mapSymbols}
+          name="Rentals"
           refreshVehicles={refreshVehicles}
           stations={stations}
-          visible
+          visible={visible}
           zoom={zoom}
         />
       </BaseMap>
@@ -212,13 +215,16 @@ ZoomControlledMapWithVehicleRentalOverlay.propTypes = {
   getStationName: PropTypes.func,
   mapSymbols: coreUtils.types.vehicleRentalMapOverlaySymbolsType,
   refreshVehicles: PropTypes.func.isRequired,
-  stations: PropTypes.arrayOf(coreUtils.types.stationType.isRequired).isRequired
+  stations: PropTypes.arrayOf(coreUtils.types.stationType.isRequired)
+    .isRequired,
+  visible: PropTypes.bool
 };
 
 ZoomControlledMapWithVehicleRentalOverlay.defaultProps = {
   companies: null,
   getStationName: undefined,
-  mapSymbols: null
+  mapSymbols: null,
+  visible: undefined
 };
 
 function customStationName(_, station) {
@@ -236,6 +242,16 @@ export const RentalBicycles = () => (
     mapSymbols={bikeMapSymbols}
     refreshVehicles={action("refresh bicycles")}
     stations={bikeRentalStations}
+  />
+);
+
+export const RentalBicyclesVisibleOnMount = () => (
+  <ZoomControlledMapWithVehicleRentalOverlay
+    companies={["BIKETOWN"]}
+    mapSymbols={bikeMapSymbols}
+    refreshVehicles={action("refresh bicycles")}
+    stations={bikeRentalStations}
+    visible
   />
 );
 

--- a/packages/vehicle-rental-overlay/src/index.js
+++ b/packages/vehicle-rental-overlay/src/index.js
@@ -150,8 +150,12 @@ class VehicleRentalOverlay extends MapLayer {
 
   render() {
     const { companies, mapSymbols, stations, visible } = this.props;
-    // Don't render anything if we're not visible
-    if (!visible) return null;
+    // Render an empty FeatureGroup if the rental vehicles should not be visible
+    // on the map. Otherwise previous stations may still be shown due to some
+    // react-leaflet internals, maybe?
+    if (!visible) {
+      return <FeatureGroup />;
+    }
 
     let filteredStations = stations;
     if (companies) {

--- a/packages/vehicle-rental-overlay/src/leaflet-layer-control-interface.tsx
+++ b/packages/vehicle-rental-overlay/src/leaflet-layer-control-interface.tsx
@@ -27,9 +27,15 @@ type State = {
 };
 
 /**
- * This class is a necessary intermediary to handle events from the Leaflet map
- * existing in the parent element. See more notes on the other properties and
- * methods for how everything interacts.
+ * This class is a necessary intermediary to handle events proxied from the
+ * parent @opentripplanner/base-map component handlers to this component.
+ * Without this interface, there would be no way to detect when a user would
+ * hide this layer from view on the Leaflet map. The visible property influences
+ * and sets the Leaflet Layer Control which then is handled by the
+ * @opentripplanner/base-map component and then delivered to the
+ * `onOverlayAdded` and `onOverlayRemoved` handlers which then finally set this
+ * component's state which is then finally used by the vehicle rental overlay
+ * to properly manage the requesting of vehicle rentals.
  */
 export default class LeafletLayerControlInterface extends Component<
   Props,

--- a/packages/vehicle-rental-overlay/src/leaflet-layer-control-interface.tsx
+++ b/packages/vehicle-rental-overlay/src/leaflet-layer-control-interface.tsx
@@ -1,0 +1,75 @@
+import React, { Component } from "react";
+
+import VehicleRentalOverlay from ".";
+
+type Props = {
+  /**
+   * This method is created by the @opentripplanner/base-map package when
+   * mounting user-defined layers. This will allow the component to subscribe to
+   * various leaflet events that then get forwarded on to this component.
+   */
+  registerOverlay: (component: Component) => void;
+  /**
+   * Whether or not to initially display the rental vehicles. Once the component
+   * is mounted the subscribed events of a user toggling on or off the layer via
+   * the layer control item will subsequently control the display of the
+   * component.
+   */
+  visible?: boolean;
+};
+
+type State = {
+  /**
+   * An internal state variable used to determine whether or not to display the
+   * rental vehicles for this layer.
+   */
+  visible: boolean;
+};
+
+/**
+ * This class is a necessary intermediary to handle events from the Leaflet map
+ * existing in the parent element. See more notes on the other properties and
+ * methods for how everything interacts.
+ */
+export default class LeafletLayerControlInterface extends Component<
+  Props,
+  State
+> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { visible: props.visible };
+  }
+
+  /**
+   * Upon mounting, this class calls the register overlay property that the
+   * @opentripplanner/base-map package has injected into the props.
+   */
+  componentDidMount() {
+    const { registerOverlay } = this.props;
+    registerOverlay(this);
+  }
+
+  /**
+   * A handler function for when this layer is toggled on by the user via the
+   * leaflet layer control.
+   */
+  onOverlayAdded = () => {
+    this.setState({ visible: true });
+  };
+
+  /**
+   * A handler function for when this layer is toggled off by the user via the
+   * leaflet layer control.
+   */
+  onOverlayRemoved = () => {
+    this.setState({ visible: false });
+  };
+
+  render() {
+    const { visible } = this.state;
+    return (
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      <VehicleRentalOverlay {...this.props} visible={visible} />
+    );
+  }
+}


### PR DESCRIPTION
Also fix the vehicle rental storybook stories and improve the storybook example to show detailed controlling of the vehicle rental layer via handlers of layer control events.