### PR TITLE
Export all styled.js files as Styled

### DIFF
--- a/packages/base-map/src/index.js
+++ b/packages/base-map/src/index.js
@@ -4,7 +4,7 @@ import { LayersControl, Map, Popup, TileLayer } from "react-leaflet";
 import utils from "@opentripplanner/core-utils";
 import L from "leaflet";
 
-import * as styled from "./styled";
+import * as Styled from "./styled";
 import callIfValid from "./util";
 
 /**
@@ -421,4 +421,4 @@ BaseMap.defaultProps = {
 
 export default BaseMap;
 
-export { styled };
+export { Styled };

--- a/packages/endpoints-overlay/src/index.js
+++ b/packages/endpoints-overlay/src/index.js
@@ -3,13 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import Endpoint from "./endpoint";
-import {
-  StackedCircle,
-  StackedIconContainer,
-  StackedLocationIcon,
-  StackedToIcon,
-  ToIcon
-} from "./styled";
+import * as S from "./styled";
 
 function DefaultMapMarkerIcon({ location, type }) {
   let inner;
@@ -17,8 +11,8 @@ function DefaultMapMarkerIcon({ location, type }) {
     case "to":
       inner = (
         <>
-          <StackedToIcon size={24} type={type} />
-          <ToIcon size={20} type={type} />
+          <S.StackedToIcon size={24} type={type} />
+          <S.ToIcon size={20} type={type} />
         </>
       );
       break;
@@ -26,14 +20,16 @@ function DefaultMapMarkerIcon({ location, type }) {
       // Default to the location icon on top of a white background.
       inner = (
         <>
-          <StackedCircle size={24} />
-          <StackedLocationIcon size={24} type={type} />
+          <S.StackedCircle size={24} />
+          <S.StackedLocationIcon size={24} type={type} />
         </>
       );
       break;
   }
   return (
-    <StackedIconContainer title={location.name}>{inner}</StackedIconContainer>
+    <S.StackedIconContainer title={location.name}>
+      {inner}
+    </S.StackedIconContainer>
   );
 }
 
@@ -178,3 +174,7 @@ EndpointsOverlay.defaultProps = {
 };
 
 export default EndpointsOverlay;
+
+// Rename styled components for export
+const Styled = S;
+export { Styled };

--- a/packages/from-to-location-picker/src/index.js
+++ b/packages/from-to-location-picker/src/index.js
@@ -3,7 +3,7 @@ import LocationIcon from "@opentripplanner/location-icon";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 
-import { LocationPickerSpan, Button, FromToPickerSpan } from "./styled";
+import * as S from "./styled";
 
 const iconSize = "0.9em";
 
@@ -37,16 +37,16 @@ class FromToLocationPicker extends Component {
   render() {
     const { fromText, showIcons, toText } = this.props;
     return (
-      <FromToPickerSpan>
-        <LocationPickerSpan>
+      <S.FromToPickerSpan>
+        <S.LocationPickerSpan>
           {showIcons && <LocationIcon type="from" size={iconSize} />}
-          <Button onClick={this.onFromClick}>{fromText}</Button>
-        </LocationPickerSpan>
-        <LocationPickerSpan>
+          <S.Button onClick={this.onFromClick}>{fromText}</S.Button>
+        </S.LocationPickerSpan>
+        <S.LocationPickerSpan>
           {showIcons && <LocationIcon type="to" size={iconSize} />}
-          <Button onClick={this.onToClick}>{toText}</Button>
-        </LocationPickerSpan>
-      </FromToPickerSpan>
+          <S.Button onClick={this.onToClick}>{toText}</S.Button>
+        </S.LocationPickerSpan>
+      </S.FromToPickerSpan>
     );
   }
 }
@@ -98,3 +98,7 @@ FromToLocationPicker.defaultProps = {
 };
 
 export default FromToLocationPicker;
+
+// Rename styled components for export
+const Styled = S;
+export { Styled };

--- a/packages/itinerary-body/src/index.js
+++ b/packages/itinerary-body/src/index.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import PlaceRow from "./place-row";
-import * as Styled from "./styled";
+import * as S from "./styled";
 
 const ItineraryBody = ({
   LegIcon,
@@ -94,9 +94,7 @@ const ItineraryBody = ({
     if (leg.transitLeg) followsTransit = true;
     lastLeg = leg;
   });
-  return (
-    <Styled.ItineraryBody className={className}>{rows}</Styled.ItineraryBody>
-  );
+  return <S.ItineraryBody className={className}>{rows}</S.ItineraryBody>;
 };
 
 ItineraryBody.propTypes = {
@@ -239,3 +237,7 @@ ItineraryBody.defaultProps = {
 };
 
 export default ItineraryBody;
+
+// Rename styled components for export
+const Styled = S;
+export { Styled };

--- a/packages/itinerary-body/src/place-row.js
+++ b/packages/itinerary-body/src/place-row.js
@@ -4,7 +4,7 @@ import React from "react";
 
 import DefaultTimeColumnContent from "./defaults/time-column-content";
 import AccessLegBody from "./AccessLegBody";
-import * as Styled from "./styled";
+import * as S from "./styled";
 import TransitLegBody from "./TransitLegBody";
 
 /*
@@ -53,16 +53,16 @@ const PlaceRow = ({
 
   const { longDateFormat, timeFormat } = config.dateTime;
   return (
-    <Styled.PlaceRowWrapper key={legIndex || "destination-place"}>
-      <Styled.TimeColumn>
+    <S.PlaceRowWrapper key={legIndex || "destination-place"}>
+      <S.TimeColumn>
         {/* Custom rendering of the departure/arrival time of the specified leg. */}
         <TimeColumnContent
           isDestination={isDestination}
           leg={leg}
           timeOptions={timeOptions}
         />
-      </Styled.TimeColumn>
-      <Styled.LineColumn>
+      </S.TimeColumn>
+      <S.LineColumn>
         <LineColumnContent
           interline={interline}
           isDestination={isDestination}
@@ -72,20 +72,20 @@ const PlaceRow = ({
           legIndex={legIndex}
           toRouteAbbreviation={toRouteAbbreviation}
         />
-      </Styled.LineColumn>
-      <Styled.DetailsColumn hideBorder={hideBorder.toString()}>
-        <Styled.PlaceDetails>
+      </S.LineColumn>
+      <S.DetailsColumn hideBorder={hideBorder.toString()}>
+        <S.PlaceDetails>
           {/* Dot separating interlined segments, if applicable */}
-          <Styled.PlaceHeader>
+          <S.PlaceHeader>
             {/*
               TODO: Need to rework this -- Need to display a marker
               for an interline place
             */}
-            {interline && <Styled.InterlineDot>&bull;</Styled.InterlineDot>}
-            <Styled.PlaceName>
+            {interline && <S.InterlineDot>&bull;</S.InterlineDot>}
+            <S.PlaceName>
               <PlaceName config={config} interline={interline} place={place} />
-            </Styled.PlaceName>
-          </Styled.PlaceHeader>
+            </S.PlaceName>
+          </S.PlaceHeader>
 
           {/* Show the leg, if not rendering the destination */}
           {!isDestination &&
@@ -129,19 +129,19 @@ const PlaceRow = ({
                 timeOptions={timeOptions}
               />
             ))}
-        </Styled.PlaceDetails>
-      </Styled.DetailsColumn>
+        </S.PlaceDetails>
+      </S.DetailsColumn>
       {showMapButtonColumn && (
-        <Styled.MapButtonColumn hideBorder={hideBorder.toString()}>
-          <Styled.MapButton
+        <S.MapButtonColumn hideBorder={hideBorder.toString()}>
+          <S.MapButton
             onClick={() => frameLeg({ isDestination, leg, legIndex, place })}
             title={messages.mapIconTitle}
           >
-            <Styled.MapIcon />
-          </Styled.MapButton>
-        </Styled.MapButtonColumn>
+            <S.MapIcon />
+          </S.MapButton>
+        </S.MapButtonColumn>
       )}
-    </Styled.PlaceRowWrapper>
+    </S.PlaceRowWrapper>
   );
 };
 

--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -20,7 +20,7 @@ import {
   TransitStopOption,
   UserLocationIcon
 } from "./options";
-import * as Styled from "./styled";
+import * as S from "./styled";
 
 // FIXME have a better key generator for options
 let optionKey = 0;
@@ -395,9 +395,9 @@ class LocationField extends Component {
     if (nearbyStops.length > 0 && !suppressNearby) {
       // Add the menu sub-heading (not a selectable item)
       menuItems.push(
-        <Styled.MenuItem header key="ns-header">
+        <S.MenuItem header key="ns-header">
           Nearby Stops
-        </Styled.MenuItem>
+        </S.MenuItem>
       );
 
       // Iterate through the found nearby stops
@@ -440,9 +440,9 @@ class LocationField extends Component {
     if (sessionSearches.length > 0) {
       // Add the menu sub-heading (not a selectable item)
       menuItems.push(
-        <Styled.MenuItem header key="ss-header">
+        <S.MenuItem header key="ss-header">
           Recently Searched
-        </Styled.MenuItem>
+        </S.MenuItem>
       );
 
       // Iterate through any saved locations
@@ -476,9 +476,9 @@ class LocationField extends Component {
     if (userLocationsAndRecentPlaces.length > 0 && showUserSettings) {
       // Add the menu sub-heading (not a selectable item)
       menuItems.push(
-        <Styled.MenuItem header key="mp-header">
+        <S.MenuItem header key="mp-header">
           My Places
-        </Styled.MenuItem>
+        </S.MenuItem>
       );
 
       // Iterate through any saved locations
@@ -569,7 +569,7 @@ class LocationField extends Component {
         ? "Fetching location..."
         : defaultPlaceholder;
     const textControl = (
-      <Styled.Input
+      <S.Input
         ref={ref => {
           this.inputRef = ref;
         }}
@@ -588,58 +588,58 @@ class LocationField extends Component {
     // or if the input field has text.
     const clearButton =
       showClearButton && location ? (
-        <Styled.InputGroupAddon>
-          <Styled.Button
+        <S.InputGroupAddon>
+          <S.Button
             aria-label="Clear location"
             onClick={this.onClearButtonClick}
           >
             <Times size={13} />
-          </Styled.Button>
-        </Styled.InputGroupAddon>
+          </S.Button>
+        </S.InputGroupAddon>
       ) : null;
     if (isStatic) {
       // 'static' mode (menu is displayed alongside input, e.g., for mobile view)
       return (
         <div className={className}>
-          <Styled.FormGroup>
-            <Styled.InputGroup>
-              <Styled.InputGroupAddon>
+          <S.FormGroup>
+            <S.InputGroup>
+              <S.InputGroupAddon>
                 <LocationIconComponent locationType={locationType} />
-              </Styled.InputGroupAddon>
+              </S.InputGroupAddon>
               {textControl}
               {clearButton}
-            </Styled.InputGroup>
-          </Styled.FormGroup>
-          <Styled.StaticMenuItemList>
+            </S.InputGroup>
+          </S.FormGroup>
+          <S.StaticMenuItemList>
             {menuItems.length > 0 ? ( // Show typing prompt to avoid empty screen
               menuItems
             ) : (
-              <Styled.MenuItem header centeredText>
+              <S.MenuItem header centeredText>
                 Begin typing to search for locations
-              </Styled.MenuItem>
+              </S.MenuItem>
             )}
-          </Styled.StaticMenuItemList>
+          </S.StaticMenuItemList>
         </div>
       );
     }
 
     // default display mode with dropdown menu
     return (
-      <Styled.FormGroup onBlur={this.onBlurFormGroup} className={className}>
-        <Styled.InputGroup>
+      <S.FormGroup onBlur={this.onBlurFormGroup} className={className}>
+        <S.InputGroup>
           {/* location field icon -- also serves as dropdown anchor */}
-          <Styled.Dropdown
+          <S.Dropdown
             locationType={locationType}
             open={menuVisible}
             onToggle={this.onDropdownToggle}
             title={<LocationIconComponent locationType={locationType} />}
           >
             {menuItems}
-          </Styled.Dropdown>
+          </S.Dropdown>
           {textControl}
           {clearButton}
-        </Styled.InputGroup>
-      </Styled.FormGroup>
+        </S.InputGroup>
+      </S.FormGroup>
     );
   }
 }
@@ -888,3 +888,7 @@ LocationField.defaultProps = {
 };
 
 export default LocationField;
+
+// Rename styled components for export
+const Styled = S;
+export { Styled };

--- a/packages/location-field/src/options.js
+++ b/packages/location-field/src/options.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import { Briefcase, Home, MapMarker, MapPin } from "styled-icons/fa-solid";
 
-import * as Styled from "./styled";
+import * as S from "./styled";
 
 export function GeocodedOptionIcon() {
   return <MapPin size={13} />;
@@ -12,7 +12,7 @@ export function GeocodedOptionIcon() {
 
 export function Option({ disabled, icon, isActive, onClick, title }) {
   return (
-    <Styled.MenuItem onClick={onClick} active={isActive} disabled={disabled}>
+    <S.MenuItem onClick={onClick} active={isActive} disabled={disabled}>
       {coreUtils.ui.isIE() ? (
         // In internet explorer 11, some really weird stuff is happening where it
         // is not possible to click the text of the title, but if you click just
@@ -21,12 +21,12 @@ export function Option({ disabled, icon, isActive, onClick, title }) {
         // See https://github.com/ibi-group/trimet-mod-otp/issues/237
         title
       ) : (
-        <Styled.OptionContainer>
-          <Styled.OptionIconContainer>{icon}</Styled.OptionIconContainer>
-          <Styled.OptionContent>{title}</Styled.OptionContent>
-        </Styled.OptionContainer>
+        <S.OptionContainer>
+          <S.OptionIconContainer>{icon}</S.OptionIconContainer>
+          <S.OptionContent>{title}</S.OptionContent>
+        </S.OptionContainer>
       )}
-    </Styled.MenuItem>
+    </S.MenuItem>
   );
 }
 
@@ -47,28 +47,26 @@ Option.defaultProps = {
 
 export function TransitStopOption({ isActive, onClick, stop, stopOptionIcon }) {
   return (
-    <Styled.MenuItem onClick={onClick} active={isActive}>
-      <Styled.StopIconAndDistanceContainer>
+    <S.MenuItem onClick={onClick} active={isActive}>
+      <S.StopIconAndDistanceContainer>
         {stopOptionIcon}
-        <Styled.StopDistance>
+        <S.StopDistance>
           {humanizeDistanceStringImperial(stop.dist, true)}
-        </Styled.StopDistance>
-      </Styled.StopIconAndDistanceContainer>
-      <Styled.StopContentContainer>
-        <Styled.StopName>
+        </S.StopDistance>
+      </S.StopIconAndDistanceContainer>
+      <S.StopContentContainer>
+        <S.StopName>
           {stop.name} ({stop.code})
-        </Styled.StopName>
-        <Styled.StopRoutes>
+        </S.StopName>
+        <S.StopRoutes>
           {(stop.routes || []).map(route => {
             const name = route.shortName || route.longName;
-            return (
-              <Styled.RouteName key={`route-${name}`}>{name}</Styled.RouteName>
-            );
+            return <S.RouteName key={`route-${name}`}>{name}</S.RouteName>;
           })}
-        </Styled.StopRoutes>
-      </Styled.StopContentContainer>
-      <Styled.ClearBoth />
-    </Styled.MenuItem>
+        </S.StopRoutes>
+      </S.StopContentContainer>
+      <S.ClearBoth />
+    </S.MenuItem>
   );
 }
 

--- a/packages/location-icon/src/index.tsx
+++ b/packages/location-icon/src/index.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from "react";
 
-import * as Styled from "./styled";
+import * as S from "./styled";
 
 type Props = {
   className?: string;
@@ -34,7 +34,7 @@ export function LocationIcon({
   switch (type) {
     case "from":
       return (
-        <Styled.FromIcon
+        <S.FromIcon
           className={className}
           size={size}
           title={title || "From Location Icon"}
@@ -42,7 +42,7 @@ export function LocationIcon({
       );
     case "to":
       return (
-        <Styled.ToIcon
+        <S.ToIcon
           className={className}
           size={size}
           title={title || "To Location Icon"}
@@ -50,7 +50,7 @@ export function LocationIcon({
       );
     default:
       return (
-        <Styled.PlaceIcon
+        <S.PlaceIcon
           className={className}
           size={size}
           title={title || "Location Icon"}
@@ -60,3 +60,7 @@ export function LocationIcon({
 }
 
 export default LocationIcon;
+
+// Rename styled components for export
+const Styled = S;
+export { Styled };

--- a/packages/printable-itinerary/src/access-leg.js
+++ b/packages/printable-itinerary/src/access-leg.js
@@ -3,37 +3,37 @@ import { humanizeDistanceString } from "@opentripplanner/humanize-distance";
 import PropTypes from "prop-types";
 import React from "react";
 
-import * as Styled from "./styled";
+import * as S from "./styled";
 
 export default function AccessLeg({ config, leg, LegIcon }) {
   return (
-    <Styled.Leg>
-      <Styled.ModeIcon>
+    <S.Leg>
+      <S.ModeIcon>
         <LegIcon leg={leg} />
-      </Styled.ModeIcon>
-      <Styled.LegBody>
-        <Styled.LegHeader>
+      </S.ModeIcon>
+      <S.LegBody>
+        <S.LegHeader>
           <b>{coreUtils.itinerary.getLegModeLabel(leg)}</b>{" "}
           {leg.distance > 0 && (
             <span> {humanizeDistanceString(leg.distance)}</span>
           )}
           {" to "}
           <b>{coreUtils.itinerary.getPlaceName(leg.to, config.companies)}</b>
-        </Styled.LegHeader>
+        </S.LegHeader>
         {!leg.hailedCar && (
-          <Styled.LegDetails>
+          <S.LegDetails>
             {leg.steps.map((step, k) => {
               return (
-                <Styled.LegDetail key={k}>
+                <S.LegDetail key={k}>
                   {coreUtils.itinerary.getStepDirection(step)} on{" "}
                   <b>{coreUtils.itinerary.getStepStreetName(step)}</b>
-                </Styled.LegDetail>
+                </S.LegDetail>
               );
             })}
-          </Styled.LegDetails>
+          </S.LegDetails>
         )}
-      </Styled.LegBody>
-    </Styled.Leg>
+      </S.LegBody>
+    </S.Leg>
   );
 }
 

--- a/packages/printable-itinerary/src/index.js
+++ b/packages/printable-itinerary/src/index.js
@@ -3,11 +3,11 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import AccessLeg from "./access-leg";
-import * as Styled from "./styled";
+import * as S from "./styled";
 import TNCLeg from "./tnc-leg";
 import TransitLeg from "./transit-leg";
 
-export default function PrintableItinerary({
+function PrintableItinerary({
   className,
   config,
   itinerary,
@@ -15,15 +15,15 @@ export default function PrintableItinerary({
   timeOptions
 }) {
   return (
-    <Styled.PrintableItinerary className={className}>
+    <S.PrintableItinerary className={className}>
       {itinerary.legs.length > 0 && (
-        <Styled.CollapsedTop>
-          <Styled.LegBody>
-            <Styled.LegHeader>
+        <S.CollapsedTop>
+          <S.LegBody>
+            <S.LegHeader>
               <b>Depart</b> from <b>{itinerary.legs[0].from.name}</b>
-            </Styled.LegHeader>
-          </Styled.LegBody>
-        </Styled.CollapsedTop>
+            </S.LegHeader>
+          </S.LegBody>
+        </S.CollapsedTop>
       )}
       {itinerary.legs.map((leg, k) =>
         leg.transitLeg ? (
@@ -54,7 +54,7 @@ export default function PrintableItinerary({
           />
         )
       )}
-    </Styled.PrintableItinerary>
+    </S.PrintableItinerary>
   );
 }
 
@@ -75,3 +75,9 @@ PrintableItinerary.defaultProps = {
   className: null,
   timeOptions: null
 };
+
+export default PrintableItinerary;
+
+// Rename styled components for export
+const Styled = S;
+export { Styled };

--- a/packages/printable-itinerary/src/tnc-leg.js
+++ b/packages/printable-itinerary/src/tnc-leg.js
@@ -2,34 +2,34 @@ import coreUtils from "@opentripplanner/core-utils";
 import PropTypes from "prop-types";
 import React from "react";
 
-import * as Styled from "./styled";
+import * as S from "./styled";
 
 export default function TNCLeg({ leg, LegIcon }) {
   const { tncData } = leg;
   if (!tncData) return null;
 
   return (
-    <Styled.Leg>
-      <Styled.ModeIcon>
+    <S.Leg>
+      <S.ModeIcon>
         <LegIcon leg={leg} />
-      </Styled.ModeIcon>
-      <Styled.LegBody>
-        <Styled.LegHeader>
+      </S.ModeIcon>
+      <S.LegBody>
+        <S.LegHeader>
           <b>Take {tncData.displayName}</b> to <b>{leg.to.name}</b>
-        </Styled.LegHeader>
-        <Styled.LegDetails>
-          <Styled.LegDetail>
+        </S.LegHeader>
+        <S.LegDetails>
+          <S.LegDetail>
             Estimated wait time for pickup:{" "}
             <b>{coreUtils.time.formatDuration(tncData.estimatedArrival)}</b>
-          </Styled.LegDetail>
-          <Styled.LegDetail>
+          </S.LegDetail>
+          <S.LegDetail>
             Estimated travel time:{" "}
             <b>{coreUtils.time.formatDuration(leg.duration)}</b> (does not
             account for traffic)
-          </Styled.LegDetail>
-        </Styled.LegDetails>
-      </Styled.LegBody>
-    </Styled.Leg>
+          </S.LegDetail>
+        </S.LegDetails>
+      </S.LegBody>
+    </S.Leg>
   );
 }
 

--- a/packages/printable-itinerary/src/transit-leg.js
+++ b/packages/printable-itinerary/src/transit-leg.js
@@ -2,7 +2,7 @@ import coreUtils from "@opentripplanner/core-utils";
 import PropTypes from "prop-types";
 import React from "react";
 
-import * as Styled from "./styled";
+import * as S from "./styled";
 
 export default function TransitLeg({
   leg,
@@ -13,44 +13,44 @@ export default function TransitLeg({
   // Handle case of transit leg interlined w/ previous
   if (leg.interlineWithPreviousLeg) {
     return (
-      <Styled.CollapsedTop>
-        <Styled.LegBody>
-          <Styled.LegHeader>
+      <S.CollapsedTop>
+        <S.LegBody>
+          <S.LegHeader>
             Continues as{" "}
             <b>
               {leg.routeShortName} {leg.routeLongName}
             </b>{" "}
             to <b>{leg.to.name}</b>
-          </Styled.LegHeader>
-          <Styled.LegDetails>
-            <Styled.LegDetail>
+          </S.LegHeader>
+          <S.LegDetails>
+            <S.LegDetail>
               Get off at <b>{leg.to.name}</b> at{" "}
               {coreUtils.time.formatTime(leg.endTime, timeOptions)}
-            </Styled.LegDetail>
-          </Styled.LegDetails>
-        </Styled.LegBody>
-      </Styled.CollapsedTop>
+            </S.LegDetail>
+          </S.LegDetails>
+        </S.LegBody>
+      </S.CollapsedTop>
     );
   }
 
   return (
-    <Styled.Leg>
-      <Styled.ModeIcon>
+    <S.Leg>
+      <S.ModeIcon>
         <LegIcon leg={leg} />
-      </Styled.ModeIcon>
-      <Styled.LegBody>
-        <Styled.LegHeader>
+      </S.ModeIcon>
+      <S.LegBody>
+        <S.LegHeader>
           <b>
             {leg.routeShortName} {leg.routeLongName}
           </b>{" "}
           to <b>{leg.to.name}</b>
-        </Styled.LegHeader>
-        <Styled.LegDetails>
-          <Styled.LegDetail>
+        </S.LegHeader>
+        <S.LegDetails>
+          <S.LegDetail>
             Board at <b>{leg.from.name}</b> at{" "}
             {coreUtils.time.formatTime(leg.startTime, timeOptions)}
-          </Styled.LegDetail>
-          <Styled.LegDetail>
+          </S.LegDetail>
+          <S.LegDetail>
             {interlineFollows ? (
               <span>
                 Stay on board at <b>{leg.to.name}</b>
@@ -61,10 +61,10 @@ export default function TransitLeg({
                 {coreUtils.time.formatTime(leg.endTime, timeOptions)}
               </span>
             )}
-          </Styled.LegDetail>
-        </Styled.LegDetails>
-      </Styled.LegBody>
-    </Styled.Leg>
+          </S.LegDetail>
+        </S.LegDetails>
+      </S.LegBody>
+    </S.Leg>
   );
 }
 

--- a/packages/stops-overlay/src/default-stop-marker.js
+++ b/packages/stops-overlay/src/default-stop-marker.js
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { CircleMarker, Popup } from "react-leaflet";
 
-import * as Styled from "./styled";
+import * as S from "./styled";
 
 const {
   languageConfigType,
@@ -52,9 +52,9 @@ export default class StopMarker extends Component {
               <span>
                 <b>Stop ID:</b> {idArr[1]}
               </span>
-              <Styled.ViewStopButton onClick={this.onClickView}>
+              <S.ViewStopButton onClick={this.onClickView}>
                 {languageConfig.stopViewer || "Stop Viewer"}
-              </Styled.ViewStopButton>
+              </S.ViewStopButton>
             </BaseMapStyled.PopupRow>
 
             {/* The "Set as [from/to]" ButtonGroup */}

--- a/packages/transit-vehicle-overlay/src/components/markers/ModeCircles/index.js
+++ b/packages/transit-vehicle-overlay/src/components/markers/ModeCircles/index.js
@@ -25,3 +25,7 @@ export const CircledVehicle = utils.makeRotatedMarker(
     );
   }
 );
+
+// Rename styled components for export
+const Styled = StyledCircle;
+export { Styled };

--- a/packages/transit-vehicle-overlay/src/components/markers/ModeRectangles/index.js
+++ b/packages/transit-vehicle-overlay/src/components/markers/ModeRectangles/index.js
@@ -46,3 +46,7 @@ export const DetailedRectangle = utils.makeRotatedMarker(
   },
   getRectangleSize
 );
+
+// Rename styled components for export
+const Styled = StyledRectangle;
+export { Styled };

--- a/packages/transit-vehicle-overlay/src/components/popups/vehicle-tracker.js
+++ b/packages/transit-vehicle-overlay/src/components/popups/vehicle-tracker.js
@@ -2,7 +2,7 @@ import coreUtils from "@opentripplanner/core-utils";
 import React from "react";
 import PropTypes from "prop-types";
 
-import { PopupStyle } from "./styled";
+import * as S from "./styled";
 
 /**
  * presentational component for tracking button on marker popup
@@ -17,9 +17,9 @@ export default function VehicleTracker(props) {
   };
 
   return (
-    <PopupStyle.Button onClick={handleClick} className={cls}>
+    <S.Button onClick={handleClick} className={cls}>
       {text}
-    </PopupStyle.Button>
+    </S.Button>
   );
 }
 
@@ -38,3 +38,7 @@ VehicleTracker.defaultProps = {
   vehicle: null,
   isTracked: false
 };
+
+// Rename styled components for export
+const Styled = S;
+export { Styled };

--- a/packages/trip-details/src/index.js
+++ b/packages/trip-details/src/index.js
@@ -4,10 +4,10 @@ import PropTypes from "prop-types";
 import React from "react";
 import { CalendarAlt, Heartbeat, MoneyBillAlt } from "styled-icons/fa-solid";
 
-import * as Styled from "./styled";
+import * as S from "./styled";
 import TripDetail from "./trip-detail";
 
-export default function TripDetails({
+function TripDetails({
   className,
   itinerary,
   longDateFormat,
@@ -38,25 +38,25 @@ export default function TripDetails({
   let fare;
   if (transitFare || minTNCFare) {
     fare = (
-      <Styled.Fare>
+      <S.Fare>
         {transitFare && (
-          <Styled.TransitFare>
+          <S.TransitFare>
             {messages.transitFare}: <b>{centsToString(transitFare)}</b>
-          </Styled.TransitFare>
+          </S.TransitFare>
         )}
         {minTNCFare !== 0 && (
-          <Styled.TNCFare>
+          <S.TNCFare>
             <br />
-            <Styled.TNCFareCompanies>
+            <S.TNCFareCompanies>
               {companies.toLowerCase()}
-            </Styled.TNCFareCompanies>{" "}
+            </S.TNCFareCompanies>{" "}
             {messages.fare}:{" "}
             <b>
               {dollarsToString(minTNCFare)} - {dollarsToString(maxTNCFare)}
             </b>
-          </Styled.TNCFare>
+          </S.TNCFare>
         )}
-      </Styled.Fare>
+      </S.Fare>
     );
   }
 
@@ -68,14 +68,14 @@ export default function TripDetails({
   } = coreUtils.itinerary.calculatePhysicalActivity(itinerary);
 
   return (
-    <Styled.TripDetails className={className}>
-      <Styled.TripDetailsHeader>{messages.title}</Styled.TripDetailsHeader>
-      <Styled.TripDetailsBody>
+    <S.TripDetails className={className}>
+      <S.TripDetailsHeader>{messages.title}</S.TripDetailsHeader>
+      <S.TripDetailsBody>
         <TripDetail
           description={messages.departDescription}
           icon={<CalendarAlt size={17} />}
           summary={
-            <Styled.Timing>
+            <S.Timing>
               <span>
                 {messages.depart} <b>{date.format(longDateFormat)}</b>
               </span>
@@ -91,7 +91,7 @@ export default function TripDetails({
                   </b>
                 </span>
               )}
-            </Styled.Timing>
+            </S.Timing>
           }
         />
         {fare && (
@@ -105,12 +105,12 @@ export default function TripDetails({
           <TripDetail
             icon={<Heartbeat size={17} />}
             summary={
-              <Styled.CaloriesSummary>
+              <S.CaloriesSummary>
                 {messages.caloriesBurned}: <b>{Math.round(caloriesBurned)}</b>
-              </Styled.CaloriesSummary>
+              </S.CaloriesSummary>
             }
             description={
-              <Styled.CaloriesDescription>
+              <S.CaloriesDescription>
                 Calories burned is based on{" "}
                 <b>{Math.round(walkDuration / 60)} minute(s)</b> spent walking
                 and <b>{Math.round(bikeDuration / 60)} minute(s)</b> spent
@@ -123,12 +123,12 @@ export default function TripDetails({
                   Dietary Guidelines for Americans 2005, page 16, Table 4
                 </a>
                 .
-              </Styled.CaloriesDescription>
+              </S.CaloriesDescription>
             }
           />
         )}
-      </Styled.TripDetailsBody>
-    </Styled.TripDetails>
+      </S.TripDetailsBody>
+    </S.TripDetails>
   );
 }
 
@@ -182,3 +182,9 @@ TripDetails.defaultProps = {
   routingType: "ITINERARY",
   timeOptions: null
 };
+
+export default TripDetails;
+
+// Rename styled components for export
+const Styled = S;
+export { Styled };

--- a/packages/trip-details/src/trip-detail.js
+++ b/packages/trip-details/src/trip-detail.js
@@ -3,7 +3,7 @@ import React, { Component } from "react";
 import { QuestionCircle, TimesCircle } from "styled-icons/fa-solid";
 import { VelocityTransitionGroup } from "velocity-react";
 
-import * as Styled from "./styled";
+import * as S from "./styled";
 
 export default class TripDetail extends Component {
   constructor(props) {
@@ -31,30 +31,30 @@ export default class TripDetail extends Component {
     const { icon, summary, description } = this.props;
     const { expanded } = this.state;
     return (
-      <Styled.TripDetail>
-        <Styled.TripDetailIcon>{icon}</Styled.TripDetailIcon>
-        <Styled.TripDetailSummary>
+      <S.TripDetail>
+        <S.TripDetailIcon>{icon}</S.TripDetailIcon>
+        <S.TripDetailSummary>
           {summary}
           {description && (
-            <Styled.ExpandButton onClick={this.toggle}>
+            <S.ExpandButton onClick={this.toggle}>
               <QuestionCircle size="0.92em" />
-            </Styled.ExpandButton>
+            </S.ExpandButton>
           )}
           <VelocityTransitionGroup
             enter={{ animation: "slideDown" }}
             leave={{ animation: "slideUp" }}
           >
             {expanded && (
-              <Styled.TripDetailDescription>
-                <Styled.HideButton onClick={this.onHideClick}>
+              <S.TripDetailDescription>
+                <S.HideButton onClick={this.onHideClick}>
                   <TimesCircle size="0.92em" />
-                </Styled.HideButton>
+                </S.HideButton>
                 {description}
-              </Styled.TripDetailDescription>
+              </S.TripDetailDescription>
             )}
           </VelocityTransitionGroup>
-        </Styled.TripDetailSummary>
-      </Styled.TripDetail>
+        </S.TripDetailSummary>
+      </S.TripDetail>
     );
   }
 }

--- a/packages/vehicle-rental-overlay/src/bike-icons.js
+++ b/packages/vehicle-rental-overlay/src/bike-icons.js
@@ -2,17 +2,17 @@ import { divIcon } from "leaflet";
 import React from "react";
 import ReactDOMServer from "react-dom/server";
 
-import * as Styled from "./styled";
+import * as S from "./styled";
 
 export const floatingBikeIcon = divIcon({
   iconSize: [24, 24],
   iconAnchor: [12, 24],
   popupAnchor: [0, -12],
-  html: ReactDOMServer.renderToStaticMarkup(<Styled.OutOfHubBikeIcon />),
+  html: ReactDOMServer.renderToStaticMarkup(<S.OutOfHubBikeIcon />),
   className: ""
 });
 
-export const hubIcons = Styled.hubIcons.map(StyledIcon =>
+export const hubIcons = S.hubIcons.map(StyledIcon =>
   divIcon({
     iconSize: [24, 24],
     iconAnchor: [12, 24],


### PR DESCRIPTION
This should help out quite a bit with the rest of #65. I'll wait for @grant-humphries to chime in with the rest of the lib imports they're doing in the new trimet.org site, so we can append those changes to this PR as well.

BREAKING CHANGE: For `base-map` package this commit changes the name of the 'styled' export to 'Styled' to match the preferred naming convention across otp-ui packages.