### PR TITLE
feat(location-field): allow special layers to avoid distance sorting

### DIFF
--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -392,7 +392,7 @@ class LocationField extends Component {
       currentPositionIcon,
       currentPositionUnavailableIcon,
       inputPlaceholder,
-      favoredLayers,
+      preferredLayers,
       layerColorMap,
       location,
       clearButtonIcon,
@@ -433,7 +433,7 @@ class LocationField extends Component {
       const { special, normal } = geocodedFeatures.reduce(
         (prev, cur) => {
           prev[
-            favoredLayers.includes(cur?.properties?.layer)
+            preferredLayers.includes(cur?.properties?.layer)
               ? "special"
               : "normal"
           ].push(cur);
@@ -826,7 +826,7 @@ LocationField.propTypes = {
    * Results are sorted by distance, but favored layers will always appear
    * first.
    */
-  favoredLayers: PropTypes.arrayOf(PropTypes.string),
+  preferredLayers: PropTypes.arrayOf(PropTypes.string),
   /**
    * Invoked whenever the currentPosition is set, but the nearbyStops are not.
    * Sends the following argument:
@@ -1038,7 +1038,7 @@ LocationField.defaultProps = {
   currentPositionIcon: <LocationArrow size={13} />,
   currentPositionUnavailableIcon: <Ban size={13} />,
   initialSearchResults: null,
-  favoredLayers: [],
+  preferredLayers: [],
   findNearbyStops: () => {},
   GeocodedOptionIconComponent: GeocodedOptionIcon,
   hideExistingValue: false,

--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -402,6 +402,7 @@ class LocationField extends Component {
       sessionOptionIcon,
       showClearButton,
       showUserSettings,
+      sortByDistance,
       static: isStatic,
       stopOptionIcon,
       stopsIndex,
@@ -443,11 +444,13 @@ class LocationField extends Component {
 
       geocodedFeatures = [
         ...special,
-        ...normal.sort(
-          (a, b) =>
+        ...normal.sort((a, b) => {
+          if (!sortByDistance) return 0;
+          return (
             (b.properties?.distance || Infinity) -
             (a.properties?.distance || Infinity)
-        )
+          );
+        })
       ];
 
       // Add the menu sub-heading (not a selectable item)
@@ -957,6 +960,11 @@ LocationField.propTypes = {
    */
   operatorIconMap: PropTypes.shape({ [PropTypes.string]: PropTypes.node }),
   /**
+   * A boolean for whether to override the result sort order and sort by
+   * distance.
+   */
+  sortByDistance: PropTypes.bool,
+  /**
    * A slot for the icon to display for an option that was used during the
    * current session.
    */
@@ -1043,6 +1051,7 @@ LocationField.defaultProps = {
   operatorIconMap: {},
   sessionOptionIcon: <Search size={13} />,
   sessionSearches: [],
+  sortByDistance: false,
   showClearButton: true,
   showUserSettings: false,
   static: false,

--- a/packages/location-field/src/mocks/autocomplete.json
+++ b/packages/location-field/src/mocks/autocomplete.json
@@ -457,11 +457,12 @@
       "properties": {
         "id": "way/555892536",
         "gid": "openstreetmap:venue:way/555892536",
-        "layer": "venue",
+        "layer": "example_layer",
         "source": "openstreetmap",
         "source_id": "way/555892536",
         "country_code": "US",
-        "name": "Whole Foods Market",
+        "distance": 999999,
+        "name": "Important, far away Whole Foods Market",
         "accuracy": "point",
         "country": "United States",
         "country_gid": "whosonfirst:country:85633793",
@@ -476,7 +477,7 @@
         "locality_gid": "whosonfirst:locality:101730265",
         "continent": "North America",
         "continent_gid": "whosonfirst:continent:102191575",
-        "label": "Whole Foods Market, University Place, WA, USA",
+        "label": "Whole Foods that is far away, but prioritized",
         "addendum": {
           "osm": {
             "brand": "Whole Foods Market"

--- a/packages/location-field/src/stories/Desktop.story.js
+++ b/packages/location-field/src/stories/Desktop.story.js
@@ -140,7 +140,7 @@ export const WithPrefilledSearch = () => (
     currentPosition={currentPosition}
     geocoderConfig={geocoderConfig}
     getCurrentPosition={getCurrentPosition}
-    favoredLayers={["example_layer"]}
+    preferredLayers={["example_layer"]}
     initialSearchResults={mockedGeocoderResponse.features}
     inputPlaceholder="Select from location"
     layerColorMap={layerColorMap}

--- a/packages/location-field/src/stories/Desktop.story.js
+++ b/packages/location-field/src/stories/Desktop.story.js
@@ -146,6 +146,7 @@ export const WithPrefilledSearch = () => (
     layerColorMap={layerColorMap}
     locationType="from"
     onLocationSelected={onLocationSelected}
+    sortByDistance
     style={{ fontFamily: "sans-serif" }}
   />
 );

--- a/packages/location-field/src/stories/Desktop.story.js
+++ b/packages/location-field/src/stories/Desktop.story.js
@@ -140,6 +140,7 @@ export const WithPrefilledSearch = () => (
     currentPosition={currentPosition}
     geocoderConfig={geocoderConfig}
     getCurrentPosition={getCurrentPosition}
+    favoredLayers={["example_layer"]}
     initialSearchResults={mockedGeocoderResponse.features}
     inputPlaceholder="Select from location"
     layerColorMap={layerColorMap}


### PR DESCRIPTION
This PR adds a prop to the location field that allows certain layers to avoid the distance based sorting all results are otherwise subjected to.