### PR TITLE
fix(geocoder): fix reverse geocoding

### DIFF
--- a/packages/geocoder/package.json
+++ b/packages/geocoder/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@conveyal/geocoder-arcgis-geojson": "^0.0.3",
     "@conveyal/lonlat": "^1.4.1",
-    "isomorphic-mapzen-search": "^1.6.0",
+    "isomorphic-mapzen-search": "miles-grant-ibigroup/isomorphic-mapzen-search#fix-reverse-search",
     "lodash.memoize": "^4.1.2"
   },
   "gitHead": "644c72e0d08f8daf93b44eaf0deec88a1e16f414",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12152,10 +12152,9 @@ isomorphic-fetch@^3.0.0:
     node-fetch "^2.6.1"
     whatwg-fetch "^3.4.1"
 
-isomorphic-mapzen-search@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/isomorphic-mapzen-search/-/isomorphic-mapzen-search-1.6.0.tgz#eb368756d6132016a32c76435d6f34a38da5279f"
-  integrity sha512-90Zp8jxWuMCk582S7d6b85lHO2Lj4Nybv8o6ShqQX2SRP7SFh1fzHx67eilNUGNjBeamKYQJHmijZ1/wSzFe3A==
+isomorphic-mapzen-search@miles-grant-ibigroup/isomorphic-mapzen-search#fix-reverse-search:
+  version "999.999.999"
+  resolved "https://codeload.github.com/miles-grant-ibigroup/isomorphic-mapzen-search/tar.gz/5f6243a55bb33c8f84da9d72103facdf0061a9b4"
   dependencies:
     "@conveyal/lonlat" "^1.4.1"
     isomorphic-fetch "^3.0.0"


### PR DESCRIPTION
While we wait for https://github.com/conveyal/isomorphic-mapzen-search/pull/75 to be merged, this PR allows us to use that fix.