### PR TITLE
Render Flex Legs as arcs in Itinerary View

### DIFF
--- a/packages/core-utils/src/map.js
+++ b/packages/core-utils/src/map.js
@@ -1,6 +1,6 @@
 import moment from "moment";
 
-import { getPlaceName, isTransit, toSentenceCase } from "./itinerary";
+import { getPlaceName, isTransit, isFlex, toSentenceCase } from "./itinerary";
 
 export function latlngToString(latlng) {
   return (
@@ -274,6 +274,7 @@ export function itineraryToTransitive(itin, companies, getRouteLabel) {
 
       // add the pattern reference to the journey object
       journey.segments.push({
+        arc: isFlex(leg),
         type: "TRANSIT",
         patterns: [
           {


### PR DESCRIPTION
This is a small change to not use the OTP-generated shapes. These could often be inaccurate. 

The route viewer is not affected by these changes, as the route viewer does not render flex legs via transitive.