### PR TITLE
fix(route-viewer-overlay): avoid crash on empty but not missing geometry

### DIFF
--- a/packages/route-viewer-overlay/src/index.js
+++ b/packages/route-viewer-overlay/src/index.js
@@ -62,7 +62,8 @@ class RouteViewerOverlay extends MapLayer {
         },
         []
       );
-      if (allPoints.length > 0) this.props.leaflet.map.fitBounds(allPoints);
+      if (allPoints.length > 0 && this.props.leaflet.map)
+        this.props.leaflet.map.fitBounds(allPoints);
     }
   }
 

--- a/packages/route-viewer-overlay/src/index.js
+++ b/packages/route-viewer-overlay/src/index.js
@@ -53,12 +53,9 @@ class RouteViewerOverlay extends MapLayer {
   // TODO: determine why the default MapLayer componentWillUnmount() method throws an error
   componentWillUnmount() {}
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate() {
     // if pattern geometry updated, update the map points
-    if (
-      this.props.routeData?.id !== prevProps.routeData?.id &&
-      isGeomComplete(this.props.routeData)
-    ) {
+    if (this.props.allowMapCentering && isGeomComplete(this.props.routeData)) {
       const allPoints = Object.values(this.props.routeData.patterns).reduce(
         (acc, ptn) => {
           return acc.concat(polyline.decode(ptn.geometry.points));
@@ -110,6 +107,10 @@ class RouteViewerOverlay extends MapLayer {
 
 RouteViewerOverlay.propTypes = {
   /**
+   * This boolean value allows disabling of map centering and panning.
+   */
+  allowMapCentering: PropTypes.boolean,
+  /**
    * If pattern stops contain polygons, we can request that the routes are not drawn
    * inside of these polygons by setting this prop to true. If true, the layer will
    * check every zone of every stop in a pattern before drawing the route for that pattern
@@ -150,6 +151,7 @@ RouteViewerOverlay.propTypes = {
 };
 
 RouteViewerOverlay.defaultProps = {
+  allowMapCentering: true,
   path: {
     color: "#00bfff",
     opacity: 1,

--- a/packages/route-viewer-overlay/src/index.js
+++ b/packages/route-viewer-overlay/src/index.js
@@ -79,7 +79,7 @@ class RouteViewerOverlay extends MapLayer {
     const routeColor = routeData.color ? `#${routeData.color}` : path.color;
     const segments = [];
     Object.values(routeData.patterns).forEach(pattern => {
-      if (!pattern.geometry) return;
+      if (!pattern?.geometry) return;
       const pts = polyline.decode(pattern.geometry.points);
       const clippedPts = clipToPatternStops
         ? removePointsInFlexZone(pattern?.stops, pts)

--- a/packages/route-viewer-overlay/src/index.js
+++ b/packages/route-viewer-overlay/src/index.js
@@ -110,7 +110,7 @@ RouteViewerOverlay.propTypes = {
   /**
    * This boolean value allows disabling of map centering and panning.
    */
-  allowMapCentering: PropTypes.boolean,
+  allowMapCentering: PropTypes.bool,
   /**
    * If pattern stops contain polygons, we can request that the routes are not drawn
    * inside of these polygons by setting this prop to true. If true, the layer will

--- a/packages/route-viewer-overlay/src/index.js
+++ b/packages/route-viewer-overlay/src/index.js
@@ -53,9 +53,12 @@ class RouteViewerOverlay extends MapLayer {
   // TODO: determine why the default MapLayer componentWillUnmount() method throws an error
   componentWillUnmount() {}
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     // if pattern geometry updated, update the map points
-    if (isGeomComplete(this.props.routeData)) {
+    if (
+      this.props.routeData?.id !== prevProps.routeData?.id &&
+      isGeomComplete(this.props.routeData)
+    ) {
       const allPoints = Object.values(this.props.routeData.patterns).reduce(
         (acc, ptn) => {
           return acc.concat(polyline.decode(ptn.geometry.points));

--- a/packages/route-viewer-overlay/src/index.js
+++ b/packages/route-viewer-overlay/src/index.js
@@ -53,12 +53,9 @@ class RouteViewerOverlay extends MapLayer {
   // TODO: determine why the default MapLayer componentWillUnmount() method throws an error
   componentWillUnmount() {}
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate() {
     // if pattern geometry just finished populating, update the map points
-    if (
-      !isGeomComplete(prevProps.routeData) &&
-      isGeomComplete(this.props.routeData)
-    ) {
+    if (isGeomComplete(this.props.routeData)) {
       const allPoints = Object.values(this.props.routeData.patterns).reduce(
         (acc, ptn) => {
           return acc.concat(polyline.decode(ptn.geometry.points));

--- a/packages/route-viewer-overlay/src/index.js
+++ b/packages/route-viewer-overlay/src/index.js
@@ -65,7 +65,7 @@ class RouteViewerOverlay extends MapLayer {
         },
         []
       );
-      this.props.leaflet.map.fitBounds(allPoints);
+      if (allPoints.length > 0) this.props.leaflet.map.fitBounds(allPoints);
     }
   }
 

--- a/packages/route-viewer-overlay/src/index.js
+++ b/packages/route-viewer-overlay/src/index.js
@@ -12,7 +12,7 @@ const isGeomComplete = routeData => {
     routeData &&
     routeData.patterns &&
     Object.values(routeData.patterns).every(
-      ptn => typeof ptn.geometry !== "undefined"
+      ptn => typeof ptn?.geometry !== "undefined"
     )
   );
 };

--- a/packages/route-viewer-overlay/src/index.js
+++ b/packages/route-viewer-overlay/src/index.js
@@ -54,7 +54,7 @@ class RouteViewerOverlay extends MapLayer {
   componentWillUnmount() {}
 
   componentDidUpdate() {
-    // if pattern geometry just finished populating, update the map points
+    // if pattern geometry updated, update the map points
     if (isGeomComplete(this.props.routeData)) {
       const allPoints = Object.values(this.props.routeData.patterns).reduce(
         (acc, ptn) => {


### PR DESCRIPTION
This PR resolves crashes found in OTP-RR. We were checking for lack of geometry, but not empty geometry.