### PR TITLE
Add walk reluctance to `core-utils`

### DIFF
--- a/packages/core-utils/src/__tests__/__snapshots__/query-params.js.snap
+++ b/packages/core-utils/src/__tests__/__snapshots__/query-params.js.snap
@@ -247,6 +247,19 @@ Array [
   },
   Object {
     "applicable": [Function],
+    "high": 20,
+    "label": "walk reluctance",
+    "low": 0.5,
+    "name": "walkReluctance",
+    "routingTypes": Array [
+      "ITINERARY",
+      "PROFILE",
+    ],
+    "selector": "SLIDER",
+    "step": 0.5,
+  },
+  Object {
+    "applicable": [Function],
     "default": 20,
     "label": "Max Bike Time",
     "name": "maxBikeTime",
@@ -458,12 +471,6 @@ Array [
   },
   Object {
     "name": "maxPreTransitTime",
-    "routingTypes": Array [
-      "ITINERARY",
-    ],
-  },
-  Object {
-    "name": "walkReluctance",
     "routingTypes": Array [
       "ITINERARY",
     ],

--- a/packages/core-utils/src/query-params.js
+++ b/packages/core-utils/src/query-params.js
@@ -168,7 +168,10 @@ const queryParams = [
     name: "maxWalkDistance",
     routingTypes: ["ITINERARY"],
     applicable: query =>
-      query.mode && hasTransit(query.mode) && query.mode.indexOf("WALK") !== -1,
+      !query.otp2 &&
+      query.mode &&
+      hasTransit(query.mode) &&
+      query.mode.indexOf("WALK") !== -1,
     default: 1207, // 3/4 mi.
     selector: "DROPDOWN",
     label: "Maximum Walk",
@@ -390,6 +393,17 @@ const queryParams = [
     ]
   },
 
+  {
+    name: "walkReluctance",
+    routingTypes: ["ITINERARY", "PROFILE"],
+    selector: "SLIDER",
+    low: 0.5,
+    high: 20,
+    step: 0.5,
+    label: "walk reluctance",
+    applicable: query =>
+      !!query.otp2 && query.mode && query.mode.indexOf("WALK") !== -1
+  },
   {
     /* maxBikeTime -- the maximum time the user will spend biking in minutes */
     name: "maxBikeTime",
@@ -671,10 +685,6 @@ const queryParams = [
   },
   {
     name: "maxPreTransitTime",
-    routingTypes: ["ITINERARY"]
-  },
-  {
-    name: "walkReluctance",
     routingTypes: ["ITINERARY"]
   },
   {

--- a/packages/core-utils/src/query-params.js
+++ b/packages/core-utils/src/query-params.js
@@ -168,6 +168,10 @@ const queryParams = [
     name: "maxWalkDistance",
     routingTypes: ["ITINERARY"],
     applicable: query =>
+      /* Since this query variable isn't in this list, it's not included in the generated query
+       * It does however allow us to determine if we should show the OTP1 max walk distance
+       * dropdown or the OTP2 walk reluctance slider
+       */
       !query.otp2 &&
       query.mode &&
       hasTransit(query.mode) &&
@@ -402,6 +406,10 @@ const queryParams = [
     step: 0.5,
     label: "walk reluctance",
     applicable: query =>
+      /* Since this query variable isn't in this list, it's not included in the generated query
+       * It does however allow us to determine if we should show the OTP1 max walk distance
+       * dropdown or the OTP2 walk reluctance slider
+       */
       !!query.otp2 && query.mode && query.mode.indexOf("WALK") !== -1
   },
   {

--- a/packages/core-utils/src/query.js
+++ b/packages/core-utils/src/query.js
@@ -29,7 +29,8 @@ export const defaultParams = [
   "optimize",
   "optimizeBike",
   "maxEScooterDistance",
-  "watts"
+  "watts",
+  "walkReluctance"
 ];
 
 /**

--- a/packages/core-utils/src/query.js
+++ b/packages/core-utils/src/query.js
@@ -21,6 +21,7 @@ export { summarizeQuery };
 export const defaultParams = [
   "wheelchair",
   "maxWalkDistance",
+  "walkReluctance",
   "maxWalkTime",
   "walkSpeed",
   "maxBikeDistance",
@@ -29,8 +30,7 @@ export const defaultParams = [
   "optimize",
   "optimizeBike",
   "maxEScooterDistance",
-  "watts",
-  "walkReluctance"
+  "watts"
 ];
 
 /**


### PR DESCRIPTION
A stub was present, but this PR adds a full entry for it. A new `otp2` field in the query object is used to switch between walk reluctance and the max walk distance, which is no longer supported by OTP2.