### PR TITLE
Stops overlay i18n

### DIFF
--- a/.storybook/react-intl.js
+++ b/.storybook/react-intl.js
@@ -19,6 +19,7 @@ const packages = [
   "itinerary-body",
   "location-field",
   "printable-itinerary",
+  "stops-overlay",
   "trip-details",
   "trip-form",
   "vehicle-rental-overlay"

--- a/packages/stops-overlay/i18n/en-US.yml
+++ b/packages/stops-overlay/i18n/en-US.yml
@@ -1,0 +1,14 @@
+# Default messages for the StopsOverlay component and subcomponents.
+# To use from a react-intl application:
+# - merge the content of this file into the messages object
+#   that has your other localized strings,
+# - flatten the ids, i.e. convert a structure such as
+#      otpUi > StopsOverlay > stopId
+#   into "otpUi.StopsOverlay.stopId" (see story for an example),
+# - pass the resulting object to the messages prop of IntlProvider.
+
+otpUi:
+  # TODO: Move these shared strings to a shared package.
+  StopsOverlay:
+    stopId: "Stop ID: {stopId}"
+    stopViewer: Stop Viewer

--- a/packages/stops-overlay/i18n/fr.yml
+++ b/packages/stops-overlay/i18n/fr.yml
@@ -1,0 +1,13 @@
+# Default messages for the StopsOverlay component and subcomponents.
+# To use from a react-intl application:
+# - merge the content of this file into the messages object
+#   that has your other localized strings,
+# - flatten the ids, i.e. convert a structure such as
+#      otpUi > StopsOverlay > stopId
+#   into "otpUi.StopsOverlay.stopId" (see story for an example),
+# - pass the resulting object to the messages prop of IntlProvider.
+
+otpUi:
+  StopsOverlay:
+    stopId: Arrêt n°{stopId}
+    stopViewer: Info arrêt

--- a/packages/stops-overlay/package.json
+++ b/packages/stops-overlay/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/from-to-location-picker": "^1.3.0",
+    "@opentripplanner/from-to-location-picker": "^2.1.0",
     "@opentripplanner/core-utils": "^4.5.0",
     "@opentripplanner/zoom-based-markers": "^1.2.1"
   },

--- a/packages/stops-overlay/package.json
+++ b/packages/stops-overlay/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "@opentripplanner/from-to-location-picker": "^2.1.0",
     "@opentripplanner/core-utils": "^4.5.0",
-    "@opentripplanner/zoom-based-markers": "^1.2.1"
+    "@opentripplanner/zoom-based-markers": "^1.2.1",
+    "flat": "^5.0.2"
   },
   "devDependencies": {
     "styled-icons": "^10.34.0"
@@ -29,6 +30,7 @@
     "@opentripplanner/base-map": "^2.0.0",
     "prop-types": "^15.7.2",
     "react": "^16.14.0",
+    "react-intl": "^5.24.6",
     "react-leaflet": "^2.6.1",
     "styled-components": "^5.3.0"
   },

--- a/packages/stops-overlay/src/StopsOverlay.story.js
+++ b/packages/stops-overlay/src/StopsOverlay.story.js
@@ -19,13 +19,11 @@ import DefaultStopMarker from "./default-stop-marker";
 import "../../../node_modules/leaflet/dist/leaflet.css";
 
 const center = [45.523092, -122.671202];
-const languageConfig = { stopViewer: "View Stop" };
 const refreshStopsAction = action("refreshStops");
 
 function ExampleMarker({ entity: stop }) {
   return (
     <DefaultStopMarker
-      languageConfig={languageConfig}
       setLocation={action("setLocation")}
       setViewedStop={action("setViewedStop")}
       stop={stop}

--- a/packages/stops-overlay/src/default-stop-marker.js
+++ b/packages/stops-overlay/src/default-stop-marker.js
@@ -1,17 +1,26 @@
 import { Styled as BaseMapStyled } from "@opentripplanner/base-map";
 import coreUtils from "@opentripplanner/core-utils";
+import flatten from "flat";
 import FromToLocationPicker from "@opentripplanner/from-to-location-picker";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
+import { FormattedMessage } from "react-intl";
 import { CircleMarker, Popup } from "react-leaflet";
 
 import * as S from "./styled";
 
-const {
-  languageConfigType,
-  leafletPathType,
-  stopLayerStopType
-} = coreUtils.types;
+// Load the default messages.
+import defaultEnglishMessages from "../i18n/en-US.yml";
+
+// HACK: We should flatten the messages loaded above because
+// the YAML loaders behave differently between webpack and our version of jest:
+// - the yaml loader for webpack returns a nested object,
+// - the yaml loader for jest returns messages with flattened ids.
+export const defaultMessages /* : Record<string, string> */ = flatten(
+  defaultEnglishMessages
+);
+
+const { leafletPathType, stopLayerStopType } = coreUtils.types;
 
 export default class StopMarker extends Component {
   onClickView = () => {
@@ -34,7 +43,7 @@ export default class StopMarker extends Component {
   }
 
   render() {
-    const { languageConfig, leafletPath, radius, stop } = this.props;
+    const { leafletPath, radius, stop } = this.props;
     const { code, geometries, id, lat, lon, name } = stop;
     const userFacingId = code || id.split(":")[1] || id;
 
@@ -62,17 +71,37 @@ export default class StopMarker extends Component {
             <BaseMapStyled.PopupTitle>{name}</BaseMapStyled.PopupTitle>
             <BaseMapStyled.PopupRow>
               <span>
-                <b>Stop ID:</b> {userFacingId}
+                <strong>
+                  <FormattedMessage
+                    defaultMessage={
+                      defaultMessages["otpUi.StopsOverlay.stopId"]
+                    }
+                    description="Displays the stop id"
+                    id="otpUi.StopsOverlay.stopId"
+                    values={{
+                      stopId: userFacingId
+                    }}
+                  />
+                </strong>
               </span>
               <S.ViewStopButton onClick={this.onClickView}>
-                {languageConfig.stopViewer || "Stop Viewer"}
+                <FormattedMessage
+                  defaultMessage={
+                    defaultMessages["otpUi.StopsOverlay.stopViewer"]
+                  }
+                  description="Text for link that opens the stop viewer"
+                  id="otpUi.StopsOverlay.stopViewer"
+                  values={{
+                    stopId: userFacingId
+                  }}
+                />
               </S.ViewStopButton>
             </BaseMapStyled.PopupRow>
 
             {/* The "Set as [from/to]" ButtonGroup */}
             <BaseMapStyled.PopupRow>
-              <b>Plan a trip:</b>
               <FromToLocationPicker
+                label
                 onFromClick={this.onFromClick}
                 onToClick={this.onToClick}
               />
@@ -85,7 +114,6 @@ export default class StopMarker extends Component {
 }
 
 StopMarker.propTypes = {
-  languageConfig: languageConfigType.isRequired,
   leafletPath: leafletPathType,
   radius: PropTypes.number,
   setLocation: PropTypes.func.isRequired,

--- a/packages/stops-overlay/src/default-stop-marker.js
+++ b/packages/stops-overlay/src/default-stop-marker.js
@@ -89,9 +89,6 @@ export default class StopMarker extends Component {
                   }
                   description="Text for link that opens the stop viewer"
                   id="otpUi.StopsOverlay.stopViewer"
-                  values={{
-                    stopId: userFacingId
-                  }}
                 />
               </S.ViewStopButton>
             </BaseMapStyled.PopupRow>

--- a/packages/stops-overlay/src/default-stop-marker.js
+++ b/packages/stops-overlay/src/default-stop-marker.js
@@ -16,9 +16,7 @@ import defaultEnglishMessages from "../i18n/en-US.yml";
 // the YAML loaders behave differently between webpack and our version of jest:
 // - the yaml loader for webpack returns a nested object,
 // - the yaml loader for jest returns messages with flattened ids.
-export const defaultMessages /* : Record<string, string> */ = flatten(
-  defaultEnglishMessages
-);
+export const defaultMessages = flatten(defaultEnglishMessages);
 
 const { leafletPathType, stopLayerStopType } = coreUtils.types;
 


### PR DESCRIPTION
This PR adds i18n support to the Stops Overlay component (does not include TypeScript because of MapLayer typing issues).