### PR TITLE
fix(core-utils): improve OTP2 support

### DIFF
--- a/packages/core-utils/src/__tests__/__snapshots__/query-params.js.snap
+++ b/packages/core-utils/src/__tests__/__snapshots__/query-params.js.snap
@@ -249,6 +249,8 @@ Array [
     "applicable": [Function],
     "high": 20,
     "label": "walk reluctance",
+    "labelHigh": "More Transit",
+    "labelLow": "More Walking",
     "low": 0.5,
     "name": "walkReluctance",
     "routingTypes": Array [

--- a/packages/core-utils/src/query-params.js
+++ b/packages/core-utils/src/query-params.js
@@ -278,7 +278,8 @@ const queryParams = [
   {
     /* optimize -- how to optimize a trip (non-bike, non-micromobility trips) */
     name: "optimize",
-    applicable: query => hasTransit(query.mode) && !hasBike(query.mode),
+    applicable: query =>
+      !query.otp2 && hasTransit(query.mode) && !hasBike(query.mode),
     routingTypes: ["ITINERARY"],
     default: "QUICK",
     selector: "DROPDOWN",
@@ -298,7 +299,7 @@ const queryParams = [
   {
     /* optimizeBike -- how to optimize an bike-based trip */
     name: "optimizeBike",
-    applicable: query => hasBike(query.mode),
+    applicable: query => !query.otp2 && hasBike(query.mode),
     routingTypes: ["ITINERARY"],
     default: "SAFE",
     selector: "DROPDOWN",
@@ -405,6 +406,8 @@ const queryParams = [
     high: 20,
     step: 0.5,
     label: "walk reluctance",
+    labelLow: "More Walking",
+    labelHigh: "More Transit",
     applicable: query =>
       /* Since this query variable isn't in this list, it's not included in the generated query
        * It does however allow us to determine if we should show the OTP1 max walk distance


### PR DESCRIPTION
This PR adds some more OTP2 support to `core-utils`. Most notably this fixes [#594](https://github.com/opentripplanner/otp-react-redux/issues/594) and provides support for #371