### PR TITLE
chore(trip-details:deps): Remove types pkg dep

### DIFF
--- a/packages/trip-details/package.json
+++ b/packages/trip-details/package.json
@@ -17,6 +17,7 @@
     "velocity-react": "^1.4.3"
   },
   "devDependencies": {
+    "@opentripplanner/types": "^2.0.0",
     "@types/flat": "^5.0.2"
   },
   "peerDependencies": {

--- a/packages/trip-details/package.json
+++ b/packages/trip-details/package.json
@@ -17,7 +17,6 @@
     "velocity-react": "^1.4.3"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^1.1.0",
     "@types/flat": "^5.0.2"
   },
   "peerDependencies": {

--- a/packages/trip-details/tsconfig.json
+++ b/packages/trip-details/tsconfig.json
@@ -6,5 +6,10 @@
     "rootDir": "./src",
     "skipLibCheck": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../types"
+    }
+  ]
 }

--- a/packages/trip-details/tsconfig.json
+++ b/packages/trip-details/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "./lib",
+    "paths": {
+      "types": ["../types"]
+    },
     "rootDir": "./src",
     "skipLibCheck": true
   },

--- a/packages/trip-details/tsconfig.json
+++ b/packages/trip-details/tsconfig.json
@@ -3,9 +3,6 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "./lib",
-    "paths": {
-      "types": ["../types"]
-    },
     "rootDir": "./src",
     "skipLibCheck": true
   },

--- a/packages/trip-details/tsconfig.json
+++ b/packages/trip-details/tsconfig.json
@@ -6,10 +6,5 @@
     "rootDir": "./src",
     "skipLibCheck": true
   },
-  "include": ["src/**/*"],
-  "references": [
-    {
-      "path": "../types"
-    }
-  ]
+  "include": ["src/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2852,6 +2852,24 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
+"@opentripplanner/core-utils@^4.11.0", "@opentripplanner/core-utils@^4.11.2", "@opentripplanner/core-utils@^4.11.5", "@opentripplanner/core-utils@^4.5.0", "@opentripplanner/core-utils@^4.6.0":
+  version "4.11.5"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-4.11.5.tgz#ac90d443009fab02aae971d4ed6c1e0fc7da134f"
+  integrity sha512-oVVfbQqzHaY82cYLRm/GpybCo5LsDa8PTJQDU/w/DJLqSqyYm2I2sitQxk6jvmP6Zq80asdxMRvM8Si8yI77aQ==
+  dependencies:
+    "@mapbox/polyline" "^1.1.0"
+    "@opentripplanner/geocoder" "^1.2.2"
+    "@styled-icons/foundation" "^10.34.0"
+    "@turf/along" "^6.0.1"
+    bowser "^2.7.0"
+    date-fns "^2.23.0"
+    date-fns-tz "^1.1.4"
+    lodash.clonedeep "^4.5.0"
+    lodash.isequal "^4.5.0"
+    moment "^2.24.0"
+    prop-types "^15.7.2"
+    qs "^6.9.1"
+
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.1":
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.4.tgz#df0d0d855fc527db48aac93c218a0bf4ada41f99"


### PR DESCRIPTION
Dev-time references to other packages in the same mono repo are not necessary. This fixes the build that's reported broken after merging #403 (it probably became broken after merging #367).
