### PR TITLE
Remove all English strings from core-utils

### DIFF
--- a/packages/core-utils/src/deprecated.js
+++ b/packages/core-utils/src/deprecated.js
@@ -141,10 +141,7 @@ export function getPlaceName(place, companies) {
  * an object with string formatters and the fare value (in cents).
  */
 export function getTransitFare(fareComponent) {
-  logDeprecationWarning(
-    "getTransitFare",
-    "getFare, getAllFaresForLeg, and getTncFare"
-  );
+  logDeprecationWarning("getTransitFare", "the fare object and getTncFare");
 
   // Default values (if fare component is not valid).
   let digits = 2;
@@ -203,10 +200,7 @@ export function getTransitFare(fareComponent) {
  * a tnc ride within the leg. This will make typescripting easier, as the types will be cleaner.
  */
 export function calculateFares(itinerary, multiple = false) {
-  logDeprecationWarning(
-    "calculateFares",
-    "getFare, getAllFaresForLeg, and getTncFare"
-  );
+  logDeprecationWarning("calculateFares", "the fare object and getTncFare");
 
   // Process any TNC fares
   let minTNCFare = 0;

--- a/packages/core-utils/src/deprecated.js
+++ b/packages/core-utils/src/deprecated.js
@@ -1,0 +1,316 @@
+import moment from "moment";
+
+// Need to avoid cyclic dependency resolution
+/* eslint-disable global-require */
+export function logDeprecationWarning(method, alternative) {
+  console.warn(
+    `${method ||
+      "This method"} is deprecated and will be removed in a future otp-ui release. All language functionality should be handled using react-intl.
+        ${
+          alternative
+            ? `
+
+        Use ${alternative} instead, which provides a new interface that doesn't return English strings.`
+            : ""
+        }`
+  );
+}
+
+// itinerary.js
+
+export function getStepDirection(step) {
+  logDeprecationWarning("getStepDirection");
+
+  switch (step.relativeDirection) {
+    case "DEPART":
+      return `Head ${step.absoluteDirection.toLowerCase()}`;
+    case "LEFT":
+      return "Left";
+    case "HARD_LEFT":
+      return "Hard left";
+    case "SLIGHTLY_LEFT":
+      return "Slight left";
+    case "CONTINUE":
+      return "Continue";
+    case "SLIGHTLY_RIGHT":
+      return "Slight right";
+    case "RIGHT":
+      return "Right";
+    case "HARD_RIGHT":
+      return "Hard right";
+    case "CIRCLE_CLOCKWISE":
+      return "Follow circle clockwise";
+    case "CIRCLE_COUNTERCLOCKWISE":
+      return "Follow circle counterclockwise";
+    case "ELEVATOR":
+      return "Take elevator";
+    case "UTURN_LEFT":
+      return "Left U-turn";
+    case "UTURN_RIGHT":
+      return "Right U-turn";
+    default:
+      return step.relativeDirection;
+  }
+}
+
+export function getStepInstructions(step) {
+  logDeprecationWarning("getStepInstructions");
+
+  const conjunction = step.relativeDirection === "ELEVATOR" ? "to" : "on";
+  return `${getStepDirection(step)} ${conjunction} ${step.streetName}`;
+}
+
+export function getStepStreetName(step) {
+  logDeprecationWarning("getStepStreetName");
+
+  if (step.streetName === "road") return "Unnamed Road";
+  if (step.streetName === "path") return "Unnamed Path";
+  return step.streetName;
+}
+
+export function getLegModeLabel(leg) {
+  logDeprecationWarning("getLegModeLabel");
+
+  switch (leg.mode) {
+    case "BICYCLE_RENT":
+      return "Biketown";
+    case "CAR":
+      return leg.hailedCar ? "Ride" : "Drive";
+    case "GONDOLA":
+      return "Aerial Tram";
+    case "TRAM":
+      if (leg.routeLongName.toLowerCase().indexOf("streetcar") !== -1)
+        return "Streetcar";
+      return "Light Rail";
+    case "MICROMOBILITY":
+      return "Ride";
+    default:
+      return require("./itinerary").toSentenceCase(leg.mode);
+  }
+}
+
+/**
+ * Returns mode name by checking the vertex type (VertexType class in OTP) for
+ * the provided place. NOTE: this is currently only intended for vehicles at
+ * the moment (not transit or walking).
+ *
+ * @param  {string} place place from itinerary leg
+ */
+export function getModeForPlace(place) {
+  logDeprecationWarning("getModeForPlace");
+
+  switch (place.vertexType) {
+    case "CARSHARE":
+      return "car";
+    case "VEHICLERENTAL":
+      return "E-scooter";
+    // TODO: Should the type change depending on bike vertex type?
+    case "BIKESHARE":
+    case "BIKEPARK":
+      return "bike";
+    // If company offers more than one mode, default to `vehicle` string.
+    default:
+      return "vehicle";
+  }
+}
+
+export function getPlaceName(place, companies) {
+  logDeprecationWarning("getPlaceName");
+
+  // If address is provided (i.e. for carshare station, use it)
+  if (place.address) return place.address.split(",")[0];
+  if (place.networks && place.vertexType === "VEHICLERENTAL") {
+    // For vehicle rental pick up, do not use the place name. Rather, use
+    // company name + vehicle type (e.g., SPIN E-scooter). Place name is often just
+    // a UUID that has no relevance to the actual vehicle. For bikeshare, however,
+    // there are often hubs or bikes that have relevant names to the user.
+    const company = require("./itinerary").getCompanyForNetwork(
+      place.networks[0],
+      companies
+    );
+    if (company) {
+      return `${company.label} ${getModeForPlace(place)}`;
+    }
+  }
+  // Default to place name
+  return place.name;
+}
+
+/**
+ * For a given fare component (either total fare or component parts), returns
+ * an object with string formatters and the fare value (in cents).
+ */
+export function getTransitFare(fareComponent) {
+  logDeprecationWarning(
+    "getTransitFare",
+    "getFare, getAllFaresForLeg, and getTncFare"
+  );
+
+  // Default values (if fare component is not valid).
+  let digits = 2;
+  let transitFare = 0;
+  let symbol = "$";
+  let currencyCode = "USD";
+  if (fareComponent) {
+    // Assign values without declaration. See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#assignment_without_declaration
+    ({
+      currencyCode,
+      defaultFractionDigits: digits,
+      symbol
+    } = fareComponent.currency);
+    transitFare = fareComponent.cents;
+  }
+  // For cents to string conversion, use digits from fare component.
+  const centsToString = cents => {
+    const dollars = (cents / 10 ** digits).toFixed(digits);
+    return `${symbol}${dollars}`;
+  };
+  // For dollars to string conversion, assume we're rounding to two digits.
+  const dollarsToString = dollars => `${symbol}${dollars.toFixed(2)}`;
+  return {
+    centsToString,
+    currencyCode,
+    dollarsToString,
+    transitFare
+  };
+}
+
+/**
+ * For an itinerary, calculates the transit/TNC fares and returns an object with
+ * these values, currency info, as well as string formatters.
+ * It is assumed that the same currency is used for transit and TNC legs.
+ *
+ * multiple being set to true will change the output behavior:
+ * - dollarsToString and centsToString will be returned as part of each fare
+ * - currencyCode will be returned separately for each fare
+ * - tnc currency code will be returned separately
+ * - each fare type will be returned separately within a new transitFares property
+ *
+ * FIXME: a new approach to fare calculation must be found:
+ * the current approach is not sustainable, as centsToString and DollarsToString
+ * must be replaced by i18n anyway.
+ *
+ * However, the current behavior should ideally be kept to avoid a breaking change.
+ * The "multiple" mode is helpful, but only prevents tnc fare calculation from being duplicated.
+ * This method could be split out into a new one, along with tnc fare calculation.
+ * If this is done, the individual fare calculation should also be modified to support
+ * a default fare not being called "regular". However, this again would be a breaking change.
+ * This breaking change is avoided by adding the "multiple" parameter.
+ *
+ * When centsToString and dollarsToString are removed, this method should be split into
+ * individual fare calculation on a variable fare key, fare calculation of an entire leg,
+ * which will get fares for every fare key in the leg, and a method to calculate the fare of
+ * a tnc ride within the leg. This will make typescripting easier, as the types will be cleaner.
+ */
+export function calculateFares(itinerary, multiple = false) {
+  logDeprecationWarning(
+    "calculateFares",
+    "getFare, getAllFaresForLeg, and getTncFare"
+  );
+
+  // Process any TNC fares
+  let minTNCFare = 0;
+  let maxTNCFare = 0;
+  let tncCurrencyCode;
+  itinerary.legs.forEach(leg => {
+    if (leg.mode === "CAR" && leg.hailedCar && leg.tncData) {
+      const { currency, maxCost, minCost } = leg.tncData;
+      // TODO: Support non-USD
+      minTNCFare += minCost;
+      maxTNCFare += maxCost;
+      tncCurrencyCode = currency;
+    }
+  });
+
+  if (multiple) {
+    // Return object of fares
+    const transitFares = {};
+    if (itinerary && itinerary.fare && itinerary.fare.fare) {
+      Object.keys(itinerary.fare.fare).forEach(fareKey => {
+        const fareComponent = itinerary.fare.fare[fareKey];
+        transitFares[fareKey] = getTransitFare(fareComponent);
+      });
+    }
+
+    return {
+      maxTNCFare,
+      minTNCFare,
+      tncCurrencyCode,
+      transitFares
+    };
+  }
+
+  // Extract fare total from itinerary fares.
+  const fareComponent =
+    itinerary.fare && itinerary.fare.fare && itinerary.fare.fare.regular;
+  // Get string formatters and itinerary fare.
+  const {
+    centsToString,
+    currencyCode: transitCurrencyCode,
+    dollarsToString,
+    transitFare
+  } = getTransitFare(fareComponent);
+
+  return {
+    centsToString,
+    currencyCode: transitCurrencyCode || tncCurrencyCode,
+    dollarsToString,
+    maxTNCFare,
+    minTNCFare,
+    transitFare
+  };
+}
+
+// map.js
+
+export function latlngToString(latlng) {
+  logDeprecationWarning("latlngToString", "the latlng object");
+
+  return (
+    latlng &&
+    `${latlng.lat.toFixed(5)}, ${(latlng.lng || latlng.lon).toFixed(5)}`
+  );
+}
+
+export function coordsToString(coords) {
+  logDeprecationWarning("coordsToString", "the coords object");
+
+  return coords.length && coords.map(c => (+c).toFixed(5)).join(", ");
+}
+
+export function getDetailText(location) {
+  let detailText;
+  if (location.type === "home" || location.type === "work") {
+    detailText = location.name;
+  }
+  if (location.type === "stop") {
+    detailText = location.id;
+  } else if (location.type === "recent" && location.timestamp) {
+    detailText = moment(location.timestamp).fromNow();
+  }
+  return detailText;
+}
+
+// query.js
+
+export function summarizeQuery(query, locations = []) {
+  logDeprecationWarning("summarizeQuery");
+
+  function findLocationType(
+    location,
+    ls = [],
+    types = ["home", "work", "suggested"]
+  ) {
+    const match = ls.find(l => require("./map").matchLatLon(l, location));
+    return match && types.indexOf(match.type) !== -1 ? match.type : null;
+  }
+
+  const from =
+    findLocationType(query.from, locations) || query.from.name.split(",")[0];
+  const to =
+    findLocationType(query.to, locations) || query.to.name.split(",")[0];
+  const mode = require("./itinerary").hasTransit(query.mode)
+    ? "Transit"
+    : require("./itinerary").toSentenceCase(query.mode);
+  return `${mode} from ${from} to ${to}`;
+}

--- a/packages/core-utils/src/itinerary.js
+++ b/packages/core-utils/src/itinerary.js
@@ -1,6 +1,28 @@
 import polyline from "@mapbox/polyline";
 import turfAlong from "@turf/along";
 
+import {
+  calculateFares,
+  getLegModeLabel,
+  getModeForPlace,
+  getPlaceName,
+  getStepDirection,
+  getStepInstructions,
+  getStepStreetName,
+  getTransitFare
+} from "./deprecated";
+
+export {
+  calculateFares,
+  getLegModeLabel,
+  getModeForPlace,
+  getPlaceName,
+  getStepDirection,
+  getStepInstructions,
+  getStepStreetName,
+  getTransitFare
+};
+
 // All OTP transit modes
 export const transitModes = [
   "TRAM",
@@ -159,51 +181,6 @@ export function getMapColor(mode) {
   return "#aaa";
 }
 
-// TODO: temporary code; handle via migrated OTP i18n language table
-export function getStepDirection(step) {
-  switch (step.relativeDirection) {
-    case "DEPART":
-      return `Head ${step.absoluteDirection.toLowerCase()}`;
-    case "LEFT":
-      return "Left";
-    case "HARD_LEFT":
-      return "Hard left";
-    case "SLIGHTLY_LEFT":
-      return "Slight left";
-    case "CONTINUE":
-      return "Continue";
-    case "SLIGHTLY_RIGHT":
-      return "Slight right";
-    case "RIGHT":
-      return "Right";
-    case "HARD_RIGHT":
-      return "Hard right";
-    case "CIRCLE_CLOCKWISE":
-      return "Follow circle clockwise";
-    case "CIRCLE_COUNTERCLOCKWISE":
-      return "Follow circle counterclockwise";
-    case "ELEVATOR":
-      return "Take elevator";
-    case "UTURN_LEFT":
-      return "Left U-turn";
-    case "UTURN_RIGHT":
-      return "Right U-turn";
-    default:
-      return step.relativeDirection;
-  }
-}
-
-export function getStepInstructions(step) {
-  const conjunction = step.relativeDirection === "ELEVATOR" ? "to" : "on";
-  return `${getStepDirection(step)} ${conjunction} ${step.streetName}`;
-}
-
-export function getStepStreetName(step) {
-  if (step.streetName === "road") return "Unnamed Road";
-  if (step.streetName === "path") return "Unnamed Path";
-  return step.streetName;
-}
-
 export function toSentenceCase(str) {
   if (str == null) {
     return "";
@@ -231,25 +208,6 @@ export function getCompanyFromLeg(leg) {
     return from.networks[0];
   }
   return null;
-}
-
-export function getLegModeLabel(leg) {
-  switch (leg.mode) {
-    case "BICYCLE_RENT":
-      return "Biketown";
-    case "CAR":
-      return leg.hailedCar ? "Ride" : "Drive";
-    case "GONDOLA":
-      return "Aerial Tram";
-    case "TRAM":
-      if (leg.routeLongName.toLowerCase().indexOf("streetcar") !== -1)
-        return "Streetcar";
-      return "Light Rail";
-    case "MICROMOBILITY":
-      return "Ride";
-    default:
-      return toSentenceCase(leg.mode);
-  }
 }
 
 export function getItineraryBounds(itinerary) {
@@ -400,7 +358,7 @@ export function getTextWidth(text, font = "22px Arial") {
  * Get the configured company object for the given network string if the company
  * has been defined in the provided companies array config.
  */
-function getCompanyForNetwork(networkString, companies = []) {
+export function getCompanyForNetwork(networkString, companies = []) {
   const company = companies.find(co => co.id === networkString);
   if (!company) {
     console.warn(
@@ -426,47 +384,6 @@ export function getCompaniesLabelFromNetworks(networks, companies = []) {
     .join("/");
 }
 
-/**
- * Returns mode name by checking the vertex type (VertexType class in OTP) for
- * the provided place. NOTE: this is currently only intended for vehicles at
- * the moment (not transit or walking).
- *
- * TODO: I18N
- * @param  {string} place place from itinerary leg
- */
-export function getModeForPlace(place) {
-  switch (place.vertexType) {
-    case "CARSHARE":
-      return "car";
-    case "VEHICLERENTAL":
-      return "E-scooter";
-    // TODO: Should the type change depending on bike vertex type?
-    case "BIKESHARE":
-    case "BIKEPARK":
-      return "bike";
-    // If company offers more than one mode, default to `vehicle` string.
-    default:
-      return "vehicle";
-  }
-}
-
-export function getPlaceName(place, companies) {
-  // If address is provided (i.e. for carshare station, use it)
-  if (place.address) return place.address.split(",")[0];
-  if (place.networks && place.vertexType === "VEHICLERENTAL") {
-    // For vehicle rental pick up, do not use the place name. Rather, use
-    // company name + vehicle type (e.g., SPIN E-scooter). Place name is often just
-    // a UUID that has no relevance to the actual vehicle. For bikeshare, however,
-    // there are often hubs or bikes that have relevant names to the user.
-    const company = getCompanyForNetwork(place.networks[0], companies);
-    if (company) {
-      return `${company.label} ${getModeForPlace(place)}`;
-    }
-  }
-  // Default to place name
-  return place.name;
-}
-
 export function getTNCLocation(leg, type) {
   const location = leg[type];
   return `${location.lat.toFixed(5)},${location.lon.toFixed(5)}`;
@@ -488,121 +405,6 @@ export function calculatePhysicalActivity(itinerary) {
   };
 }
 
-/**
- * For a given fare component (either total fare or component parts), returns
- * an object with string formatters and the fare value (in cents).
- */
-export function getTransitFare(fareComponent) {
-  // Default values (if fare component is not valid).
-  let digits = 2;
-  let transitFare = 0;
-  let symbol = "$";
-  let currencyCode = "USD";
-  if (fareComponent) {
-    // Assign values without declaration. See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#assignment_without_declaration
-    ({
-      currencyCode,
-      defaultFractionDigits: digits,
-      symbol
-    } = fareComponent.currency);
-    transitFare = fareComponent.cents;
-  }
-  // For cents to string conversion, use digits from fare component.
-  const centsToString = cents => {
-    const dollars = (cents / 10 ** digits).toFixed(digits);
-    return `${symbol}${dollars}`;
-  };
-  // For dollars to string conversion, assume we're rounding to two digits.
-  const dollarsToString = dollars => `${symbol}${dollars.toFixed(2)}`;
-  return {
-    centsToString,
-    currencyCode,
-    dollarsToString,
-    transitFare
-  };
-}
-
-/**
- * For an itinerary, calculates the transit/TNC fares and returns an object with
- * these values, currency info, as well as string formatters.
- * It is assumed that the same currency is used for transit and TNC legs.
- *
- * multiple being set to true will change the output behavior:
- * - dollarsToString and centsToString will be returned as part of each fare
- * - currencyCode will be returned separately for each fare
- * - tnc currency code will be returned separately
- * - each fare type will be returned separately within a new transitFares property
- *
- * FIXME: a new approach to fare calculation must be found:
- * the current approach is not sustainable, as centsToString and DollarsToString
- * must be replaced by i18n anyway.
- *
- * However, the current behavior should ideally be kept to avoid a breaking change.
- * The "multiple" mode is helpful, but only prevents tnc fare calculation from being duplicated.
- * This method could be split out into a new one, along with tnc fare calculation.
- * If this is done, the individual fare calculation should also be modified to support
- * a default fare not being called "regular". However, this again would be a breaking change.
- * This breaking change is avoided by adding the "multiple" parameter.
- *
- * When centsToString and dollarsToString are removed, this method should be split into
- * individual fare calculation on a variable fare key, fare calculation of an entire leg,
- * which will get fares for every fare key in the leg, and a method to calculate the fare of
- * a tnc ride within the leg. This will make typescripting easier, as the types will be cleaner.
- */
-export function calculateFares(itinerary, multiple = false) {
-  // Process any TNC fares
-  let minTNCFare = 0;
-  let maxTNCFare = 0;
-  let tncCurrencyCode;
-  itinerary.legs.forEach(leg => {
-    if (leg.mode === "CAR" && leg.hailedCar && leg.tncData) {
-      const { currency, maxCost, minCost } = leg.tncData;
-      // TODO: Support non-USD
-      minTNCFare += minCost;
-      maxTNCFare += maxCost;
-      tncCurrencyCode = currency;
-    }
-  });
-
-  if (multiple) {
-    // Return object of fares
-    const transitFares = {};
-    if (itinerary && itinerary.fare && itinerary.fare.fare) {
-      Object.keys(itinerary.fare.fare).forEach(fareKey => {
-        const fareComponent = itinerary.fare.fare[fareKey];
-        transitFares[fareKey] = getTransitFare(fareComponent);
-      });
-    }
-
-    return {
-      maxTNCFare,
-      minTNCFare,
-      tncCurrencyCode,
-      transitFares
-    };
-  }
-
-  // Extract fare total from itinerary fares.
-  const fareComponent =
-    itinerary.fare && itinerary.fare.fare && itinerary.fare.fare.regular;
-  // Get string formatters and itinerary fare.
-  const {
-    centsToString,
-    currencyCode: transitCurrencyCode,
-    dollarsToString,
-    transitFare
-  } = getTransitFare(fareComponent);
-
-  return {
-    centsToString,
-    currencyCode: transitCurrencyCode || tncCurrencyCode,
-    dollarsToString,
-    maxTNCFare,
-    minTNCFare,
-    transitFare
-  };
-}
-
 export function getTimeZoneOffset(itinerary) {
   if (!itinerary.legs || !itinerary.legs.length) return 0;
 
@@ -615,4 +417,14 @@ export function getTimeZoneOffset(itinerary) {
     itinerary.legs[0].agencyTimeZoneOffset +
     (new Date().getTimezoneOffset() + dstOffset) * 60000
   );
+}
+
+export function calculateTncFares(itinerary) {
+  // TODO: don't rely on deprecated methods!
+  // At the moment this is safe as none of these exported variables contain strings
+  const { maxTNCFare, minTNCFare, tncCurrencyCode } = calculateFares(
+    itinerary,
+    true
+  );
+  return { maxTNCFare, minTNCFare, tncCurrencyCode };
 }

--- a/packages/core-utils/src/map.js
+++ b/packages/core-utils/src/map.js
@@ -1,17 +1,13 @@
-import moment from "moment";
-
 import { getPlaceName, isTransit, isFlex, toSentenceCase } from "./itinerary";
 
-export function latlngToString(latlng) {
-  return (
-    latlng &&
-    `${latlng.lat.toFixed(5)}, ${(latlng.lng || latlng.lon).toFixed(5)}`
-  );
-}
+import {
+  coordsToString,
+  getDetailText,
+  latlngToString,
+  logDeprecationWarning
+} from "./deprecated";
 
-export function coordsToString(coords) {
-  return coords.length && coords.map(c => (+c).toFixed(5)).join(", ");
-}
+export { coordsToString, getDetailText, latlngToString };
 
 export function currentPositionToLocation(currentPosition) {
   if (currentPosition.error || !currentPosition.coords) {
@@ -23,7 +19,6 @@ export function currentPositionToLocation(currentPosition) {
   return {
     lat: currentPosition.coords.latitude,
     lon: currentPosition.coords.longitude,
-    name: "(Current Location)",
     category: "CURRENT_LOCATION"
   };
 }
@@ -34,26 +29,16 @@ export function stringToCoords(str) {
 
 export function constructLocation(latlng) {
   return {
-    name: latlngToString(latlng),
     lat: latlng.lat,
     lon: latlng.lng
   };
 }
 
-export function getDetailText(location) {
-  let detailText;
-  if (location.type === "home" || location.type === "work") {
-    detailText = location.name;
-  }
-  if (location.type === "stop") {
-    detailText = location.id;
-  } else if (location.type === "recent" && location.timestamp) {
-    detailText = moment(location.timestamp).fromNow();
-  }
-  return detailText;
-}
-
 export function formatStoredPlaceName(location, withDetails = true) {
+  if (withDetails) {
+    logDeprecationWarning("formatStoredPlaceName withDetails parameter");
+  }
+
   let displayName =
     location.type === "home" || location.type === "work"
       ? toSentenceCase(location.type)
@@ -99,6 +84,7 @@ export function itineraryToTransitive(
 
   const journey = {
     journey_id: "itin",
+    // This string is not shown in the UI
     journey_name: "Iterarary-derived Journey",
     segments: []
   };
@@ -205,6 +191,7 @@ export function itineraryToTransitive(
       const ptnId = `ptn_${patternId}`;
       const pattern = {
         pattern_id: ptnId,
+        // This string is not shown in the UI
         pattern_name: `Pattern ${patternId}`,
         route_id: leg.routeId,
         stops: []

--- a/packages/core-utils/src/map.js
+++ b/packages/core-utils/src/map.js
@@ -36,7 +36,7 @@ export function constructLocation(latlng) {
 
 export function formatStoredPlaceName(location, withDetails = true) {
   if (withDetails) {
-    logDeprecationWarning("formatStoredPlaceName withDetails parameter");
+    logDeprecationWarning("the formatStoredPlaceName withDetails parameter");
   }
 
   let displayName =
@@ -166,6 +166,7 @@ export function itineraryToTransitive(
       });
       tdata.places.push({
         place_id: toPlaceId,
+        // This string is not shown in the UI
         place_name: getPlaceName(leg.to, companies),
         place_lat: leg.to.lat,
         place_lon: leg.to.lon

--- a/packages/core-utils/src/messages.js
+++ b/packages/core-utils/src/messages.js
@@ -1,3 +1,5 @@
+// This entire file can be removed once deprecation goes forward
+import { logDeprecationWarning } from "./deprecated";
 /**
  * Takes component's default props messages and its instance props messages and
  * returns the merged messages. The returned object will ensure that the default
@@ -7,6 +9,8 @@
  */
 /* eslint-disable import/prefer-default-export */
 export function mergeMessages(defaultPropsMessages, propsMessages) {
+  logDeprecationWarning("mergeMessages");
+
   const defaultMessages = defaultPropsMessages || {};
   const instanceMessages = propsMessages || {};
   return {

--- a/packages/core-utils/src/profile.js
+++ b/packages/core-utils/src/profile.js
@@ -27,8 +27,8 @@ export function filterProfileOptions(response) {
   return response;
 }
 
-function locationString(str, defaultStr) {
-  return str ? str.split(",")[0] : defaultStr;
+function locationString(str) {
+  return str ? str.split(",")[0] : null;
 }
 
 function accessToLeg(access, origin, destination) {
@@ -37,10 +37,10 @@ function accessToLeg(access, origin, destination) {
     duration: access.time,
     transitLeg: false,
     from: {
-      name: locationString(origin, "Origin")
+      name: locationString(origin)
     },
     to: {
-      name: locationString(destination, "Destination")
+      name: locationString(destination)
     }
   };
 }
@@ -98,7 +98,7 @@ function optionToItinerary(option, query) {
         duration: walkOnTime,
         transitLeg: false,
         from: {
-          name: locationString(query && query.from.name, "Destination")
+          name: locationString(query && query.from.name)
         },
         to: {
           name: onStationName
@@ -127,7 +127,7 @@ function optionToItinerary(option, query) {
           name: offStationName
         },
         to: {
-          name: locationString(query && query.to.name, "Destination")
+          name: locationString(query && query.to.name)
         }
       });
     } else {
@@ -176,16 +176,6 @@ function optionToItinerary(option, query) {
     if (option.egress[0].mode === "WALK")
       itin.walkTime += option.egress[0].time;
   }
-
-  // construct summary
-  if (option.transit) {
-    itin.summary = "Transit";
-  } else if (option.modes.length === 1 && option.modes[0] === "bicycle")
-    itin.summary = "Bicycle";
-  else if (option.modes.length === 1 && option.modes[0] === "walk")
-    itin.summary = "Walk";
-  else if (option.modes.indexOf("bicycle_rent") !== -1)
-    itin.summary = "Bikeshare";
 
   return itin;
 }

--- a/packages/core-utils/src/query-params.js
+++ b/packages/core-utils/src/query-params.js
@@ -1,3 +1,7 @@
+// TODO: Remove this entire file, as it is deprecated in favor of i18n-queryParams within
+// the SettingsSelector package
+
+// This is only used within stories
 import cloneDeep from "lodash.clonedeep";
 import React from "react";
 import { Wheelchair } from "@styled-icons/foundation/Wheelchair";
@@ -54,10 +58,14 @@ import { getCurrentDate, getCurrentTime } from "./time";
 /**
  * Format location object as string for use in fromPlace or toPlace query param.
  */
-export function formatPlace(location, alternateName = "Place") {
+export function formatPlace(location, alternateName) {
   if (!location) return null;
   const name =
-    location.name || `${alternateName} (${location.lat},${location.lon})`;
+    location.name ||
+    `${alternateName ? `${alternateName} ` : ""}(${location.lat},${
+      location.lon
+    })`;
+  // This string is not language-specific
   return `${name}::${location.lat},${location.lon}`;
 }
 
@@ -70,7 +78,7 @@ const queryParams = [
     name: "from",
     routingTypes: ["ITINERARY", "PROFILE"],
     default: null,
-    itineraryRewrite: value => ({ fromPlace: formatPlace(value, "Origin") }),
+    itineraryRewrite: value => ({ fromPlace: formatPlace(value) }),
     profileRewrite: value => ({ from: { lat: value.lat, lon: value.lon } })
     // FIXME: Use for parsing URL values?
     // fromURL: stringToLocation
@@ -81,7 +89,7 @@ const queryParams = [
     name: "to",
     routingTypes: ["ITINERARY", "PROFILE"],
     default: null,
-    itineraryRewrite: value => ({ toPlace: formatPlace(value, "Destination") }),
+    itineraryRewrite: value => ({ toPlace: formatPlace(value) }),
     profileRewrite: value => ({ to: { lat: value.lat, lon: value.lon } })
     // FIXME: Use for parsing URL values?
     // fromURL: stringToLocation

--- a/packages/core-utils/src/query.js
+++ b/packages/core-utils/src/query.js
@@ -12,7 +12,7 @@ import {
   OTP_API_TIME_FORMAT
 } from "./time";
 
-import { summarizeQuery } from "./deprecated";
+import { coordsToString, summarizeQuery } from "./deprecated";
 
 export { summarizeQuery };
 
@@ -257,7 +257,7 @@ export function parseLocationString(value) {
   const coordinates = parts[1]
     ? stringToCoords(parts[1])
     : stringToCoords(parts[0]);
-  const name = parts[1] ? parts[0] : null;
+  const name = parts[1] ? parts[0] : coordsToString(coordinates);
   return coordinates.length === 2
     ? {
         name: name || null,

--- a/packages/core-utils/src/query.js
+++ b/packages/core-utils/src/query.js
@@ -3,7 +3,7 @@ import getGeocoder from "@opentripplanner/geocoder/lib";
 import qs from "qs";
 
 import { getTransitModes, hasCar, isAccessMode } from "./itinerary";
-import { coordsToString, stringToCoords } from "./map";
+import { stringToCoords } from "./map";
 import queryParams from "./query-params";
 import {
   getCurrentTime,
@@ -257,7 +257,7 @@ export function parseLocationString(value) {
   const coordinates = parts[1]
     ? stringToCoords(parts[1])
     : stringToCoords(parts[0]);
-  const name = parts[1] ? parts[0] : coordsToString(coordinates);
+  const name = parts[1] ? parts[0] : null;
   return coordinates.length === 2
     ? {
         name: name || null,

--- a/packages/core-utils/src/query.js
+++ b/packages/core-utils/src/query.js
@@ -2,14 +2,8 @@ import moment from "moment";
 import getGeocoder from "@opentripplanner/geocoder/lib";
 import qs from "qs";
 
-import {
-  getTransitModes,
-  hasCar,
-  hasTransit,
-  isAccessMode,
-  toSentenceCase
-} from "./itinerary";
-import { coordsToString, matchLatLon, stringToCoords } from "./map";
+import { getTransitModes, hasCar, isAccessMode } from "./itinerary";
+import { coordsToString, stringToCoords } from "./map";
 import queryParams from "./query-params";
 import {
   getCurrentTime,
@@ -17,6 +11,10 @@ import {
   OTP_API_DATE_FORMAT,
   OTP_API_TIME_FORMAT
 } from "./time";
+
+import { summarizeQuery } from "./deprecated";
+
+export { summarizeQuery };
 
 /* The list of default parameters considered in the settings panel */
 
@@ -82,24 +80,6 @@ export function getUrlParams() {
 
 export function getOtpUrlParams() {
   return Object.keys(getUrlParams()).filter(key => !key.startsWith("ui_"));
-}
-
-function findLocationType(
-  location,
-  locations = [],
-  types = ["home", "work", "suggested"]
-) {
-  const match = locations.find(l => matchLatLon(l, location));
-  return match && types.indexOf(match.type) !== -1 ? match.type : null;
-}
-
-export function summarizeQuery(query, locations = []) {
-  const from =
-    findLocationType(query.from, locations) || query.from.name.split(",")[0];
-  const to =
-    findLocationType(query.to, locations) || query.to.name.split(",")[0];
-  const mode = hasTransit(query.mode) ? "Transit" : toSentenceCase(query.mode);
-  return `${mode} from ${from} to ${to}`;
 }
 
 export function getTripOptionsFromQuery(query, keepPlace = false) {

--- a/packages/core-utils/src/time.js
+++ b/packages/core-utils/src/time.js
@@ -23,7 +23,11 @@ export const OTP_API_TIME_FORMAT = "HH:mm";
  * Otherwise, uses date-fns default
  * @returns                   Formatted duration
  */
-function formatDurationLikeMoment(seconds, showSeconds, localize = true) {
+function formatDurationLikeMoment(
+  seconds,
+  showSeconds,
+  localize = { enabled: true, code: "en-US" }
+) {
   // date-fns doesn't do this automatically
   if ((!showSeconds && seconds < 60) || seconds === 0) {
     return "0 min";
@@ -41,7 +45,8 @@ function formatDurationLikeMoment(seconds, showSeconds, localize = true) {
   };
   const locale = localize
     ? {
-        code: "en-US",
+        // Maintain backwards compatibility when called with localize=true
+        code: localize?.code || "en-US",
         formatDistance: (spec, val) => {
           return `${val} ${specLookup[spec]}`;
         }
@@ -92,8 +97,8 @@ export function formatDuration(seconds) {
  * @param {number} seconds duration in seconds
  * @returns {string} formatted text representation
  */
-export function formatDurationWithSeconds(seconds) {
-  return formatDurationLikeMoment(seconds, true);
+export function formatDurationWithSeconds(seconds, region) {
+  return formatDurationLikeMoment(seconds, { enabled: true, code: region });
 }
 /**
  * Formats a time value for display in narrative


### PR DESCRIPTION
No breaking changes at this point. All depurated functions are still present, just moved outside of where they used to be. Backwards compatibility was the focus, although some parameters that were not used have been removed. 