### PR TITLE
fix(trip-details): Revert accidental breaking change

### DIFF
--- a/packages/trip-details/src/fare-table.tsx
+++ b/packages/trip-details/src/fare-table.tsx
@@ -7,7 +7,7 @@ import { Transfer } from "@styled-icons/boxicons-regular/Transfer";
 
 import { boldText, renderFare } from "./utils";
 
-import { FareDetailsProps, FareTableLayout, FareTableText } from "./types";
+import { FareLegTableProps, FareTableLayout, FareTableText } from "./types";
 
 // Load the default messages.
 import defaultEnglishMessages from "../i18n/en-US.yml";
@@ -183,7 +183,7 @@ const FareLegDetails = ({
   transitFareDetails,
   transitFares,
   legs
-}: FareDetailsProps): JSX.Element => {
+}: FareLegTableProps): JSX.Element => {
   const fareKeys = Object.keys(transitFareDetails);
 
   const legsWithFares = legs

--- a/packages/trip-details/src/index.tsx
+++ b/packages/trip-details/src/index.tsx
@@ -276,7 +276,13 @@ export function TripDetails({
           <TripDetail
             // Any custom description for the transit fare needs to be handled by the slot.
             description={
-              FareDetails && <FareDetails transitFares={transitFares} />
+              FareDetails && (
+                <FareDetails
+                  transitFares={transitFares}
+                  minTNCFare={minTNCFare}
+                  maxTNCFare={maxTNCFare}
+                />
+              )
             }
             icon={<MoneyBillAlt size={17} />}
             summary={fare}

--- a/packages/trip-details/src/types.ts
+++ b/packages/trip-details/src/types.ts
@@ -34,6 +34,12 @@ export interface TransitFareData {
 }
 
 export interface FareDetailsProps {
+  maxTNCFare: number;
+  minTNCFare: number;
+  transitFares: TransitFareData;
+}
+
+export interface FareLegTableProps {
   layout?: FareTableLayout[];
   legs?: Leg[];
   transitFareDetails?: FareDetails;


### PR DESCRIPTION
The fare-by-leg PR got merged before I had pushed this commit to it, causing a breaking change that was not marked properly. In this PR I revert the breaking change since it is not necessary. 