### PR TITLE
fix(core-utils/map): use legGeometry instead of drawing straight lines

### DIFF
--- a/packages/core-utils/src/map.js
+++ b/packages/core-utils/src/map.js
@@ -184,6 +184,7 @@ export function itineraryToTransitive(itin, companies, getRouteLabel) {
     if (isTransit(leg.mode)) {
       // determine if we have valid inter-stop geometry
       const hasInterStopGeometry = !!leg.interStopGeometry;
+      const hasLegGeometry = !!leg.legGeometry?.points;
       const hasIntermediateStopGeometry =
         hasInterStopGeometry &&
         leg.intermediateStops &&
@@ -208,7 +209,13 @@ export function itineraryToTransitive(itin, companies, getRouteLabel) {
       pattern.stops.push({ stop_id: leg.from.stopId });
 
       // add intermediate stops to stops dictionary and pattern object
-      if (leg.intermediateStops) {
+      // If there is no intermediateStopGeometry, do not add the intermediate stops
+      // as it will be straight lines instead of the nice legGeometry (but only if
+      // the legGeometry exists).
+      if (
+        leg.intermediateStops &&
+        (hasIntermediateStopGeometry || !hasLegGeometry)
+      ) {
         leg.intermediateStops.forEach((stop, i) => {
           stops[stop.stopId] = {
             stop_id: stop.stopId,
@@ -234,7 +241,8 @@ export function itineraryToTransitive(itin, companies, getRouteLabel) {
       pattern.stops.push({
         stop_id: leg.to.stopId,
         geometry:
-          hasInterStopGeometry &&
+          // Some legs don't have intermediateStopGeometry, but do have valid legGeometry
+          (hasInterStopGeometry || hasLegGeometry) &&
           (hasIntermediateStopGeometry
             ? leg.interStopGeometry[leg.interStopGeometry.length - 1].points
             : leg.legGeometry.points)
@@ -265,7 +273,7 @@ export function itineraryToTransitive(itin, companies, getRouteLabel) {
           {
             pattern_id: ptnId,
             from_stop_index: 0,
-            to_stop_index: leg.intermediateStops
+            to_stop_index: hasIntermediateStopGeometry
               ? leg.intermediateStops.length + 2 - 1
               : 1
           }


### PR DESCRIPTION
Avoids drawing straight lines through roads and houses when `interStopGeometry` is missing by using `legGeometry`, if present. This does bring the caveat of some transitive features no longer being supported when the `interStopGeometry` is missing.

Closes https://github.com/opentripplanner/otp-react-redux/issues/489