### PR TITLE
Deprecate TimeOptions

### DIFF
--- a/packages/core-utils/src/deprecated.js
+++ b/packages/core-utils/src/deprecated.js
@@ -318,6 +318,8 @@ export function summarizeQuery(query, locations = []) {
 }
 
 export function getTimeZoneOffset(itinerary) {
+  logDeprecationWarning("getTimeZoneOffset");
+
   if (!itinerary.legs || !itinerary.legs.length) return 0;
 
   // Determine if there is a DST offset between now and the itinerary start date

--- a/packages/core-utils/src/deprecated.js
+++ b/packages/core-utils/src/deprecated.js
@@ -316,3 +316,17 @@ export function summarizeQuery(query, locations = []) {
     : require("./itinerary").toSentenceCase(query.mode);
   return `${mode} from ${from} to ${to}`;
 }
+
+export function getTimeZoneOffset(itinerary) {
+  if (!itinerary.legs || !itinerary.legs.length) return 0;
+
+  // Determine if there is a DST offset between now and the itinerary start date
+  const dstOffset =
+    new Date(itinerary.startTime).getTimezoneOffset() -
+    new Date().getTimezoneOffset();
+
+  return (
+    itinerary.legs[0].agencyTimeZoneOffset +
+    (new Date().getTimezoneOffset() + dstOffset) * 60000
+  );
+}

--- a/packages/core-utils/src/itinerary.js
+++ b/packages/core-utils/src/itinerary.js
@@ -9,6 +9,7 @@ import {
   getStepDirection,
   getStepInstructions,
   getStepStreetName,
+  getTimeZoneOffset,
   getTransitFare
 } from "./deprecated";
 
@@ -20,6 +21,7 @@ export {
   getStepDirection,
   getStepInstructions,
   getStepStreetName,
+  getTimeZoneOffset,
   getTransitFare
 };
 
@@ -407,20 +409,6 @@ export function calculatePhysicalActivity(itinerary) {
     caloriesBurned,
     walkDuration
   };
-}
-
-export function getTimeZoneOffset(itinerary) {
-  if (!itinerary.legs || !itinerary.legs.length) return 0;
-
-  // Determine if there is a DST offset between now and the itinerary start date
-  const dstOffset =
-    new Date(itinerary.startTime).getTimezoneOffset() -
-    new Date().getTimezoneOffset();
-
-  return (
-    itinerary.legs[0].agencyTimeZoneOffset +
-    (new Date().getTimezoneOffset() + dstOffset) * 60000
-  );
 }
 
 export function calculateTncFares(itinerary) {

--- a/packages/itinerary-body/src/AccessLegBody/index.tsx
+++ b/packages/itinerary-body/src/AccessLegBody/index.tsx
@@ -1,9 +1,4 @@
-import {
-  Config,
-  Leg,
-  LegIconComponent,
-  TimeOptions
-} from "@opentripplanner/types";
+import { Config, Leg, LegIconComponent } from "@opentripplanner/types";
 import React, { Component, ReactElement } from "react";
 import { VelocityTransitionGroup } from "velocity-react";
 import { Duration } from "../defaults";
@@ -35,7 +30,6 @@ interface Props {
   setLegDiagram: (leg: Leg) => void;
   showElevationProfile: boolean;
   showLegIcon: boolean;
-  timeOptions?: TimeOptions;
 }
 
 interface State {
@@ -74,8 +68,7 @@ class AccessLegBody extends Component<Props, State> {
       mapillaryKey,
       setLegDiagram,
       showElevationProfile,
-      showLegIcon,
-      timeOptions
+      showLegIcon
     } = this.props;
     const { expanded } = this.state;
 
@@ -88,7 +81,6 @@ class AccessLegBody extends Component<Props, State> {
           LegIcon={LegIcon}
           onSummaryClick={this.onSummaryClick}
           showLegIcon={showLegIcon}
-          timeOptions={timeOptions}
         />
       );
     }

--- a/packages/itinerary-body/src/AccessLegBody/tnc-leg.tsx
+++ b/packages/itinerary-body/src/AccessLegBody/tnc-leg.tsx
@@ -1,12 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore FIXME: Create TypeScript types for core-utils packages.
 import coreUtils from "@opentripplanner/core-utils";
-import {
-  Config,
-  Leg,
-  LegIconComponent,
-  TimeOptions
-} from "@opentripplanner/types";
+import { Config, Leg, LegIconComponent } from "@opentripplanner/types";
 import React, { ReactElement } from "react";
 import { FormattedMessage, FormattedNumber } from "react-intl";
 import { Duration } from "../defaults";
@@ -18,26 +13,24 @@ import AccessLegSummary from "./access-leg-summary";
 
 interface Props {
   config: Config;
-  LYFT_CLIENT_ID?: string;
-  UBER_CLIENT_ID?: string;
   followsTransit: boolean;
   leg: Leg;
   LegIcon: LegIconComponent;
+  LYFT_CLIENT_ID?: string;
   onSummaryClick: () => void;
   showLegIcon: boolean;
-  timeOptions: TimeOptions;
+  UBER_CLIENT_ID?: string;
 }
 
 export default function TNCLeg({
   config,
-  LYFT_CLIENT_ID = "",
-  UBER_CLIENT_ID = "",
   followsTransit,
   leg,
   LegIcon,
+  LYFT_CLIENT_ID = "",
   onSummaryClick,
   showLegIcon,
-  timeOptions
+  UBER_CLIENT_ID = ""
 }: Props): ReactElement {
   const universalLinks = {
     UBER: `https://m.uber.com/${
@@ -110,10 +103,8 @@ export default function TNCLeg({
                     description="Hint text to book a ride at a later time."
                     id="otpUi.AccessLegBody.TncLeg.bookRideLater"
                     values={{
-                      timeMillis: coreUtils.time.offsetTime(
-                        leg.startTime - tncData.estimatedArrival * 1000,
-                        timeOptions
-                      )
+                      timeMillis:
+                        leg.startTime - tncData.estimatedArrival * 1000
                     }}
                   />
                 </S.BookLaterText>

--- a/packages/itinerary-body/src/ItineraryBody/index.tsx
+++ b/packages/itinerary-body/src/ItineraryBody/index.tsx
@@ -37,7 +37,6 @@ const ItineraryBody = ({
   showRouteFares,
   showViewTripButton,
   TimeColumnContent,
-  timeOptions,
   toRouteAbbreviation = defaultRouteAbbr,
   TransitLegSubheader,
   TransitLegSummary
@@ -89,7 +88,6 @@ const ItineraryBody = ({
           showMapButtonColumn={showMapButtonColumn}
           showViewTripButton={showViewTripButton}
           TimeColumnContent={TimeColumnContent}
-          timeOptions={timeOptions}
           toRouteAbbreviation={toRouteAbbreviation}
           TransitLegSubheader={TransitLegSubheader}
           TransitLegSummary={TransitLegSummary}

--- a/packages/itinerary-body/src/ItineraryBody/place-row.tsx
+++ b/packages/itinerary-body/src/ItineraryBody/place-row.tsx
@@ -45,7 +45,6 @@ export default function PlaceRow({
   showMapButtonColumn,
   showViewTripButton,
   TimeColumnContent = DefaultTimeColumnContent,
-  timeOptions,
   toRouteAbbreviation,
   TransitLegSubheader,
   TransitLegSummary
@@ -140,7 +139,6 @@ export default function PlaceRow({
                 setLegDiagram={setLegDiagram}
                 showElevationProfile={showElevationProfile}
                 showLegIcon={showLegIcon}
-                timeOptions={timeOptions}
               />
             ))}
         </S.PlaceDetails>

--- a/packages/itinerary-body/src/demos/index.tsx
+++ b/packages/itinerary-body/src/demos/index.tsx
@@ -1,8 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore FIXME: Create TypeScript types for core-utils packages.
 import coreUtils from "@opentripplanner/core-utils";
-import { Place, TimeOptions } from "@opentripplanner/types";
+import { Place } from "@opentripplanner/types";
 import React, { ReactElement } from "react";
+import { FormattedTime } from "react-intl";
 import { action } from "@storybook/addon-actions";
 import styled from "styled-components";
 import { ExclamationTriangle } from "@styled-icons/fa-solid/ExclamationTriangle";
@@ -16,10 +17,6 @@ import {
   TransitLegSummaryProps
 } from "../types";
 
-type TimeColumnProps = TimeColumnContentProps & {
-  timeOptions: TimeOptions;
-};
-
 export function CustomPlaceName({ place }: { place: Place }): string {
   return `🎉✨🎊 ${place.name} 🎉✨🎊`;
 }
@@ -30,16 +27,15 @@ export function CustomPlaceName({ place }: { place: Place }): string {
  */
 export function CustomTimeColumnContent({
   isDestination,
-  leg,
-  timeOptions
-}: TimeColumnProps): ReactElement {
+  leg
+}: TimeColumnContentProps): ReactElement {
   const time = isDestination ? leg.endTime : leg.startTime;
 
   return (
     <>
       <div>
         <span style={{ color: "#E60000" }}>
-          {time && coreUtils.time.formatTime(time, timeOptions)}
+          <FormattedTime value={time} />
         </span>
       </div>
       <div style={{ fontSize: "80%", lineHeight: "1em" }}>

--- a/packages/itinerary-body/src/types.ts
+++ b/packages/itinerary-body/src/types.ts
@@ -8,7 +8,6 @@ import {
   Leg,
   LegIconComponent,
   Place,
-  TimeOptions,
   TransitOperator
 } from "@opentripplanner/types";
 
@@ -192,11 +191,8 @@ interface ItineraryBodySharedProps {
    * This component is sent the following props:
    * - isDestination - whether this place is the destination
    * - leg - the current leg
-   * - timeOptions - options for formatting time.
    */
   TimeColumnContent?: FunctionComponent<TimeColumnContentProps>;
-  /** Contains the preferred format string for time display and a timezone offset */
-  timeOptions?: TimeOptions;
   /** Converts a route's ID to its accepted badge abbreviation */
   toRouteAbbreviation?: ToRouteAbbreviationFunction;
   /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -396,6 +396,7 @@ export interface StopLayerStop extends LayerEntity {
 }
 
 /**
+ * @deprecated
  * Describes time options, including time format and timezone-related offset.
  */
 export interface TimeOptions {


### PR DESCRIPTION
No breaking changes in this PR that just removes superficial uses of `TimeOptions` and related code in the `itinerary-body` demo code.
