### PR TITLE
update internal dependency versions

### DIFF
--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -13,7 +13,7 @@
   "private": false,
   "dependencies": {
     "@mapbox/polyline": "^1.1.0",
-    "@opentripplanner/geocoder": "^1.1.2",
+    "@opentripplanner/geocoder": "^1.2.2",
     "@styled-icons/foundation": "^10.34.0",
     "@turf/along": "^6.0.1",
     "bowser": "^2.7.0",

--- a/packages/itinerary-body/package.json
+++ b/packages/itinerary-body/package.json
@@ -10,9 +10,9 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^4.8.0",
+    "@opentripplanner/core-utils": "^4.11.2",
     "@opentripplanner/humanize-distance": "^1.2.0",
-    "@opentripplanner/icons": "^1.2.1",
+    "@opentripplanner/icons": "^1.2.2",
     "@opentripplanner/location-icon": "^1.4.0",
     "@styled-icons/fa-solid": "^10.34.0",
     "@styled-icons/foundation": "^10.34.0",
@@ -31,8 +31,6 @@
   "bugs": {
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
-  "scripts": {
-    "tsc": "tsc"
-  },
+  "scripts": {},
   "gitHead": "0af1b7cda60bd4252b219dcf893e01c2acb2ed5d"
 }

--- a/packages/itinerary-body/package.json
+++ b/packages/itinerary-body/package.json
@@ -31,6 +31,8 @@
   "bugs": {
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
-  "scripts": {},
+  "scripts": {
+    "tsc": "tsc"
+  },
   "gitHead": "0af1b7cda60bd4252b219dcf893e01c2acb2ed5d"
 }

--- a/packages/itinerary-body/src/demos/index.tsx
+++ b/packages/itinerary-body/src/demos/index.tsx
@@ -65,7 +65,7 @@ export function CustomTransitLegSummary({
     /* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
     <div onClick={onClick}>
       {leg.duration && (
-        <span>Ride {coreUtils.time.formatDuration(leg.duration)}</span>
+        <span>Ride {coreUtils.time.formatDuration(leg.duration, "en-US")}</span>
       )}
       {leg.intermediateStops && (
         <span>

--- a/packages/printable-itinerary/package.json
+++ b/packages/printable-itinerary/package.json
@@ -10,10 +10,10 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/itinerary-body": "^3.0.0"
+    "@opentripplanner/itinerary-body": "^3.0.1"
   },
   "devDependencies": {
-    "@opentripplanner/icons": "^1.2.1"
+    "@opentripplanner/icons": "^1.2.2"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/trip-form/package.json
+++ b/packages/trip-form/package.json
@@ -10,8 +10,8 @@
   "types": "lib/index.d.ts",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^4.11.1",
-    "@opentripplanner/icons": "^1.2.1",
+    "@opentripplanner/core-utils": "^4.11.2",
+    "@opentripplanner/icons": "^1.2.2",
     "@styled-icons/bootstrap": "^10.34.0",
     "@styled-icons/boxicons-regular": "^10.38.0",
     "@styled-icons/fa-regular": "^10.34.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2852,33 +2852,6 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
-"@opentripplanner/core-utils@^4.11.1":
-  version "4.11.1"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-4.11.1.tgz#62f58ab0e318a4ccd27fe5171973770650725f99"
-  integrity sha512-S//G5KllmmzYUn6n9I7cL3cvacWlBfjFAU2MyzdsMKIOY1zXBSPHSbe10eQAccJXp73IUeBbGkInAepyCp7eUw==
-  dependencies:
-    "@mapbox/polyline" "^1.1.0"
-    "@opentripplanner/geocoder" "^1.1.2"
-    "@styled-icons/foundation" "^10.34.0"
-    "@turf/along" "^6.0.1"
-    bowser "^2.7.0"
-    date-fns "^2.23.0"
-    date-fns-tz "^1.1.4"
-    lodash.clonedeep "^4.5.0"
-    lodash.isequal "^4.5.0"
-    moment "^2.24.0"
-    prop-types "^15.7.2"
-    qs "^6.9.1"
-
-"@opentripplanner/from-to-location-picker@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/from-to-location-picker/-/from-to-location-picker-1.3.0.tgz#fa24a1e0e9b8df41b997ef766dbc2f67843db9f0"
-  integrity sha512-OHvGphABYQv075CuLqiw1CdONl6TYQMVw27CR5xr24wz6KVOhLokd5BEcHvKGJvhMtKDmU5csXUx6b42y58lww==
-  dependencies:
-    "@opentripplanner/core-utils" "^4.1.0"
-    "@opentripplanner/location-icon" "^1.3.0"
-    prop-types "^15.7.2"
-
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.1":
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.4.tgz#df0d0d855fc527db48aac93c218a0bf4ada41f99"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2852,6 +2852,15 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
+"@opentripplanner/from-to-location-picker@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/from-to-location-picker/-/from-to-location-picker-1.3.0.tgz#fa24a1e0e9b8df41b997ef766dbc2f67843db9f0"
+  integrity sha512-OHvGphABYQv075CuLqiw1CdONl6TYQMVw27CR5xr24wz6KVOhLokd5BEcHvKGJvhMtKDmU5csXUx6b42y58lww==
+  dependencies:
+    "@opentripplanner/core-utils" "^4.1.0"
+    "@opentripplanner/location-icon" "^1.3.0"
+    prop-types "^15.7.2"
+
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.1":
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.4.tgz#df0d0d855fc527db48aac93c218a0bf4ada41f99"


### PR DESCRIPTION
Some package updates aren't working in otp-rr due to missing internal dependency updates. This PR resolves that.