### PR TITLE
Make calculateFares also return currency code

### DIFF
--- a/packages/core-utils/src/__tests__/itinerary.js
+++ b/packages/core-utils/src/__tests__/itinerary.js
@@ -1,4 +1,9 @@
-import { getCompanyFromLeg, getTransitFare, isTransit } from "../itinerary";
+import {
+  calculateFares,
+  getCompanyFromLeg,
+  getTransitFare,
+  isTransit
+} from "../itinerary";
 
 const bikeRentalItinerary = require("./__mocks__/bike-rental-itinerary.json");
 const tncItinerary = require("./__mocks__/tnc-itinerary.json");
@@ -42,15 +47,24 @@ describe("util > itinerary", () => {
       },
       cents: 575
     };
-    const { centsToString, dollarsToString, transitFare } = getTransitFare(
-      fareComponent
-    );
+    const {
+      centsToString,
+      currencyCode,
+      dollarsToString,
+      transitFare
+    } = getTransitFare(fareComponent);
     // Make sure cents to string and dollars to string return same result
     expect(dollarsToString(transitFare / 100)).toEqual(
       centsToString(transitFare)
     );
+    expect(currencyCode).toEqual(fareComponent.currency.currencyCode);
     // Snapshot tests
     expect(centsToString(transitFare)).toMatchSnapshot();
     expect(transitFare).toMatchSnapshot();
+  });
+
+  it("calculateFare should return the correct currency code for TNC leg", () => {
+    const fareResult = calculateFares(tncItinerary);
+    expect(fareResult.currencyCode).toEqual("USD");
   });
 });

--- a/packages/core-utils/src/itinerary.js
+++ b/packages/core-utils/src/itinerary.js
@@ -493,6 +493,7 @@ export function getTransitFare(fareComponent) {
 /**
  * For an itinerary, calculates the transit/TNC fares and returns an object with
  * these values, currency info, as well as string formatters.
+ * It is assumed that the same currency is used for transit and TNC legs.
  */
 export function calculateFares(itinerary) {
   // Extract fare total from itinerary fares.
@@ -521,7 +522,6 @@ export function calculateFares(itinerary) {
 
   return {
     centsToString,
-    // Hopefully, the currency code is consistent throughout.
     currencyCode: transitCurrencyCode || tncCurrencyCode,
     dollarsToString,
     maxTNCFare,

--- a/packages/core-utils/src/itinerary.js
+++ b/packages/core-utils/src/itinerary.js
@@ -468,6 +468,7 @@ export function getTransitFare(fareComponent) {
   let symbol = "$";
   let currencyCode = "USD";
   if (fareComponent) {
+    // Assign values without declaration. See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#assignment_without_declaration
     ({
       currencyCode,
       defaultFractionDigits: digits,


### PR DESCRIPTION
Proposing to expose the currency code of OTP itineraries through method `calculateFares`, so that implementers don't have to re-write that function's code to figure out the currency used. The intended use is to remove the `currency` prop introduced in #281 from the `TripDetails` component.