### PR TITLE
fix(location-field): update onFocus handler to use updated aria roles

### DIFF
--- a/packages/location-field/src/index.js
+++ b/packages/location-field/src/index.js
@@ -189,7 +189,7 @@ class LocationField extends Component {
     // see https://stackoverflow.com/a/49325196/915811
     const target =
       e.relatedTarget !== null ? e.relatedTarget : document.activeElement;
-    if (!target || target.getAttribute("role") !== "listitem") {
+    if (!target || target.getAttribute("role") !== "option") {
       this.setState({
         geocodedFeatures: [],
         menuVisible: false,


### PR DESCRIPTION
#316 changed the aria role for the list items, which broke the `onFocus` handler. This prevented items from being clicked. 

This PR adjusts the `onFocus` handler to use the updated aria role, restoring correct behavior. 