### PR TITLE
fix(ParkAndRideOverlay): Use i18n from FromToLocationPicker 2.1.0.

### DIFF
--- a/packages/park-and-ride-overlay/package.json
+++ b/packages/park-and-ride-overlay/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@opentripplanner/core-utils": "^4.5.0",
-    "@opentripplanner/from-to-location-picker": "^1.3.0",
+    "@opentripplanner/from-to-location-picker": "^2.1.0",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/park-and-ride-overlay/src/index.js
+++ b/packages/park-and-ride-overlay/src/index.js
@@ -28,6 +28,7 @@ class ParkAndRideOverlay extends MapLayer {
     return (
       <FeatureGroup>
         {parkAndRideLocations.map((location, k) => {
+          // TODO: extract park-and-ride names from international "Park-And-Ride" string constructs.
           const name = location.name.startsWith("P+R ")
             ? location.name.substring(4)
             : location.name;
@@ -41,11 +42,9 @@ class ParkAndRideOverlay extends MapLayer {
               <Popup>
                 <BaseMapStyled.MapOverlayPopup>
                   <BaseMapStyled.PopupTitle>{name}</BaseMapStyled.PopupTitle>
-
-                  {/* Set as from/to toolbar */}
                   <BaseMapStyled.PopupRow>
-                    <b>Plan a trip:</b>
                     <FromToLocationPicker
+                      label
                       location={{
                         lat: location.y,
                         lon: location.x,


### PR DESCRIPTION
This PR makes the P/R overlay to use i18n from `from-to-location-picker` 2.1.0.
Typescript is not included in this PR because of issues with react-leaflet's `MapLayer` class.
A new "fix" release will be created when merging this PR.