### PR TITLE
better screen reader support

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -27,12 +27,17 @@ export const parameters = {
           reviewOnFail: true,
         },
         {
-          // Appears to be a story bug
+          // Appears to be a bug with our stories (they do some weird hacks that are not done in production)
           id: "duplicate-id",
           reviewOnFail: true
         },
         {
-          // Appears to be a story bug
+          // Appears to be a bug with our stories (they do some weird hacks that are not done in production)
+          id: "duplicate-id-active",
+          reviewOnFail: true
+        },
+        {
+          // Appears to be a bug with our stories (they do some weird hacks that are not done in production)
           id: "duplicate-id-aria",
           reviewOnFail: true
         }

--- a/packages/itinerary-body/src/AccessLegBody/index.tsx
+++ b/packages/itinerary-body/src/AccessLegBody/index.tsx
@@ -104,7 +104,7 @@ class AccessLegBody extends Component<Props, State> {
             showLegIcon={showLegIcon}
           />
           <S.StepsHeader
-            aria-roledescription="dropdown"
+            role="button"
             aria-expanded={expanded}
             onClick={this.onStepsHeaderClick}
           >

--- a/packages/itinerary-body/src/AccessLegBody/index.tsx
+++ b/packages/itinerary-body/src/AccessLegBody/index.tsx
@@ -104,6 +104,7 @@ class AccessLegBody extends Component<Props, State> {
             showLegIcon={showLegIcon}
           />
           <S.StepsHeader
+            aria-roledescription="dropdown"
             aria-expanded={expanded}
             onClick={this.onStepsHeaderClick}
           >

--- a/packages/trip-details/src/index.tsx
+++ b/packages/trip-details/src/index.tsx
@@ -182,7 +182,7 @@ export function TripDetails({
       <S.Fare>
         <TransitFareWrapper>
           <summary
-            aria-roledescription="dropdown"
+            role="button"
             style={{ display: fareKeys.length > 1 ? "list-item" : "" }}
           >
             <TransitFare

--- a/packages/trip-details/src/index.tsx
+++ b/packages/trip-details/src/index.tsx
@@ -181,7 +181,10 @@ export function TripDetails({
     fare = (
       <S.Fare>
         <TransitFareWrapper>
-          <summary style={{ display: fareKeys.length > 1 ? "list-item" : "" }}>
+          <summary
+            aria-roledescription="dropdown"
+            style={{ display: fareKeys.length > 1 ? "list-item" : "" }}
+          >
             <TransitFare
               fareNameFallback={
                 <FormattedMessage

--- a/packages/trip-form/src/DateTimeSelector/index.tsx
+++ b/packages/trip-form/src/DateTimeSelector/index.tsx
@@ -220,6 +220,7 @@ export default function DateTimeSelector({
         {departureOptions.map(opt => (
           <ModeButton
             key={opt.type}
+            uniqueId={opt.type}
             onClick={setDepartArrive(opt)}
             selected={opt.isSelected}
           >

--- a/packages/trip-form/src/ModeButton/index.tsx
+++ b/packages/trip-form/src/ModeButton/index.tsx
@@ -58,6 +58,8 @@ export default function ModeButton({
   const activeClassName = selected ? "active" : "";
   const disabledClassName = enabled ? "" : "disabled";
 
+  const buttonId = `${title.replace(" ", "-")}-button`;
+
   return (
     <S.ModeButton className={className} style={style}>
       <S.ModeButton.Button
@@ -67,12 +69,14 @@ export default function ModeButton({
         disabled={!enabled}
         onClick={onClick}
         title={title}
+        id={buttonId}
       >
         {children}
       </S.ModeButton.Button>
 
       {title && showTitle && (
         <S.ModeButton.Title
+          aria-labelledby={buttonId}
           className={`${activeClassName} ${disabledClassName}`}
           title={title}
         >

--- a/packages/trip-form/src/ModeButton/index.tsx
+++ b/packages/trip-form/src/ModeButton/index.tsx
@@ -58,7 +58,9 @@ export default function ModeButton({
   const activeClassName = selected ? "active" : "";
   const disabledClassName = enabled ? "" : "disabled";
 
-  const buttonId = `${title?.replace(/ /g, "-")}-button`;
+  const buttonId = `${title?.replace(/ /g, "-")}-button-${Math.floor(
+    Math.random() * 1_000_000_000
+  )}`;
 
   return (
     <S.ModeButton className={className} style={style}>

--- a/packages/trip-form/src/ModeButton/index.tsx
+++ b/packages/trip-form/src/ModeButton/index.tsx
@@ -62,6 +62,7 @@ export default function ModeButton({
     <S.ModeButton className={className} style={style}>
       <S.ModeButton.Button
         aria-pressed={selected}
+        aria-label={title}
         className={`${activeClassName} ${disabledClassName}`}
         disabled={!enabled}
         onClick={onClick}

--- a/packages/trip-form/src/ModeButton/index.tsx
+++ b/packages/trip-form/src/ModeButton/index.tsx
@@ -58,7 +58,7 @@ export default function ModeButton({
   const activeClassName = selected ? "active" : "";
   const disabledClassName = enabled ? "" : "disabled";
 
-  const buttonId = `${title.replace(/ /g, "-")}-button`;
+  const buttonId = `${title?.replace(/ /g, "-")}-button`;
 
   return (
     <S.ModeButton className={className} style={style}>

--- a/packages/trip-form/src/ModeButton/index.tsx
+++ b/packages/trip-form/src/ModeButton/index.tsx
@@ -37,6 +37,10 @@ interface ModeButtonProps {
    * Standard React inline style prop.
    */
   style?: CSS.Properties;
+  /**
+   * Unique key used for generating a11y-mandated ID
+   */
+  uniqueId: string;
 }
 
 /**
@@ -53,14 +57,13 @@ export default function ModeButton({
   selected = false,
   showTitle = true,
   title = null,
-  style = null
+  style = null,
+  uniqueId
 }: ModeButtonProps): ReactElement {
   const activeClassName = selected ? "active" : "";
   const disabledClassName = enabled ? "" : "disabled";
 
-  const buttonId = `${title?.replace(/ /g, "-")}-button-${Math.floor(
-    Math.random() * 1_000_000_000
-  )}`;
+  const buttonId = `${title?.replace(/ /g, "-")}-button-${uniqueId}`;
 
   return (
     <S.ModeButton className={className} style={style}>

--- a/packages/trip-form/src/ModeButton/index.tsx
+++ b/packages/trip-form/src/ModeButton/index.tsx
@@ -58,7 +58,7 @@ export default function ModeButton({
   const activeClassName = selected ? "active" : "";
   const disabledClassName = enabled ? "" : "disabled";
 
-  const buttonId = `${title.replace(" ", "-")}-button`;
+  const buttonId = `${title.replace(/ /g, "-")}-button`;
 
   return (
     <S.ModeButton className={className} style={style}>

--- a/packages/trip-form/src/ModeSelector/index.tsx
+++ b/packages/trip-form/src/ModeSelector/index.tsx
@@ -53,6 +53,7 @@ export default function ModeSelector({
   const makeButton = (option: ModeSelectorOption): ReactElement => (
     <ModeButton
       key={option.id}
+      uniqueId={option.id}
       selected={option.selected}
       showTitle={option.showTitle}
       title={option.title}

--- a/packages/trip-form/src/SubmodeSelector/index.tsx
+++ b/packages/trip-form/src/SubmodeSelector/index.tsx
@@ -57,9 +57,10 @@ export default function SubmodeSelector({
       {label && <LabelType>{label}</LabelType>}
       <RowType>
         {modes &&
-          modes.map(option => (
+          modes.map(( option, index ) => (
             <ModeButton
               key={option.id}
+              uniqueId={option.id + index}
               selected={option.selected}
               showTitle={false}
               title={option.title}


### PR DESCRIPTION
Some packages had elements which caused issues with screen readers. This PR addresses these by adding relevant aria tags.

### TODO:
~- [ ] icons are still rendered as svg without aria labels~
- [ ] correctly apply aria tags via styled components
- [ ] `transitFareWrapper` needs to be an aria button only when it has children.
- [ ] `transitFareWrapper` needs to be adjusted to match html spec
- [ ] internal `core-utils` versions need to be updated