### PR TITLE
Fix regressions introduced in previous releases

### DIFF
--- a/packages/geocoder/package.json
+++ b/packages/geocoder/package.json
@@ -10,7 +10,7 @@
   "private": false,
   "dependencies": {
     "@conveyal/geocoder-arcgis-geojson": "^0.0.2",
-    "@conveyal/lonlat": "^1.4.0",
+    "@conveyal/lonlat": "^1.4.1",
     "isomorphic-mapzen-search": "^1.5.1",
     "lodash.memoize": "^4.1.2"
   },

--- a/packages/geocoder/src/geocoders/abstract-geocoder.js
+++ b/packages/geocoder/src/geocoders/abstract-geocoder.js
@@ -1,4 +1,4 @@
-import lonlat from "@conveyal/lonlat";
+import { fromCoordinates } from "@conveyal/lonlat";
 
 /**
  * Create customized geocoder functions given a certain geocoding API, the
@@ -32,7 +32,7 @@ export default class Geocoder {
    * done to obtain that detailed data.
    */
   getLocationFromGeocodedFeature(feature) {
-    const location = lonlat.fromCoordinates(feature.geometry.coordinates);
+    const location = fromCoordinates(feature.geometry.coordinates);
     location.name = feature.properties.label;
     location.rawGeocodedFeature = feature;
     return Promise.resolve(location);

--- a/packages/geocoder/src/geocoders/arcgis.js
+++ b/packages/geocoder/src/geocoders/arcgis.js
@@ -1,4 +1,4 @@
-import lonlat from "@conveyal/lonlat";
+import { fromCoordinates } from "@conveyal/lonlat";
 
 import Geocoder from "./abstract-geocoder";
 
@@ -26,9 +26,7 @@ export default class ArcGISGeocoder extends Geocoder {
       .search({ magicKey: feature.magicKey, text: feature.text })
       .then(response => {
         const firstFeature = response.features[0];
-        const location = lonlat.fromCoordinates(
-          firstFeature.geometry.coordinates
-        );
+        const location = fromCoordinates(firstFeature.geometry.coordinates);
         location.name = firstFeature.properties.label;
         location.rawGeocodedFeature = firstFeature;
         return location;

--- a/packages/geocoder/src/geocoders/noapi.js
+++ b/packages/geocoder/src/geocoders/noapi.js
@@ -1,4 +1,4 @@
-import lonlat from "@conveyal/lonlat";
+import { toCoordinates, fromLatFirstString } from "@conveyal/lonlat";
 
 import Geocoder from "./abstract-geocoder";
 
@@ -46,7 +46,7 @@ export default class NoApiGeocoder extends Geocoder {
     try {
       feature = {
         geometry: {
-          coordinates: lonlat.toCoordinates(lonlat.fromLatFirstString(string)),
+          coordinates: toCoordinates(fromLatFirstString(string)),
           type: "Point"
         },
         properties: {

--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -471,7 +471,7 @@ class LocationField extends Component {
     if (nearbyStops.length > 0 && !suppressNearby) {
       // Add the menu sub-heading (not a selectable item)
       menuItems.push(
-        <S.MenuItem header key="ns-header">
+        <S.MenuItem header centeredText key="ns-header">
           Nearby Stops
         </S.MenuItem>
       );
@@ -516,7 +516,7 @@ class LocationField extends Component {
     if (sessionSearches.length > 0) {
       // Add the menu sub-heading (not a selectable item)
       menuItems.push(
-        <S.MenuItem header key="ss-header">
+        <S.MenuItem header centeredText key="ss-header">
           Recently Searched
         </S.MenuItem>
       );
@@ -552,7 +552,7 @@ class LocationField extends Component {
     if (userLocationsAndRecentPlaces.length > 0 && showUserSettings) {
       // Add the menu sub-heading (not a selectable item)
       menuItems.push(
-        <S.MenuItem header key="mp-header">
+        <S.MenuItem header centeredText key="mp-header">
           My Places
         </S.MenuItem>
       );

--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -185,7 +185,7 @@ class LocationField extends Component {
     // see https://stackoverflow.com/a/49325196/915811
     const target =
       e.relatedTarget !== null ? e.relatedTarget : document.activeElement;
-    if (!target || target.getAttribute("role") !== "menuitem") {
+    if (!target || target.getAttribute("role") !== "listitem") {
       this.setState({
         geocodedFeatures: [],
         menuVisible: false,

--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -430,7 +430,9 @@ class LocationField extends Component {
         .filter(feature => feature.properties.source !== "transit")
         .slice(0, suggestionCount);
 
-      const nonOtherFeaturesPresent =
+      // If no categories of features are returned, this variable is used to
+      // avoid displaying headers
+      const nonStandardFeaturesPresent =
         stopFeatures.length > 0 || stationFeatures.length > 0;
 
       // Iterate through the geocoder results
@@ -461,7 +463,7 @@ class LocationField extends Component {
         ),
         stopFeatures.map(feature => this.renderFeature(itemIndex++, feature)),
 
-        nonOtherFeaturesPresent && otherFeatures.length > 0 && (
+        nonStandardFeaturesPresent && otherFeatures.length > 0 && (
           <S.MenuItem bgColor="#333" header centeredText key="other-header">
             Other
           </S.MenuItem>

--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -432,7 +432,7 @@ class LocationField extends Component {
 
       // If no categories of features are returned, this variable is used to
       // avoid displaying headers
-      const nonStandardFeaturesPresent =
+      const transitFeaturesPresent =
         stopFeatures.length > 0 || stationFeatures.length > 0;
 
       // Iterate through the geocoder results
@@ -463,7 +463,7 @@ class LocationField extends Component {
         ),
         stopFeatures.map(feature => this.renderFeature(itemIndex++, feature)),
 
-        nonStandardFeaturesPresent && otherFeatures.length > 0 && (
+        transitFeaturesPresent && otherFeatures.length > 0 && (
           <S.MenuItem bgColor="#333" header centeredText key="other-header">
             Other
           </S.MenuItem>

--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -430,6 +430,9 @@ class LocationField extends Component {
         .filter(feature => feature.properties.source !== "transit")
         .slice(0, suggestionCount);
 
+      const nonOtherFeaturesPresent =
+        stopFeatures.length > 0 || stationFeatures.length > 0;
+
       // Iterate through the geocoder results
       menuItems = menuItems.concat(
         stationFeatures.length > 0 && (
@@ -458,7 +461,7 @@ class LocationField extends Component {
         ),
         stopFeatures.map(feature => this.renderFeature(itemIndex++, feature)),
 
-        otherFeatures.length > 0 && (
+        nonOtherFeaturesPresent && otherFeatures.length > 0 && (
           <S.MenuItem bgColor="#333" header centeredText key="other-header">
             Other
           </S.MenuItem>

--- a/packages/location-field/src/styled.js
+++ b/packages/location-field/src/styled.js
@@ -22,7 +22,8 @@ export const DropdownButton = styled(BaseButton)`
 `;
 
 export const DropdownContainer = styled.span`
-  position: relative;
+  position: contents;
+  width: 100%;
 `;
 
 export const MenuItemList = styled.ul`
@@ -36,7 +37,7 @@ export const MenuItemList = styled.ul`
   left: 0;
   list-style: none;
   margin: 2px 0 0;
-  max-width: 45ch;
+  max-width: 100%;
   min-width: 160px;
   padding: 5px 0;
   position: absolute;

--- a/packages/location-field/src/styled.js
+++ b/packages/location-field/src/styled.js
@@ -36,6 +36,7 @@ export const MenuItemList = styled.ul`
   left: 0;
   list-style: none;
   margin: 2px 0 0;
+  max-width: 45ch;
   min-width: 160px;
   padding: 5px 0;
   position: absolute;

--- a/packages/location-field/src/styled.js
+++ b/packages/location-field/src/styled.js
@@ -37,13 +37,13 @@ export const MenuItemList = styled.ul`
   left: 0;
   list-style: none;
   margin: 2px 0 0;
-  max-width: 100%;
   min-width: 160px;
   padding: 5px 0;
   position: absolute;
   text-align: left;
   top: 100%;
-  z-index: 1000;
+  /* this is an annoyingly high number, but is needed to be on top of some otp-rr components */
+  z-index: 1000000;
 `;
 
 export const Dropdown = ({ children, locationType, open, onToggle, title }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1266,10 +1266,15 @@
     "@conveyal/lonlat" "^1.3.0"
     geocoder-arcgis "^2.0.4"
 
-"@conveyal/lonlat@^1.1.2", "@conveyal/lonlat@^1.3.0", "@conveyal/lonlat@^1.4.0":
+"@conveyal/lonlat@^1.1.2", "@conveyal/lonlat@^1.3.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@conveyal/lonlat/-/lonlat-1.4.0.tgz#18a5c1349078a779e710d24af11bc02b24127ba0"
   integrity sha512-ag1FcRuwRGAZgeZ4e3sUq+gblf1Pgma2c9SaIVXluIrgsZ9Lrq7xhCbV0ErN8chyg/OCOoG8m/l3mgzbycQCnQ==
+
+"@conveyal/lonlat@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@conveyal/lonlat/-/lonlat-1.4.1.tgz#9970f33a2dc810ac08e89c844901405f18da478b"
+  integrity sha512-Z4W1NmvDsnkylhPMDWCk7kLaAjRtA9BVixASFxDPVkQwAiceOxaLEo4UVbZys4jNFzdtbcZ1UVPr6SQHBmEsrA==
 
 "@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
   version "10.0.29"


### PR DESCRIPTION
#283 changed the role of the menu items in the location field dropdown. This prevented the onFocus handler from ensuring their click handler fires before the dropdown disappears, resulting in menu items not being clickable.

This PR also updates the geocoder to work in more build environments, updating to use the latest lonlat.

Also includes a few related patches for location-field to make integration into otp-rr easier.