### PR TITLE
feat(location-field): sort results by distance if provided

### DIFF
--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -411,7 +411,7 @@ class LocationField extends Component {
     } = this.props;
     const { menuVisible, value } = this.state;
     const { activeIndex, message } = this.state;
-    const { geocodedFeatures } = this.state;
+    let { geocodedFeatures } = this.state;
 
     let { sessionSearches } = this.props;
     if (sessionSearches.length > 5)
@@ -427,6 +427,12 @@ class LocationField extends Component {
 
     /* 1) Process geocode search result option(s) */
     if (geocodedFeatures.length > 0) {
+      geocodedFeatures = geocodedFeatures.sort(
+        (a, b) =>
+          (a.properties.distance || Infinity) -
+          (b.properties.distance || Infinity)
+      );
+
       // Add the menu sub-heading (not a selectable item)
       // menuItems.push(<MenuItem header key='sr-header'>Search Results</MenuItem>)
 

--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -429,8 +429,8 @@ class LocationField extends Component {
     if (geocodedFeatures.length > 0) {
       geocodedFeatures = geocodedFeatures.sort(
         (a, b) =>
-          (a.properties.distance || Infinity) -
-          (b.properties.distance || Infinity)
+          (a.properties?.distance || Infinity) -
+          (b.properties?.distance || Infinity)
       );
 
       // Add the menu sub-heading (not a selectable item)

--- a/packages/location-field/src/mocks/autocomplete.json
+++ b/packages/location-field/src/mocks/autocomplete.json
@@ -87,6 +87,7 @@
         "layer": "stops",
         "source": "transit",
         "source_id": "1::Community Transit::stops",
+        "distance": 4,
         "name": "Marine Dr NE & 27th Ave NE (Community Transit Stop ID 1)",
         "accuracy": "centroid",
         "label": "Marine Dr NE & 27th Ave NE (Community Transit Stop ID 1)"
@@ -105,6 +106,7 @@
         "source": "transit",
         "source_id": "7::Community Transit::stops",
         "name": "Marine Dr NE & 23rd Ave NE (Community Transit Stop ID 7)",
+        "distance": 2,
         "accuracy": "centroid",
         "label": "Marine Dr NE & 23rd Ave NE (Community Transit Stop ID 7)"
       }


### PR DESCRIPTION
This PR adds a new sort within `locationField` which sorts results by distance, if provided. Results with distance are always prioritized.