### PR TITLE
fix(packages/location-field): generate better labels for all fields where locations are shown

### DIFF
--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -552,6 +552,7 @@ class LocationField extends Component {
             <Option
               icon={sessionOptionIcon}
               key={optionKey++}
+              // just use the name if there is no main/secondary field
               title={sessionLocation.main || sessionLocation.name}
               subTitle={sessionLocation.secondary || ""}
               onClick={locationSelected}

--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -98,7 +98,8 @@ class LocationField extends Component {
       /* FIXME only disabled this because it'd take longer to refactor */
       /* eslint-disable-next-line */
       this.setState({
-        value: location.name,
+        //  location could be null if none is set
+        value: location?.name || "",
         geocodedFeatures: []
       });
     }

--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -331,8 +331,17 @@ class LocationField extends Component {
       getGeocoder(geocoderConfig)
         .getLocationFromGeocodedFeature(feature)
         .then(geocodedLocation => {
+          // Create an improved label for the location
+          // Same label as displayed in the search results list
+          const { main, secondary } = generateLabel(
+            geocodedLocation.rawGeocodedFeature.properties
+          );
+          const geocodedLocationImprovedLabel = {
+            ...geocodedLocation,
+            name: `${main}, ${secondary}`
+          };
           // Set the current location
-          this.setLocation(geocodedLocation, "GEOCODE");
+          this.setLocation(geocodedLocationImprovedLabel, "GEOCODE");
           // Add to the location search history. This is intended to
           // populate the sessionSearches array.
           addLocationSearch({ location: geocodedLocation });

--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -110,7 +110,7 @@ class LocationField extends Component {
   }
 
   /**
-   * Generates a combined label from main and seconday for display in the main input field
+   * Generates a combined label from main and secondary for display in the main input field
    */
   getCombinedLabel = () => {
     const { location } = this.props;

--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -19,7 +19,7 @@ import {
   UserLocationIcon
 } from "./options";
 import * as S from "./styled";
-import { generateLabel } from "./utils";
+import { generateLabel, getCombinedLabel } from "./utils";
 
 // FIXME have a better key generator for options
 let optionKey = 0;
@@ -98,7 +98,7 @@ class LocationField extends Component {
       /* FIXME only disabled this because it'd take longer to refactor */
       /* eslint-disable-next-line */
       this.setState({
-        value: this.getCombinedLabel(),
+        value: location.name,
         geocodedFeatures: []
       });
     }
@@ -110,25 +110,11 @@ class LocationField extends Component {
   }
 
   /**
-   * Generates a combined label from main and secondary for display in the main input field
-   */
-  getCombinedLabel = () => {
-    const { location } = this.props;
-    if (location?.main && location?.secondary) {
-      return `${location.main}, ${location.secondary}`;
-    }
-    if (location?.name) {
-      return location.name;
-    }
-    return "";
-  };
-
-  /**
    * Gets the initial value to place in the input field.
    */
   getValueFromLocation = () => {
     const { hideExistingValue, location } = this.props;
-    const label = this.getCombinedLabel();
+    const label = location?.name || "";
     return location && !hideExistingValue ? label : "";
   };
 
@@ -350,10 +336,10 @@ class LocationField extends Component {
       getGeocoder(geocoderConfig)
         .getLocationFromGeocodedFeature(feature)
         .then(geocodedLocation => {
-          // add the friendly location labels
-          // FIXME: should this be a copy of the object so it's not mutated?
+          // add the friendly location labels for use later on
           geocodedLocation.main = main;
           geocodedLocation.secondary = secondary;
+          geocodedLocation.name = getCombinedLabel(feature.properties);
           // Set the current location
           this.setLocation(geocodedLocation, "GEOCODE");
           // Add to the location search history. This is intended to

--- a/packages/location-field/src/utils.js
+++ b/packages/location-field/src/utils.js
@@ -59,5 +59,5 @@ export const getCombinedLabel = properties => {
   if (main && secondary) {
     return `${main}, ${secondary}`;
   }
-  return properties.label || "";
+  return properties?.label || "";
 };

--- a/packages/location-field/src/utils.js
+++ b/packages/location-field/src/utils.js
@@ -42,8 +42,6 @@ const layerDisplayMap = {
  * to generate an appropriate title subtitle pair, or return the label if the layer is
  * unknown.
  */
-// TODO: Remove this exception once more utils are added
-// eslint-disable-next-line import/prefer-default-export
 export const generateLabel = properties => {
   const labelGenerator = layerDisplayMap[properties.layer];
   if (!labelGenerator) return { main: properties.label };

--- a/packages/location-field/src/utils.js
+++ b/packages/location-field/src/utils.js
@@ -50,3 +50,14 @@ export const generateLabel = properties => {
 
   return labelGenerator(properties);
 };
+
+/**
+ * Generates a combined label from main and secondary for display in the main input field
+ */
+export const getCombinedLabel = properties => {
+  const { main, secondary } = generateLabel(properties);
+  if (main && secondary) {
+    return `${main}, ${secondary}`;
+  }
+  return properties.label || "";
+};


### PR DESCRIPTION
In the last update, only the such results showed the enhanced location information (street, zip code/neighborhood). With this update, that information is displayed in the main location field as well as recent results history. 