### PR TITLE
Change back to original logic in v1.1.0 of vehicle-rental-overlay

### DIFF
--- a/packages/vehicle-rental-overlay/src/VehicleRentalOverlay.story.js
+++ b/packages/vehicle-rental-overlay/src/VehicleRentalOverlay.story.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { CircleMarker } from "react-leaflet";
 import { action } from "@storybook/addon-actions";
+import { boolean } from "@storybook/addon-knobs";
 
 import VehicleRentalOverlay from ".";
 import bikeRentalStations from "../__mocks__/bike-rental-stations.json";
@@ -34,7 +35,7 @@ const MyCircle = ({ fillColor = "gray", pixels, strokeColor }) => {
       {children}
     </CircleMarker>
   );
-  GeneratedCircle.coreUtils.types.propTypes = {
+  GeneratedCircle.propTypes = {
     children: PropTypes.node,
     entity: coreUtils.types.stationType.isRequired
   };
@@ -182,7 +183,8 @@ class ZoomControlledMapWithVehicleRentalOverlay extends Component {
       getStationName,
       mapSymbols,
       refreshVehicles,
-      stations
+      stations,
+      visible
     } = this.props;
     const { zoom } = this.state;
     return (
@@ -197,9 +199,10 @@ class ZoomControlledMapWithVehicleRentalOverlay extends Component {
           getStationName={getStationName}
           setLocation={setLocation}
           mapSymbols={mapSymbols}
+          name="Rentals"
           refreshVehicles={refreshVehicles}
           stations={stations}
-          visible
+          visible={visible}
           zoom={zoom}
         />
       </BaseMap>
@@ -212,13 +215,16 @@ ZoomControlledMapWithVehicleRentalOverlay.propTypes = {
   getStationName: PropTypes.func,
   mapSymbols: coreUtils.types.vehicleRentalMapOverlaySymbolsType,
   refreshVehicles: PropTypes.func.isRequired,
-  stations: PropTypes.arrayOf(coreUtils.types.stationType.isRequired).isRequired
+  stations: PropTypes.arrayOf(coreUtils.types.stationType.isRequired)
+    .isRequired,
+  visible: PropTypes.bool
 };
 
 ZoomControlledMapWithVehicleRentalOverlay.defaultProps = {
   companies: null,
   getStationName: undefined,
-  mapSymbols: null
+  mapSymbols: null,
+  visible: undefined
 };
 
 function customStationName(_, station) {
@@ -238,6 +244,22 @@ export const RentalBicycles = () => (
     stations={bikeRentalStations}
   />
 );
+
+export const RentalBicyclesWithKnobs = () => {
+  const isOverlayVisible = boolean(
+    "Toggle visibility of vehicle rental overlay",
+    true
+  );
+  return (
+    <ZoomControlledMapWithVehicleRentalOverlay
+      companies={["BIKETOWN"]}
+      mapSymbols={bikeMapSymbols}
+      refreshVehicles={action("refresh bicycles")}
+      stations={bikeRentalStations}
+      visible={isOverlayVisible}
+    />
+  );
+};
 
 export const RentalBicyclesUsingNewSymbolsProp = () => (
   <ZoomControlledMapWithVehicleRentalOverlay

--- a/packages/vehicle-rental-overlay/src/index.js
+++ b/packages/vehicle-rental-overlay/src/index.js
@@ -149,9 +149,7 @@ class VehicleRentalOverlay extends MapLayer {
   };
 
   render() {
-    const { companies, mapSymbols, stations, visible } = this.props;
-    // Don't render anything if we're not visible
-    if (!visible) return null;
+    const { companies, mapSymbols, stations } = this.props;
 
     let filteredStations = stations;
     if (companies) {


### PR DESCRIPTION
This undoes the change in https://github.com/opentripplanner/otp-ui/pull/265 that had to do with the `visibility` prop being used in the render method. The `visibility` prop is sent to the Leaflet Layer control which should handle the display of rental vehicles on it's own. The bug with https://github.com/opentripplanner/otp-react-redux/issues/414 should be fixed in otp-rr itself.