### PR TITLE
fix(DateTimeSelector): Add and use timeZone prop to format current time

### DIFF
--- a/packages/trip-form/src/DateTimeSelector/index.tsx
+++ b/packages/trip-form/src/DateTimeSelector/index.tsx
@@ -20,7 +20,13 @@ import defaultEnglishMessages from "../../i18n/en-US.yml";
 // - the yaml loader for jest returns messages with flattened ids.
 const defaultMessages: Record<string, string> = flatten(defaultEnglishMessages);
 
-const { getCurrentDate, getCurrentTime, OTP_API_DATE_FORMAT, OTP_API_TIME_FORMAT } = coreUtils.time;
+const {
+  getCurrentDate,
+  getCurrentTime,
+  getUserTimezone,
+  OTP_API_DATE_FORMAT,
+  OTP_API_TIME_FORMAT
+} = coreUtils.time;
 
 type DepartArriveValue = "NOW" | "DEPART" | "ARRIVE";
 
@@ -120,7 +126,7 @@ export default function DateTimeSelector({
   style = null,
   time = null,
   timeFormatLegacy = OTP_API_TIME_FORMAT,
-  timeZone
+  timeZone = getUserTimezone()
 }: DateTimeSelectorProps): ReactElement {
   const handleQueryParamChange = useCallback(
     (queryParam: QueryParamChangeEvent): void => {

--- a/packages/trip-form/src/DateTimeSelector/index.tsx
+++ b/packages/trip-form/src/DateTimeSelector/index.tsx
@@ -20,7 +20,7 @@ import defaultEnglishMessages from "../../i18n/en-US.yml";
 // - the yaml loader for jest returns messages with flattened ids.
 const defaultMessages: Record<string, string> = flatten(defaultEnglishMessages);
 
-const { OTP_API_DATE_FORMAT, OTP_API_TIME_FORMAT } = coreUtils.time;
+const { getCurrentDate, getCurrentTime, OTP_API_DATE_FORMAT, OTP_API_TIME_FORMAT } = coreUtils.time;
 
 type DepartArriveValue = "NOW" | "DEPART" | "ARRIVE";
 
@@ -63,6 +63,11 @@ interface DateTimeSelectorProps {
    * The time format string for legacy mode (on legacy browsers, or if `forceLegacy` is true).
    */
   timeFormatLegacy?: string;
+  /**
+   * An IANA timezone (e.g. "America/Los_Angeles") used to convert the "Leave now" time
+   * to the transit agency local time.
+   */
+  timeZone?: string;
 }
 
 interface DepartArriveOption {
@@ -114,7 +119,8 @@ export default function DateTimeSelector({
   onQueryParamChange = null,
   style = null,
   time = null,
-  timeFormatLegacy = OTP_API_TIME_FORMAT
+  timeFormatLegacy = OTP_API_TIME_FORMAT,
+  timeZone
 }: DateTimeSelectorProps): ReactElement {
   const handleQueryParamChange = useCallback(
     (queryParam: QueryParamChangeEvent): void => {
@@ -160,9 +166,9 @@ export default function DateTimeSelector({
     () => {
       if (option.type === "NOW") {
         handleQueryParamChange({
+          date: getCurrentDate(timeZone),
           departArrive: "NOW",
-          date: moment().format(OTP_API_DATE_FORMAT),
-          time: moment().format(OTP_API_TIME_FORMAT)
+          time: getCurrentTime(timeZone)
         });
       } else if (!option.isSelected) {
         handleQueryParamChange({
@@ -170,7 +176,7 @@ export default function DateTimeSelector({
         });
       }
     },
-    [onQueryParamChange, option.type]
+    [onQueryParamChange, option.type, option.isSelected, timeZone]
   );
 
   const departureOptions: DepartArriveOption[] = [

--- a/packages/trip-form/src/components.story.tsx
+++ b/packages/trip-form/src/components.story.tsx
@@ -50,6 +50,12 @@ const GeneralSettingsTemplate = (args: StoryArgs) => (
 );
 
 export default {
+  argTypes: {
+    timeZone: {
+      control: "select",
+      options: ["America/New_York", "America/Los_Angeles"]
+    }
+  },
   component: SettingsSelectorPanel,
   decorators: [decorator],
   parameters: {
@@ -57,7 +63,7 @@ export default {
     // (there are no args that the user can interactively change for this component).
     controls: {
       hideNoControlsWarning: true,
-      include: []
+      include: ["timeZone"]
     }
   },
   title: "Trip Form Components"
@@ -122,7 +128,8 @@ export const dateTimeSelector = makeStory(Core.DateTimeSelector, {
   forceLegacy: false,
   onQueryParamChange,
   time: "14:17",
-  timeFormatLegacy: "HH:mm"
+  timeFormatLegacy: "HH:mm",
+  timeZone: "America/New_York"
 });
 
 export const dropdownSelector = makeStory(Core.DropdownSelector, {


### PR DESCRIPTION
This PR adds a `timeZone` prop to the `DateTimeSelector` component, so that when the user clicks "Leave now", the current time passed to the OTP query parameters is the local time at the specified timeZone (which is not necessarily the user time zone). This is useful when querying OTP for agencies in a different time zone than the user time zone.