### PR TITLE
fix(transitive-overlay): avoid crash on slow leaflet load

### DIFF
--- a/packages/transitive-overlay/src/leaflet-canvas-layer.js
+++ b/packages/transitive-overlay/src/leaflet-canvas-layer.js
@@ -119,7 +119,7 @@ L.CanvasLayer = (L.Layer ? L.Layer : L.Class).extend({
     //------------------------------------------------------------------------------
     drawLayer: function () {
         // -- todo make the viewInfo properties  flat objects.
-        if (!this._map) return
+        if (!this._map) return;
         var size   = this._map.getSize();
         var bounds = this._map.getBounds();
         var zoom   = this._map.getZoom();

--- a/packages/transitive-overlay/src/leaflet-canvas-layer.js
+++ b/packages/transitive-overlay/src/leaflet-canvas-layer.js
@@ -119,6 +119,7 @@ L.CanvasLayer = (L.Layer ? L.Layer : L.Class).extend({
     //------------------------------------------------------------------------------
     drawLayer: function () {
         // -- todo make the viewInfo properties  flat objects.
+        if (!this._map) return
         var size   = this._map.getSize();
         var bounds = this._map.getBounds();
         var zoom   = this._map.getZoom();


### PR DESCRIPTION
Transitive overlay was relying on the Leaflet map object being available pretty quickly. In some environments it takes some time to arrive, so this PR resolves the issue by skipping draw when the map object isn't available.