### PR TITLE
Update TripDetails component with messages prop (i18n)

### DIFF
--- a/packages/trip-details/src/TripDetails.story.js
+++ b/packages/trip-details/src/TripDetails.story.js
@@ -1,3 +1,4 @@
+import coreUtils from "@opentripplanner/core-utils";
 import React from "react";
 import styled from "styled-components";
 
@@ -24,17 +25,75 @@ const StyledTripDetails = styled(TripDetails)`
   }
 `;
 
-const customMessages = {
-  title: "Details about this Trip",
-  transitFare: "Transit Fare",
-  transitFareDescription:
-    "Note: actual fare may be lower if you have a transit pass or something like that."
-};
+function getCustomMessages(itinerary) {
+  const itinDate = new Date(itinerary.startTime);
+  const {
+    centsToString,
+    maxTNCFare,
+    minTNCFare,
+    transitFare
+  } = coreUtils.itinerary.calculateFares(itinerary);
+  const companies = itinerary.legs
+    .filter(leg => leg.tncData)
+    .map(leg => leg.tncData.company);
+  const {
+    bikeDuration,
+    caloriesBurned,
+    walkDuration
+  } = coreUtils.itinerary.calculatePhysicalActivity(itinerary);
+
+  return {
+    caloriesBurned: <>{caloriesBurned} Calories burned</>,
+    caloriesBurnedDescription: (
+      <>
+        The calories description can be constructed using any markup and
+        itinerary params like {walkDuration} min walk and {bikeDuration} min
+        bike, and including formatting markup from a string localization
+        library.
+      </>
+    ),
+    depart: (
+      <>
+        <b>You depart at</b> <u>{itinDate.toLocaleTimeString()}</u>
+        {" on "}
+        {itinDate.toISOString()}
+      </>
+    ),
+    departDescription: (
+      <>
+        The depart message can be constructed dynamically using any markup,
+        including formatting markup from a string localization library.
+      </>
+    ),
+    title: "Details about this Trip",
+    tncFare: (
+      <>
+        <u>
+          ${minTNCFare}-${maxTNCFare}
+        </u>{" "}
+        for {companies[0]}
+      </>
+    ),
+    transitFare: (
+      <>
+        <u>{centsToString(transitFare)}</u> transit ticket
+      </>
+    ),
+    transitFareDescription: (
+      <>
+        The transit and/or TNC fare message can be constructed dynamically using
+        any markup, including formatting markup from a string localization
+        library.
+      </>
+    )
+  };
+}
+
 const longDateFormat = "MMMM D, YYYY";
 
 export default {
-  title: "TripDetails",
-  components: TripDetails
+  components: TripDetails,
+  title: "TripDetails"
 };
 
 export const WalkOnlyItinerary = () => (
@@ -52,13 +111,15 @@ export const WalkTransitWalkItinerary = () => (
   />
 );
 
-export const WalkTransitWalkItineraryAndCustomMessages = () => (
-  <TripDetails
-    itinerary={walkTransitWalkItinerary}
-    longDateFormat={longDateFormat}
-    messages={customMessages}
-  />
-);
+export const WalkTransitWalkItineraryAndCustomMessages = () => {
+  return (
+    <TripDetails
+      itinerary={walkTransitWalkItinerary}
+      longDateFormat={longDateFormat}
+      messages={getCustomMessages(walkTransitWalkItinerary)}
+    />
+  );
+};
 
 export const StyledWalkTransitWalkItinerary = () => (
   <StyledTripDetails
@@ -127,5 +188,13 @@ export const TncTransitItinerary = () => (
   <TripDetails
     itinerary={tncTransitTncItinerary}
     longDateFormat={longDateFormat}
+  />
+);
+
+export const TncTransitItineraryWithCustomMessages = () => (
+  <TripDetails
+    itinerary={tncTransitTncItinerary}
+    longDateFormat={longDateFormat}
+    messages={getCustomMessages(tncTransitTncItinerary)}
   />
 );

--- a/packages/trip-details/src/TripDetails.story.js
+++ b/packages/trip-details/src/TripDetails.story.js
@@ -1,4 +1,4 @@
-import coreUtils from "@opentripplanner/core-utils";
+/* eslint-disable react/prop-types */
 import React from "react";
 import styled from "styled-components";
 
@@ -25,69 +25,37 @@ const StyledTripDetails = styled(TripDetails)`
   }
 `;
 
-function getCustomMessages(itinerary) {
-  const itinDate = new Date(itinerary.startTime);
-  const {
-    centsToString,
-    maxTNCFare,
-    minTNCFare,
-    transitFare
-  } = coreUtils.itinerary.calculateFares(itinerary);
-  const companies = itinerary.legs
-    .filter(leg => leg.tncData)
-    .map(leg => leg.tncData.company);
-  const {
-    bikeDuration,
-    caloriesBurned,
-    walkDuration
-  } = coreUtils.itinerary.calculatePhysicalActivity(itinerary);
+const CustomDepartureDetails = ({ startTime }) => (
+  <>
+    Custom messages about {startTime} can be constructed dynamically using any
+    markup, including formatting markup from a string localization library.
+  </>
+);
 
-  return {
-    caloriesBurned: <>{caloriesBurned} Calories burned</>,
-    caloriesBurnedDescription: (
-      <>
-        The calories description can be constructed using any markup and
-        itinerary params like {walkDuration} min walk and {bikeDuration} min
-        bike, and including formatting markup from a string localization
-        library.
-      </>
-    ),
-    depart: (
-      <>
-        <b>You depart at</b> <u>{itinDate.toLocaleTimeString()}</u>
-        {" on "}
-        {itinDate.toISOString()}
-      </>
-    ),
-    departDescription: (
-      <>
-        The depart message can be constructed dynamically using any markup,
-        including formatting markup from a string localization library.
-      </>
-    ),
-    title: "Details about this Trip",
-    tncFare: (
-      <>
-        <u>
-          ${minTNCFare}-${maxTNCFare}
-        </u>{" "}
-        for {companies[0]}
-      </>
-    ),
-    transitFare: (
-      <>
-        <u>{centsToString(transitFare)}</u> transit ticket
-      </>
-    ),
-    transitFareDescription: (
-      <>
-        The transit and/or TNC fare message can be constructed dynamically using
-        any markup, including formatting markup from a string localization
-        library.
-      </>
-    )
-  };
-}
+const CustomTransitFare = ({ fareData }) => {
+  const { centsToString, transitFare } = fareData;
+  return (
+    <>
+      <b>{centsToString(transitFare)}</b> transit ticket
+    </>
+  );
+};
+
+const CustomFareDetails = ({ fareData }) => (
+  <>
+    Custom details about fares (transitFare: {fareData.transitFare} (cents),
+    minTNCFare: {fareData.minTNCFare} and maxTNCFare: {fareData.maxTNCFare} can
+    be constructed dynamically using any markup, including formatting markup
+    from a string localization library.
+  </>
+);
+
+const CustomCaloriesDetails = ({ bikeDuration, calories, walkDuration }) => (
+  <>
+    Custom message about {calories} calories burned,
+    {walkDuration} seconds and {bikeDuration} seconds.
+  </>
+);
 
 const longDateFormat = "MMMM D, YYYY";
 
@@ -111,12 +79,16 @@ export const WalkTransitWalkItinerary = () => (
   />
 );
 
-export const WalkTransitWalkItineraryAndCustomMessages = () => {
+export const WalkTransitWalkItineraryWithCustomMessages = () => {
   return (
     <TripDetails
+      CaloriesDetails={CustomCaloriesDetails}
+      DepartureDetails={CustomDepartureDetails}
+      FareDetails={CustomFareDetails}
       itinerary={walkTransitWalkItinerary}
       longDateFormat={longDateFormat}
-      messages={getCustomMessages(walkTransitWalkItinerary)}
+      title="Custom Details About This Trip"
+      TransitFare={CustomTransitFare}
     />
   );
 };
@@ -188,13 +160,5 @@ export const TncTransitItinerary = () => (
   <TripDetails
     itinerary={tncTransitTncItinerary}
     longDateFormat={longDateFormat}
-  />
-);
-
-export const TncTransitItineraryWithCustomMessages = () => (
-  <TripDetails
-    itinerary={tncTransitTncItinerary}
-    longDateFormat={longDateFormat}
-    messages={getCustomMessages(tncTransitTncItinerary)}
   />
 );

--- a/packages/trip-details/src/defaults.js
+++ b/packages/trip-details/src/defaults.js
@@ -1,0 +1,128 @@
+import coreUtils from "@opentripplanner/core-utils";
+import moment from "moment";
+import PropTypes from "prop-types";
+import React from "react";
+
+import * as Styled from "./styled";
+
+/**
+ * Default rendering for the departure date/time line
+ * if no other corresponding message is provided.
+ */
+export function DefaultDepart({ itinerary, longDateFormat, timeOptions }) {
+  const date = moment(itinerary.startTime);
+  return (
+    <>
+      Depart <b>{date.format(longDateFormat)}</b>
+      {" at "}
+      <b>{coreUtils.time.formatTime(itinerary.startTime, timeOptions)}</b>
+    </>
+  );
+}
+
+DefaultDepart.propTypes = {
+  itinerary: coreUtils.types.itineraryType.isRequired,
+  longDateFormat: PropTypes.string.isRequired,
+  timeOptions: coreUtils.types.timeOptionsType.isRequired
+};
+
+/**
+ * Default rendering for the transit fare line
+ * if no other corresponding message is provided.
+ */
+export function DefaultTransitFare({ fareResult }) {
+  const { centsToString, transitFare } = fareResult;
+  return (
+    <>
+      Transit Fare: <b>{centsToString(transitFare)}</b>
+    </>
+  );
+}
+
+DefaultTransitFare.propTypes = {
+  fareResult: PropTypes.shape({
+    centsToString: PropTypes.func,
+    transitFare: PropTypes.number
+  }).isRequired
+};
+
+/**
+ * Default rendering for the TNC fare line
+ * if no other corresponding message is provided.
+ */
+export function DefaultTNCFare({ fareResult, itinerary }) {
+  const { dollarsToString, maxTNCFare, minTNCFare } = fareResult;
+  let companies;
+  itinerary.legs.forEach(leg => {
+    if (leg.tncData) {
+      companies = leg.tncData.company;
+    }
+  });
+  return (
+    <>
+      <Styled.TNCFareCompanies>
+        {companies.toLowerCase()}
+      </Styled.TNCFareCompanies>
+      {" fare: "}
+      <b>
+        {dollarsToString(minTNCFare)} - {dollarsToString(maxTNCFare)}
+      </b>
+    </>
+  );
+}
+
+DefaultTNCFare.propTypes = {
+  fareResult: PropTypes.shape({
+    dollarsToString: PropTypes.func,
+    maxTNCFare: PropTypes.number,
+    minTNCFare: PropTypes.number
+  }).isRequired,
+  itinerary: coreUtils.types.itineraryType.isRequired
+};
+
+/**
+ * Default rendering for the calories burned line
+ * if no other corresponding message is provided.
+ */
+export function DefaultCaloriesBurned({ caloriesBurned }) {
+  return (
+    <>
+      Calories Burned: <b>{Math.round(caloriesBurned)}</b>
+    </>
+  );
+}
+
+DefaultCaloriesBurned.propTypes = {
+  caloriesBurned: PropTypes.number.isRequired
+};
+
+/**
+ * Default rendering for the calories description
+ * if no other corresponding message is provided.
+ */
+export function DefaultCaloriesBurnedDescription({
+  bikeDuration,
+  walkDuration
+}) {
+  return (
+    <>
+      Calories burned is based on{" "}
+      <b>{Math.round(walkDuration / 60)} minute(s)</b> spent walking and{" "}
+      <b>{Math.round(bikeDuration / 60)} minute(s)</b> spent biking during this
+      trip. Adapted from{" "}
+      <a
+        href="https://health.gov/dietaryguidelines/dga2005/document/html/chapter3.htm#table4"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Dietary Guidelines for Americans 2005, page 16, Table 4
+      </a>
+      .
+    </>
+  );
+}
+
+DefaultCaloriesBurnedDescription.propTypes = {
+  bikeDuration: PropTypes.number.isRequired,
+  walkDuration: PropTypes.number.isRequired
+};

--- a/packages/trip-details/src/defaults.js
+++ b/packages/trip-details/src/defaults.js
@@ -9,20 +9,20 @@ import * as Styled from "./styled";
  * Default rendering for the departure date/time line
  * if no other corresponding message is provided.
  */
-export function DefaultDepart({ itinerary, longDateFormat, timeOptions }) {
-  const date = moment(itinerary.startTime);
+export function DefaultDeparture({ longDateFormat, startTime, timeOptions }) {
+  const date = moment(startTime);
   return (
     <>
       Depart <b>{date.format(longDateFormat)}</b>
       {" at "}
-      <b>{coreUtils.time.formatTime(itinerary.startTime, timeOptions)}</b>
+      <b>{coreUtils.time.formatTime(startTime, timeOptions)}</b>
     </>
   );
 }
 
-DefaultDepart.propTypes = {
-  itinerary: coreUtils.types.itineraryType.isRequired,
+DefaultDeparture.propTypes = {
   longDateFormat: PropTypes.string.isRequired,
+  startTime: PropTypes.number.isRequired,
   timeOptions: coreUtils.types.timeOptionsType.isRequired
 };
 
@@ -30,8 +30,8 @@ DefaultDepart.propTypes = {
  * Default rendering for the transit fare line
  * if no other corresponding message is provided.
  */
-export function DefaultTransitFare({ fareResult }) {
-  const { centsToString, transitFare } = fareResult;
+export function DefaultTransitFare({ fareData }) {
+  const { centsToString, transitFare } = fareData;
   return (
     <>
       Transit Fare: <b>{centsToString(transitFare)}</b>
@@ -40,7 +40,7 @@ export function DefaultTransitFare({ fareResult }) {
 }
 
 DefaultTransitFare.propTypes = {
-  fareResult: PropTypes.shape({
+  fareData: PropTypes.shape({
     centsToString: PropTypes.func,
     transitFare: PropTypes.number
   }).isRequired
@@ -50,8 +50,8 @@ DefaultTransitFare.propTypes = {
  * Default rendering for the TNC fare line
  * if no other corresponding message is provided.
  */
-export function DefaultTNCFare({ fareResult, itinerary }) {
-  const { dollarsToString, maxTNCFare, minTNCFare } = fareResult;
+export function DefaultTNCFare({ fareData, itinerary }) {
+  const { dollarsToString, maxTNCFare, minTNCFare } = fareData;
   let companies;
   itinerary.legs.forEach(leg => {
     if (leg.tncData) {
@@ -72,7 +72,7 @@ export function DefaultTNCFare({ fareResult, itinerary }) {
 }
 
 DefaultTNCFare.propTypes = {
-  fareResult: PropTypes.shape({
+  fareData: PropTypes.shape({
     dollarsToString: PropTypes.func,
     maxTNCFare: PropTypes.number,
     minTNCFare: PropTypes.number
@@ -84,26 +84,23 @@ DefaultTNCFare.propTypes = {
  * Default rendering for the calories burned line
  * if no other corresponding message is provided.
  */
-export function DefaultCaloriesBurned({ caloriesBurned }) {
+export function DefaultCalories({ calories }) {
   return (
     <>
-      Calories Burned: <b>{Math.round(caloriesBurned)}</b>
+      Calories Burned: <b>{Math.round(calories)}</b>
     </>
   );
 }
 
-DefaultCaloriesBurned.propTypes = {
-  caloriesBurned: PropTypes.number.isRequired
+DefaultCalories.propTypes = {
+  calories: PropTypes.number.isRequired
 };
 
 /**
  * Default rendering for the calories description
  * if no other corresponding message is provided.
  */
-export function DefaultCaloriesBurnedDescription({
-  bikeDuration,
-  walkDuration
-}) {
+export function DefaultCaloriesDetails({ bikeDuration, walkDuration }) {
   return (
     <>
       Calories burned is based on{" "}
@@ -122,7 +119,7 @@ export function DefaultCaloriesBurnedDescription({
   );
 }
 
-DefaultCaloriesBurnedDescription.propTypes = {
+DefaultCaloriesDetails.propTypes = {
   bikeDuration: PropTypes.number.isRequired,
   walkDuration: PropTypes.number.isRequired
 };

--- a/packages/trip-details/src/index.js
+++ b/packages/trip-details/src/index.js
@@ -4,27 +4,29 @@ import React from "react";
 import { CalendarAlt, Heartbeat, MoneyBillAlt } from "styled-icons/fa-solid";
 
 import {
-  DefaultDepart,
+  DefaultDeparture,
   DefaultTransitFare,
   DefaultTNCFare,
-  DefaultCaloriesBurned,
-  DefaultCaloriesBurnedDescription
+  DefaultCalories,
+  DefaultCaloriesDetails
 } from "./defaults";
 import * as Styled from "./styled";
 import TripDetail from "./trip-detail";
 
 export default function TripDetails({
+  Calories,
+  CaloriesDetails,
   className,
+  Departure,
+  DepartureDetails,
+  FareDetails,
   itinerary,
   longDateFormat,
-  messages,
-  timeOptions
+  timeOptions,
+  title,
+  TransitFare,
+  TNCFare
 }) {
-  messages = coreUtils.messages.mergeMessages(
-    TripDetails.defaultProps.messages,
-    messages
-  );
-
   // process the transit fare
   const fareResult = coreUtils.itinerary.calculateFares(itinerary);
   const { minTNCFare, transitFare } = fareResult;
@@ -34,17 +36,13 @@ export default function TripDetails({
       <Styled.Fare>
         {transitFare && (
           <Styled.TransitFare>
-            {messages.transitFare || (
-              <DefaultTransitFare fareResult={fareResult} />
-            )}
+            <TransitFare fareData={fareResult} />
           </Styled.TransitFare>
         )}
         {minTNCFare !== 0 && (
           <Styled.TNCFare>
             <br />
-            {messages.tncFare || (
-              <DefaultTNCFare fareResult={fareResult} itinerary={itinerary} />
-            )}
+            <TNCFare fareData={fareResult} itinerary={itinerary} />
           </Styled.TNCFare>
         )}
       </Styled.Fare>
@@ -60,26 +58,28 @@ export default function TripDetails({
 
   return (
     <Styled.TripDetails className={className}>
-      <Styled.TripDetailsHeader>{messages.title}</Styled.TripDetailsHeader>
+      <Styled.TripDetailsHeader>{title}</Styled.TripDetailsHeader>
       <Styled.TripDetailsBody>
         <TripDetail
-          description={messages.departDescription}
+          description={
+            DepartureDetails && (
+              <DepartureDetails startTime={itinerary.startTime} />
+            )
+          }
           icon={<CalendarAlt size={17} />}
           summary={
             <Styled.Timing>
-              {messages.depart || (
-                <DefaultDepart
-                  itinerary={itinerary}
-                  longDateFormat={longDateFormat}
-                  timeOptions={timeOptions}
-                />
-              )}
+              <Departure
+                longDateFormat={longDateFormat}
+                startTime={itinerary.startTime}
+                timeOptions={timeOptions}
+              />
             </Styled.Timing>
           }
         />
         {fare && (
           <TripDetail
-            description={messages.transitFareDescription}
+            description={FareDetails && <FareDetails fareData={fareResult} />}
             icon={<MoneyBillAlt size={17} />}
             summary={fare}
           />
@@ -89,20 +89,19 @@ export default function TripDetails({
             icon={<Heartbeat size={17} />}
             summary={
               <Styled.CaloriesSummary>
-                {messages.caloriesBurned || (
-                  <DefaultCaloriesBurned caloriesBurned={caloriesBurned} />
-                )}
+                <Calories calories={caloriesBurned} />
               </Styled.CaloriesSummary>
             }
             description={
-              <Styled.CaloriesDescription>
-                {messages.caloriesBurnedDescription || (
-                  <DefaultCaloriesBurnedDescription
+              CaloriesDetails && (
+                <Styled.CaloriesDescription>
+                  <CaloriesDetails
                     bikeDuration={bikeDuration}
+                    calories={caloriesBurned}
                     walkDuration={walkDuration}
                   />
-                )}
-              </Styled.CaloriesDescription>
+                </Styled.CaloriesDescription>
+              )
             }
           />
         )}
@@ -112,46 +111,34 @@ export default function TripDetails({
 }
 
 TripDetails.propTypes = {
+  Calories: PropTypes.elementType,
+  CaloriesDetails: PropTypes.elementType,
   /** Used for additional styling with styled components for example. */
   className: PropTypes.string,
+  Departure: PropTypes.elementType,
+  DepartureDetails: PropTypes.elementType,
+  FareDetails: PropTypes.elementType,
   /** Itinerary that the user has selected to view, contains multiple legs */
   itinerary: coreUtils.types.itineraryType.isRequired,
   /** the desired format to use for a long date */
   longDateFormat: PropTypes.string,
-  /**
-   * messages to use for l10n/i8n
-   *
-   * Note: messages with default null values included here for visibility.
-   * Overriding with truthy content will cause the expandable help
-   * message to appear in trip details.
-   */
-  messages: PropTypes.shape({
-    caloriesBurned: PropTypes.string,
-    caloriesBurnedDescription: PropTypes.element,
-    depart: PropTypes.element,
-    departDescription: PropTypes.element,
-    title: PropTypes.string,
-    tncFare: PropTypes.element,
-    transitFare: PropTypes.element,
-    transitFareDescription: PropTypes.element
-  }),
+  title: PropTypes.string,
   /** Contains the preferred format string for time display and a timezone offset */
-  timeOptions: coreUtils.types.timeOptionsType
+  timeOptions: coreUtils.types.timeOptionsType,
+  TransitFare: PropTypes.elementType,
+  TNCFare: PropTypes.elementType
 };
 
 TripDetails.defaultProps = {
+  Calories: DefaultCalories,
+  CaloriesDetails: DefaultCaloriesDetails,
   className: null,
+  Departure: DefaultDeparture,
+  DepartureDetails: null,
+  FareDetails: null,
   longDateFormat: null,
-  messages: {
-    caloriesBurned: "Calories Burned",
-    // FIXME: Add templated string description.
-    caloriesBurnedDescription: null,
-    depart: null,
-    departDescription: null,
-    title: "Trip Details",
-    tncFare: null,
-    transitFare: null,
-    transitFareDescription: null
-  },
-  timeOptions: null
+  title: "Trip Details",
+  timeOptions: null,
+  TransitFare: DefaultTransitFare,
+  TNCFare: DefaultTNCFare
 };


### PR DESCRIPTION
This PR changes props in the `TripDetails` component so that implementers can pass localized messages to component for display. Localized messages are JSX content that can be built using any localization library.

BREAKING CHANGE: in the `messages` prop, `at` and `fare` are removed, `depart` has a different meaning,
`fare` is changed to `tncFare`. Implementers need to build the entire text and include any applicable dates, numbers, etc. Also, most messages now accept JSX content, so formatting markup such as `<strong>` etc. can be passed.