### PR TITLE
Humanize distance intl

### DIFF
--- a/packages/humanize-distance/package.json
+++ b/packages/humanize-distance/package.json
@@ -12,5 +12,8 @@
   "gitHead": "644c72e0d08f8daf93b44eaf0deec88a1e16f414",
   "scripts": {
     "tsc": "tsc"
+  },
+  "peerDependencies": {
+    "react-intl": "^5.24.6"
   }
 }

--- a/packages/humanize-distance/src/index.ts
+++ b/packages/humanize-distance/src/index.ts
@@ -11,25 +11,21 @@ export function humanizeDistanceStringImperial(
 ): string {
   const feet = meters * 3.28084;
 
-  let unit;
-  let value;
-  let unitIfNoIntl;
+  let unit = "mile";
+  let unitIfNoIntl = abbreviate ? "mi" : "miles";
+  let value = roundToOneDecimalPlace(feet / 5280);
 
   if (feet < 528) {
     unit = "foot";
     unitIfNoIntl = abbreviate ? "ft" : "feet";
     value = Math.round(feet);
-  } else {
-    unit = "mile";
-    unitIfNoIntl = abbreviate ? "mi" : "miles";
-    value = roundToOneDecimalPlace(feet / 5280);
   }
 
   return intl
     ? intl.formatNumber(value, {
+        style: "unit",
         unit,
-        unitDisplay: abbreviate ? "short" : "long",
-        style: "unit"
+        unitDisplay: abbreviate ? "short" : "long"
       })
     : `${value} ${unitIfNoIntl}`;
 }
@@ -39,26 +35,26 @@ export function humanizeDistanceStringMetric(
   intl?: IntlShape
 ): string {
   const km = meters / 1000;
-  let unit = "kilometer";
-  let shortUnit = "km";
-  let value;
-  if (km > 100) {
-    // 100 km => 999999999 km
-    value = Math.round(km);
-  } else if (km > 1) {
-    // 1.1 km => 99.9 km
-    value = roundToOneDecimalPlace(km);
-  } else {
-    unit = "meter";
-    shortUnit = "m";
-    value = Math.round(meters);
+  let unit = "meter";
+  let shortUnit = "m";
+  let value = Math.round(meters);
+
+  if (km > 1) {
+    unit = "kilometer";
+    shortUnit = "km";
+    value =
+      km > 100
+        ? // 100 km and over
+          Math.round(km)
+        : // 1.1 km => 99.9 km
+          roundToOneDecimalPlace(km);
   }
 
   return intl
     ? intl.formatNumber(value, {
+        style: "unit",
         unit,
-        unitDisplay: "short",
-        style: "unit"
+        unitDisplay: "short"
       })
     : `${value} ${shortUnit}`;
 }

--- a/packages/humanize-distance/src/index.ts
+++ b/packages/humanize-distance/src/index.ts
@@ -1,32 +1,74 @@
-export function humanizeDistanceStringImperial(
-  meters: number,
-  abbreviate?: boolean
-): string {
-  const feet = meters * 3.28084;
-  if (feet < 528)
-    return Math.round(feet) + (abbreviate === true ? " ft" : " feet");
-  return Math.round(feet / 528) / 10 + (abbreviate === true ? " mi" : " miles");
+import { IntlShape } from "react-intl";
+
+function roundToOneDecimalPlace(number: number): number {
+  return Math.round(number * 10) / 10;
 }
 
-export function humanizeDistanceStringMetric(meters: number): string {
+export function humanizeDistanceStringImperial(
+  meters: number,
+  abbreviate?: boolean,
+  intl?: IntlShape
+): string {
+  const feet = meters * 3.28084;
+
+  let unit;
+  let value;
+  let unitIfNoIntl;
+
+  if (feet < 528) {
+    unit = "foot";
+    unitIfNoIntl = abbreviate ? "ft" : "feet";
+    value = Math.round(feet);
+  } else {
+    unit = "mile";
+    unitIfNoIntl = abbreviate ? "mi" : "miles";
+    value = roundToOneDecimalPlace(feet / 5280);
+  }
+
+  return intl
+    ? intl.formatNumber(value, {
+        unit,
+        unitDisplay: abbreviate ? "short" : "long",
+        style: "unit"
+      })
+    : `${value} ${unitIfNoIntl}`;
+}
+
+export function humanizeDistanceStringMetric(
+  meters: number,
+  intl?: IntlShape
+): string {
   const km = meters / 1000;
+  let unit = "kilometer";
+  let shortUnit = "km";
+  let value;
   if (km > 100) {
     // 100 km => 999999999 km
-    return `${km.toFixed(0)} km`;
-  }
-  if (km > 1) {
+    value = Math.round(km);
+  } else if (km > 1) {
     // 1.1 km => 99.9 km
-    return `${km.toFixed(1)} km`;
+    value = roundToOneDecimalPlace(km);
+  } else {
+    unit = "meter";
+    shortUnit = "m";
+    value = Math.round(meters);
   }
-  // 1m => 999m
-  return `${meters.toFixed(0)} m`;
+
+  return intl
+    ? intl.formatNumber(value, {
+        unit,
+        unitDisplay: "short",
+        style: "unit"
+      })
+    : `${value} ${shortUnit}`;
 }
 
 export function humanizeDistanceString(
   meters: number,
-  outputMetricUnits = false
+  outputMetricUnits = false,
+  intl?: IntlShape
 ): string {
   return outputMetricUnits
-    ? humanizeDistanceStringMetric(meters)
-    : humanizeDistanceStringImperial(meters);
+    ? humanizeDistanceStringMetric(meters, intl)
+    : humanizeDistanceStringImperial(meters, null, intl);
 }


### PR DESCRIPTION
~Requires #355 (for an updated correct dependency version).~ Update: #355 is now merged in master.

This PR adds i18n support to the `humanize-distance` package while maintaining backwards compatibility (use of `react-intl` remains optional with this package).



