### PR TITLE
Hopefully Fix Package Releases

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
As per https://github.com/semantic-release/github/issues/175#issuecomment-877059469, this PR prevents persisting credentials used during checkout which will hopefully fix the semantic release bot.