### PR TITLE
fix(transit-vehicle-overlay): support subway

### DIFF
--- a/packages/transit-vehicle-overlay/src/utils/graphics.js
+++ b/packages/transit-vehicle-overlay/src/utils/graphics.js
@@ -139,6 +139,7 @@ export function makeVehicleIcon(
       );
       break;
     case "RAIL":
+    case "SUBWAY":
       icon = isTracked ? (
         <Styled.TrackedRail color={color} colorselected={highlightColor} />
       ) : (


### PR DESCRIPTION
The transit vehicle overlay did not support subway icons and instead rendered them as a big dot. This renders them as trains.