### PR TITLE
feat(FromToLocationPicker): Add label prop.

### DIFF
--- a/packages/from-to-location-picker/i18n/en-US.yml
+++ b/packages/from-to-location-picker/i18n/en-US.yml
@@ -11,4 +11,5 @@
 otpUi:
   FromToLocationPicker:
     from: From here
+    planATrip: "Plan a trip:"
     to: To here

--- a/packages/from-to-location-picker/i18n/fr.yml
+++ b/packages/from-to-location-picker/i18n/fr.yml
@@ -11,4 +11,5 @@
 otpUi:
   FromToLocationPicker:
     from: Départ
+    planATrip: "Plannifier un trajet :"
     to: Arrivée

--- a/packages/from-to-location-picker/src/index.story.tsx
+++ b/packages/from-to-location-picker/src/index.story.tsx
@@ -20,8 +20,11 @@ export const fromTo = (): ReactElement => (
 
 export const smallTextSansSerif = (): ReactElement => (
   <span style={{ fontSize: "75%", fontFamily: "sans-serif" }}>
-    Plan a trip:
-    <FromToLocationPicker onFromClick={onFromClick} onToClick={onToClick} />
+    <FromToLocationPicker
+      label
+      onFromClick={onFromClick}
+      onToClick={onToClick}
+    />
   </span>
 );
 
@@ -35,9 +38,10 @@ export const customStyleAndText = (): React.ReactElement => (
   >
     <div className="trimet-ambient">
       <FromToLocationPicker
-        showIcons={false}
+        label={<i style={{ color: "#ffff00" }}>Your trip:</i>}
         onFromClick={onFromClick}
         onToClick={onToClick}
+        showIcons={false}
       />
     </div>
   </IntlProvider>

--- a/packages/from-to-location-picker/src/index.tsx
+++ b/packages/from-to-location-picker/src/index.tsx
@@ -1,7 +1,7 @@
 import flatten from "flat";
 import LocationIcon from "@opentripplanner/location-icon";
 import { FormattedMessage } from "react-intl";
-import React from "react";
+import React, { ReactElement } from "react";
 
 import * as S from "./styled";
 
@@ -20,12 +20,13 @@ const iconSize = "0.9em";
 const defaultMessages: Record<string, string> = flatten(defaultEnglishMessages);
 
 const FromToLocationPicker = ({
+  label = null,
   location = null,
   onFromClick = null,
   onToClick = null,
   setLocation = null,
   showIcons = true
-}: FromToPickerProps): React.ReactElement => {
+}: FromToPickerProps): ReactElement => {
   const handleFromClick = () => {
     if (onFromClick) {
       onFromClick();
@@ -50,29 +51,44 @@ const FromToLocationPicker = ({
     });
   };
 
+  const labelIfAny = label === true
+    ? (
+    <strong>
+      <FormattedMessage
+        defaultMessage={defaultMessages["otpUi.FromToLocationPicker.planATrip"]}
+        description="Label to prompt the user to plan a trip"
+        id="otpUi.FromToLocationPicker.planATrip"
+      />
+    </strong>
+    )
+    : label
+
   return (
-    <S.FromToPickerSpan>
-      <S.LocationPickerSpan>
-        {showIcons && <LocationIcon type="from" size={iconSize} />}
-        <S.Button onClick={handleFromClick}>
-          <FormattedMessage
-            defaultMessage={defaultMessages["otpUi.FromToLocationPicker.from"]}
-            description="Text for the 'from' button of the picker"
-            id="otpUi.FromToLocationPicker.from"
-          />
-        </S.Button>
-      </S.LocationPickerSpan>
-      <S.LocationPickerSpan>
-        {showIcons && <LocationIcon type="to" size={iconSize} />}
-        <S.Button onClick={handleToClick}>
-          <FormattedMessage
-            defaultMessage={defaultMessages["otpUi.FromToLocationPicker.to"]}
-            description="Text for the 'to' button of the picker"
-            id="otpUi.FromToLocationPicker.to"
-          />
-        </S.Button>
-      </S.LocationPickerSpan>
-    </S.FromToPickerSpan>
+    <>
+      {labelIfAny}
+      <S.FromToPickerSpan>
+        <S.LocationPickerSpan>
+          {showIcons && <LocationIcon type="from" size={iconSize} />}
+          <S.Button onClick={handleFromClick}>
+            <FormattedMessage
+              defaultMessage={defaultMessages["otpUi.FromToLocationPicker.from"]}
+              description="Text for the 'from' button of the picker"
+              id="otpUi.FromToLocationPicker.from"
+            />
+          </S.Button>
+        </S.LocationPickerSpan>
+        <S.LocationPickerSpan>
+          {showIcons && <LocationIcon type="to" size={iconSize} />}
+          <S.Button onClick={handleToClick}>
+            <FormattedMessage
+              defaultMessage={defaultMessages["otpUi.FromToLocationPicker.to"]}
+              description="Text for the 'to' button of the picker"
+              id="otpUi.FromToLocationPicker.to"
+            />
+          </S.Button>
+        </S.LocationPickerSpan>
+      </S.FromToPickerSpan>
+    </>
   );
 };
 

--- a/packages/from-to-location-picker/src/types.ts
+++ b/packages/from-to-location-picker/src/types.ts
@@ -24,11 +24,11 @@ export type FromToPickerProps = {
   /**
    * Triggered when the user clicks on the "from" button.
    */
-  onFromClick: () => void;
+  onFromClick?: () => void;
   /**
    * Triggered when the user clicks on the "to" button.
    */
-  onToClick: () => void;
+  onToClick?: () => void;
   /**
    * Triggered when the user clicks either the "from" or "to" button and there
    * are no from/to specific handler functions defined as props.

--- a/packages/from-to-location-picker/src/types.ts
+++ b/packages/from-to-location-picker/src/types.ts
@@ -1,3 +1,5 @@
+import { ReactElement } from "react";
+
 export type Location = {
   lat: number;
   lon: number;
@@ -10,6 +12,10 @@ export type Location = {
 };
 
 export type FromToPickerProps = {
+  /**
+   * Specifies the label to be rendered, or if set to true, renders the default label "Plan a trip:".
+   */
+  label?: boolean | ReactElement | string;
   /**
    * A specific location to associate with this. This is only used when combined
    * with the setLocation prop.


### PR DESCRIPTION
This PR adds a `label` prop to the `FromToLocationPicker` component. If `label` is set to `true`, a default i18n-able label text is shown, that will simplify reusing message strings code in other packages in this repo and others that implement this component.