### PR TITLE
ACCESSIBILITY: leaflet marker prop to control tabindex 

### DIFF
--- a/packages/park-and-ride-overlay/src/index.js
+++ b/packages/park-and-ride-overlay/src/index.js
@@ -21,7 +21,7 @@ class ParkAndRideOverlay extends MapLayer {
   updateLeafletElement() {}
 
   render() {
-    const { parkAndRideLocations, setLocation } = this.props;
+    const { parkAndRideLocations, setLocation, keyboard } = this.props;
     if (!parkAndRideLocations || parkAndRideLocations.length === 0)
       return <FeatureGroup />;
 
@@ -36,6 +36,7 @@ class ParkAndRideOverlay extends MapLayer {
               icon={parkAndRideMarker}
               key={k}
               position={[location.y, location.x]}
+              keyboard={keyboard}
             >
               <Popup>
                 <BaseMapStyled.MapOverlayPopup>
@@ -71,7 +72,12 @@ ParkAndRideOverlay.propTypes = {
       y: PropTypes.number.isRequired
     }).isRequired
   ),
-  setLocation: PropTypes.func.isRequired
+  setLocation: PropTypes.func.isRequired,
+  keyboard: PropTypes.bool
+};
+
+ParkAndRideOverlay.defaultProps = {
+  keyboard: false
 };
 
 export default withLeaflet(ParkAndRideOverlay);

--- a/packages/park-and-ride-overlay/src/index.js
+++ b/packages/park-and-ride-overlay/src/index.js
@@ -21,7 +21,7 @@ class ParkAndRideOverlay extends MapLayer {
   updateLeafletElement() {}
 
   render() {
-    const { parkAndRideLocations, setLocation, keyboard } = this.props;
+    const { keyboard, parkAndRideLocations, setLocation } = this.props;
     if (!parkAndRideLocations || parkAndRideLocations.length === 0)
       return <FeatureGroup />;
 
@@ -35,8 +35,8 @@ class ParkAndRideOverlay extends MapLayer {
             <Marker
               icon={parkAndRideMarker}
               key={k}
-              position={[location.y, location.x]}
               keyboard={keyboard}
+              position={[location.y, location.x]}
             >
               <Popup>
                 <BaseMapStyled.MapOverlayPopup>
@@ -65,6 +65,7 @@ class ParkAndRideOverlay extends MapLayer {
 }
 
 ParkAndRideOverlay.propTypes = {
+  keyboard: PropTypes.bool,
   parkAndRideLocations: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string.isRequired,
@@ -72,8 +73,7 @@ ParkAndRideOverlay.propTypes = {
       y: PropTypes.number.isRequired
     }).isRequired
   ),
-  setLocation: PropTypes.func.isRequired,
-  keyboard: PropTypes.bool
+  setLocation: PropTypes.func.isRequired
 };
 
 ParkAndRideOverlay.defaultProps = {

--- a/packages/transit-vehicle-overlay/src/components/markers/RotatedMarker/index.js
+++ b/packages/transit-vehicle-overlay/src/components/markers/RotatedMarker/index.js
@@ -10,7 +10,11 @@ import "leaflet-rotatedmarker";
 class RotatedMarker extends MapLayer {
   createLeafletElement(props) {
     const el = new LeafletMarker(props.position, this.getOptions(props));
-    this.contextValue = { ...props.leaflet, popupContainer: el, keyboard: props.keyboard };
+    this.contextValue = {
+      ...props.leaflet,
+      popupContainer: el,
+      keyboard: props.keyboard
+    };
     return el;
   }
 

--- a/packages/transit-vehicle-overlay/src/components/markers/RotatedMarker/index.js
+++ b/packages/transit-vehicle-overlay/src/components/markers/RotatedMarker/index.js
@@ -12,8 +12,8 @@ class RotatedMarker extends MapLayer {
     const el = new LeafletMarker(props.position, this.getOptions(props));
     this.contextValue = {
       ...props.leaflet,
-      popupContainer: el,
-      keyboard: props.keyboard
+      keyboard: props.keyboard,
+      popupContainer: el
     };
     return el;
   }
@@ -55,8 +55,8 @@ class RotatedMarker extends MapLayer {
 }
 
 RotatedMarker.defaultProps = {
-  rotationOrigin: "center",
-  keyboard: false
+  keyboard: false,
+  rotationOrigin: "center"
 };
 
 export default withLeaflet(RotatedMarker);

--- a/packages/transit-vehicle-overlay/src/components/markers/RotatedMarker/index.js
+++ b/packages/transit-vehicle-overlay/src/components/markers/RotatedMarker/index.js
@@ -9,8 +9,9 @@ import "leaflet-rotatedmarker";
  */
 class RotatedMarker extends MapLayer {
   createLeafletElement(props) {
-    const el = new LeafletMarker(props.position, this.getOptions(props));
-    this.contextValue = { ...props.leaflet, popupContainer: el };
+    const p = {...props, keyboard: false};
+    const el = new LeafletMarker(props.position, this.getOptions(p));
+    this.contextValue = { ...props.leaflet, popupContainer: el, keyboard: false};
     return el;
   }
 

--- a/packages/transit-vehicle-overlay/src/components/markers/RotatedMarker/index.js
+++ b/packages/transit-vehicle-overlay/src/components/markers/RotatedMarker/index.js
@@ -9,9 +9,8 @@ import "leaflet-rotatedmarker";
  */
 class RotatedMarker extends MapLayer {
   createLeafletElement(props) {
-    const p = {...props, keyboard: false};
-    const el = new LeafletMarker(props.position, this.getOptions(p));
-    this.contextValue = { ...props.leaflet, popupContainer: el, keyboard: false};
+    const el = new LeafletMarker(props.position, this.getOptions(props));
+    this.contextValue = { ...props.leaflet, popupContainer: el, keyboard: props.keyboard };
     return el;
   }
 
@@ -52,7 +51,8 @@ class RotatedMarker extends MapLayer {
 }
 
 RotatedMarker.defaultProps = {
-  rotationOrigin: "center"
+  rotationOrigin: "center",
+  keyboard: false
 };
 
 export default withLeaflet(RotatedMarker);

--- a/packages/vehicle-rental-overlay/src/DefaultMarkers/index.js
+++ b/packages/vehicle-rental-overlay/src/DefaultMarkers/index.js
@@ -21,11 +21,14 @@ import * as Styled from "../styled";
 const templatePropTypes = {
   /** The children of the component. */
   children: PropTypes.node,
+  /** leaflet attribute to control tabindex value for keyboaryd-only / SR users */
+  keyboard: PropTypes.bool,
   /** The rental vehicle or station to render. */
   entity: coreUtils.types.stationType.isRequired
 };
 const templateDefaultProps = {
-  children: null
+  children: null,
+  keyboard: false
 };
 
 /**
@@ -38,7 +41,7 @@ export const SharedBikeCircle = ({
   pixels,
   strokeColor
 }) => {
-  const GeneratedMarker = ({ children, entity: station }) => {
+  const GeneratedMarker = ({ children, keyboard, entity: station }) => {
     let newStrokeColor = strokeColor || fillColor;
 
     if (!station.isFloatingBike) {
@@ -53,6 +56,7 @@ export const SharedBikeCircle = ({
         fillOpacity={1}
         radius={pixels - (station.isFloatingBike ? 1 : 0)}
         weight={1}
+        keyboard={keyboard}
       >
         {children}
       </CircleMarker>
@@ -68,7 +72,7 @@ export const SharedBikeCircle = ({
  * A component that renders rental bike entities
  * either as a bike or a bike dock (or hub, showing spaces available).
  */
-export const HubAndFloatingBike = ({ children, entity: station }) => {
+export const HubAndFloatingBike = ({ children, keyboard, entity: station }) => {
   let icon;
   if (station.isFloatingBike) {
     icon = floatingBikeIcon;
@@ -80,7 +84,7 @@ export const HubAndFloatingBike = ({ children, entity: station }) => {
     icon = hubIcons[i];
   }
   return (
-    <Marker icon={icon} position={[station.y, station.x]}>
+    <Marker icon={icon} position={[station.y, station.x]} keyboard={keyboard}>
       {children}
     </Marker>
   );
@@ -110,8 +114,12 @@ const getStationMarkerByColor = memoize(color =>
 export const GenericMarker = ({ fillColor = "gray" }) => {
   const markerIcon = getStationMarkerByColor(fillColor);
 
-  const GeneratedMarker = ({ children, entity: station }) => (
-    <Marker icon={markerIcon} position={[station.y, station.x]}>
+  const GeneratedMarker = ({ children, keyboard, entity: station }) => (
+    <Marker
+      icon={markerIcon}
+      position={[station.y, station.x]}
+      keyboard={keyboard}
+    >
       {children}
     </Marker>
   );

--- a/packages/vehicle-rental-overlay/src/DefaultMarkers/index.js
+++ b/packages/vehicle-rental-overlay/src/DefaultMarkers/index.js
@@ -21,10 +21,10 @@ import * as Styled from "../styled";
 const templatePropTypes = {
   /** The children of the component. */
   children: PropTypes.node,
-  /** leaflet attribute to control tabindex value for keyboaryd-only / SR users */
-  keyboard: PropTypes.bool,
   /** The rental vehicle or station to render. */
-  entity: coreUtils.types.stationType.isRequired
+  entity: coreUtils.types.stationType.isRequired,
+  /** leaflet attribute to control tabindex value for keyboaryd-only / SR users */
+  keyboard: PropTypes.bool
 };
 const templateDefaultProps = {
   children: null,
@@ -54,9 +54,9 @@ export const SharedBikeCircle = ({
         color={newStrokeColor}
         fillColor={fillColor}
         fillOpacity={1}
+        keyboard={keyboard}
         radius={pixels - (station.isFloatingBike ? 1 : 0)}
         weight={1}
-        keyboard={keyboard}
       >
         {children}
       </CircleMarker>
@@ -84,7 +84,7 @@ export const HubAndFloatingBike = ({ children, keyboard, entity: station }) => {
     icon = hubIcons[i];
   }
   return (
-    <Marker icon={icon} position={[station.y, station.x]} keyboard={keyboard}>
+    <Marker icon={icon} keyboard={keyboard} position={[station.y, station.x]}>
       {children}
     </Marker>
   );
@@ -117,8 +117,8 @@ export const GenericMarker = ({ fillColor = "gray" }) => {
   const GeneratedMarker = ({ children, keyboard, entity: station }) => (
     <Marker
       icon={markerIcon}
-      position={[station.y, station.x]}
       keyboard={keyboard}
+      position={[station.y, station.x]}
     >
       {children}
     </Marker>


### PR DESCRIPTION
Add an optional Marker prop called 'keyboard' (defaulted to a value of 'false'), which is used by leaflet to either set tabindex="0" (when true) or nothing in the resulting div.  This is important for keyboard-only and SR users, since the current map has potentially 10s to 100s of markers, each that are in the tab order -- the result is that one gets stuck in tab hell on the map, without an exit.  The keyboard=false value will now allow tabbing thru the app, with any variety of marker layer active (stop, vehicle, P&R, bike/scooter share, etc...), and no black hole where the tab order gets stuck w/out an exit.