### PR TITLE
Add Typescript to `core-utils` - `from-to-picker` updates 

### DIFF
--- a/packages/from-to-location-picker/package.json
+++ b/packages/from-to-location-picker/package.json
@@ -22,7 +22,7 @@
     "url": "git+https://github.com/opentripplanner/otp-ui.git"
   },
   "scripts": {
-    "tsc": "tsc && echo Remove the @ts-expect-error exception in index.tsx once core-utils is typed!"
+    "tsc": "tsc"
   },
   "bugs": {
     "url": "https://github.com/opentripplanner/otp-ui/issues"

--- a/packages/from-to-location-picker/src/types.ts
+++ b/packages/from-to-location-picker/src/types.ts
@@ -1,21 +1,11 @@
-import { ReactElement } from "react";
-
-export type Location = {
-  lat: number;
-  lon: number;
-  name: string;
-  /**
-   * This is only used for locations that a user has saved. Can be either:
-   * "home" or "work"
-   */
-  type?: string;
-};
+// eslint-disable-next-line prettier/prettier
+import type { Location } from "@opentripplanner/types";
 
 export type FromToPickerProps = {
   /**
    * Specifies the label to be rendered, or if set to true, renders the default label "Plan a trip:".
    */
-  label?: boolean | ReactElement | string;
+  label?: boolean | React.ReactElement | string;
   /**
    * A specific location to associate with this. This is only used when combined
    * with the setLocation prop.
@@ -38,6 +28,7 @@ export type FromToPickerProps = {
    */
   setLocation?: ({
     locationType: string,
+    // eslint-disable-next-line @typescript-eslint/no-shadow
     location: Location,
     reverseGeocode: boolean
   }) => void;


### PR DESCRIPTION
As mentioned in https://github.com/opentripplanner/otp-ui/pull/367, `from-to-picker` changes had to be extracted to allow unit tests to pass