### PR TITLE
Vector tiles PR tweaks

### DIFF
--- a/packages/base-map/src/index.story.tsx
+++ b/packages/base-map/src/index.story.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable react/button-has-type */
-import React, { useRef } from "react";
+import React from "react";
 import {
   AttributionControl,
-  MapboxMap,
+  MapProvider,
   NavigationControl,
   Popup,
-  ScaleControl
+  ScaleControl,
+  useMap
 } from "react-map-gl";
 import { action } from "@storybook/addon-actions";
 import { ComponentStory } from "@storybook/react";
@@ -77,33 +78,37 @@ zoomed.args = {
   zoom: 17
 };
 
-export const clickToSetBounds = () => {
-  const ref = useRef<MapboxMap>();
-  const bbox: [number, number, number, number] = [-79, 43, -73, 45];
+const SetBoundsButton = () => {
+  const { mapWithBounds } = useMap();
+  const bbox = [-79, 43, -73, 45];
 
   return (
-    <>
-      <button
-        onClick={
-          () =>
-            ref.current?.fitBounds(bbox, {
-              duration: 300,
-              padding: {
-                bottom: 25,
-                left: 15,
-                right: 5,
-                top: 10
-              }
-            })
-          // eslint-disable-next-line react/jsx-curly-newline
-        }
-      >
-        Set the bounds
-      </button>
-      <BaseMap passedRef={ref} center={center} />
-    </>
+    <button
+      onClick={
+        () =>
+          mapWithBounds?.fitBounds(bbox, {
+            duration: 300,
+            padding: {
+              bottom: 25,
+              left: 15,
+              right: 5,
+              top: 10
+            }
+          })
+        // eslint-disable-next-line react/jsx-curly-newline
+      }
+    >
+      Set the bounds
+    </button>
   );
 };
+
+export const clickToSetBounds = (): ComponentStory<BaseMap> => (
+  <MapProvider>
+    <SetBoundsButton />
+    <BaseMap center={center} id="mapWithBounds" />
+  </MapProvider>
+);
 
 export const maxZoom = Template.bind({});
 maxZoom.args = {

--- a/packages/base-map/src/index.story.tsx
+++ b/packages/base-map/src/index.story.tsx
@@ -22,8 +22,8 @@ import "maplibre-gl/dist/maplibre-gl.css";
 const center: [number, number] = [45.522862, -122.667837];
 
 const mapDecorator = (
-  Story: ComponentStory<typeof EndpointsOverlay>
-): ReactElement => (
+  Story: ComponentStory<typeof BaseMap>
+): React.ReactElement => (
   <StoryMapContainer>
     {/* For some reason, <Story /> does not work with snapshots,
         so use the function syntax instead. */}
@@ -103,7 +103,7 @@ const SetBoundsButton = () => {
   );
 };
 
-export const clickToSetBounds = (): ComponentStory<BaseMap> => (
+export const clickToSetBounds = (): ComponentStory<typeof BaseMap> => (
   <MapProvider>
     <SetBoundsButton />
     <BaseMap center={center} id="mapWithBounds" />

--- a/packages/base-map/src/index.story.tsx
+++ b/packages/base-map/src/index.story.tsx
@@ -8,18 +8,32 @@ import {
   ScaleControl
 } from "react-map-gl";
 import { action } from "@storybook/addon-actions";
+import { ComponentStory } from "@storybook/react";
 
 import AllVehiclesOverlay from "../__mocks__/AllVehicles";
 import ContextMenuDemo from "../__mocks__/ContextMenuDemo";
+
+import { StoryMapContainer } from "./styled";
 import BaseMap, { MarkerWithPopup, LayerWrapper } from ".";
 
 import "maplibre-gl/dist/maplibre-gl.css";
 
 const center: [number, number] = [45.522862, -122.667837];
 
+const mapDecorator = (
+  Story: ComponentStory<typeof EndpointsOverlay>
+): ReactElement => (
+  <StoryMapContainer>
+    {/* For some reason, <Story /> does not work with snapshots,
+        so use the function syntax instead. */}
+    {Story()}
+  </StoryMapContainer>
+);
+
 export default {
-  args: { center, forceMaxHeight: true },
+  args: { center },
   component: BaseMap,
+  decorators: [mapDecorator],
   title: "BaseMap"
 };
 
@@ -52,7 +66,6 @@ const a11yOverrideParameters = {
 export const clickAndViewportchangedEvents = Template.bind({});
 clickAndViewportchangedEvents.args = {
   center,
-  forceMaxHeight: true,
   onClick,
   onContextMenu,
   onViewportChanged
@@ -61,8 +74,7 @@ clickAndViewportchangedEvents.args = {
 export const zoomed = Template.bind({});
 zoomed.args = {
   center,
-  zoom: 17,
-  forceMaxHeight: true
+  zoom: 17
 };
 
 export const clickToSetBounds = () => {
@@ -70,7 +82,7 @@ export const clickToSetBounds = () => {
   const bbox: [number, number, number, number] = [-79, 43, -73, 45];
 
   return (
-    <div>
+    <>
       <button
         onClick={
           () =>
@@ -88,8 +100,8 @@ export const clickToSetBounds = () => {
       >
         Set the bounds
       </button>
-      <BaseMap passedRef={ref} center={center} forceMaxHeight zoom={17} />
-    </div>
+      <BaseMap passedRef={ref} center={center} />
+    </>
   );
 };
 
@@ -103,34 +115,31 @@ export const withCustomBaseLayer = Template.bind({});
 
 withCustomBaseLayer.args = {
   baseLayer: `https://api.maptiler.com/maps/voyager/style.json?key=<PASTE YOUR MAPTILER TOKEN HERE>`,
-  center,
-  forceMaxHeight: true
+  center
 };
 
 export const withSampleMarkers = () => (
-  <BaseMap center={center} forceMaxHeight>
-    {sampleMarkers}
-  </BaseMap>
+  <BaseMap center={center}>{sampleMarkers}</BaseMap>
 );
 
 export const overlayWithLargeDataSet = () => (
-  <div>
+  <>
     <div>Do not add Storybook overhead on layers with large dataset...</div>
-    <BaseMap center={center} forceMaxHeight>
+    <BaseMap center={center}>
       <AllVehiclesOverlay />
     </BaseMap>
-  </div>
+  </>
 );
 
 export const customLocationPopupContent = () => (
-  <BaseMap center={center} forceMaxHeight>
+  <BaseMap center={center}>
     <Popup longitude={center[1]} latitude={center[0]}>
       {samplePopup}
     </Popup>
   </BaseMap>
 );
 export const optionalLayers = () => (
-  <BaseMap center={center} forceMaxHeight>
+  <BaseMap center={center}>
     <LayerWrapper
       id="layer-1"
       name="This layer has a name prop, the second one doesn't"
@@ -157,7 +166,6 @@ export const onContextMenuPopup = () => <ContextMenuDemo />;
 export const withOptionalControls = () => (
   <BaseMap
     center={center}
-    forceMaxHeight
     // We supply our own AttributionControl, so disable the default one
     // See https://visgl.github.io/react-map-gl/docs/api-reference/attribution-control
     mapLibreProps={{ attributionControl: false }}

--- a/packages/base-map/src/index.tsx
+++ b/packages/base-map/src/index.tsx
@@ -26,8 +26,6 @@ type Props = React.ComponentPropsWithoutRef<React.ElementType> & {
   baseLayer?: string;
   /** A [lat, lon] position to center the map at. */
   center?: [number, number];
-  /** Whether or not to override the default MapLibre 100% height to be 90vh */
-  forceMaxHeight?: boolean;
   /** An object of props which should be passed down to MapLibre */
   mapLibreProps?: MapProps;
   /** The maximum zoom level the map should allow */
@@ -57,13 +55,13 @@ const BaseMap = ({
   baseLayer = "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
   center,
   children,
-  forceMaxHeight,
   mapLibreProps,
   maxZoom,
   onClick,
   onContextMenu,
   passedRef,
   onViewportChanged,
+  style,
   zoom: initZoom = 12
 }: Props): JSX.Element => {
   const [viewState, setViewState] = React.useState<State>({
@@ -140,11 +138,7 @@ const BaseMap = ({
         setFakeMobileHover(false);
       }}
       ref={passedRef}
-      style={{
-        display: "block",
-        height: forceMaxHeight ? "90vh" : "100%",
-        width: "100%"
-      }}
+      style={style}
       zoom={viewState.zoom}
     >
       {toggleableLayers.length > 0 && (

--- a/packages/base-map/src/index.tsx
+++ b/packages/base-map/src/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { MapProps, MapRef, Map } from "react-map-gl";
+import { MapProps, Map } from "react-map-gl";
 import maplibregl, { Event } from "maplibre-gl";
 
 import * as Styled from "./styled";
@@ -26,6 +26,8 @@ type Props = React.ComponentPropsWithoutRef<React.ElementType> & {
   baseLayer?: string;
   /** A [lat, lon] position to center the map at. */
   center?: [number, number];
+  /** A unique identifier for the map (useful when using MapProvider) */
+  id?: string;
   /** An object of props which should be passed down to MapLibre */
   mapLibreProps?: MapProps;
   /** The maximum zoom level the map should allow */
@@ -38,8 +40,6 @@ type Props = React.ComponentPropsWithoutRef<React.ElementType> & {
   /** A callback method which is fired when the map zoom or map bounds change */
   // TODO: does this cause integration issues?
   onViewportChanged?: (e: maplibregl.MapLibreEvent) => void;
-  /** A ref to pass to the MapLibre react component */
-  passedRef?: React.Ref<MapRef>;
   /** An initial zoom value for the map */
   zoom?: number;
 };
@@ -55,11 +55,11 @@ const BaseMap = ({
   baseLayer = "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
   center,
   children,
+  id,
   mapLibreProps,
   maxZoom,
   onClick,
   onContextMenu,
-  passedRef,
   onViewportChanged,
   style,
   zoom: initZoom = 12
@@ -100,8 +100,8 @@ const BaseMap = ({
         .flat()
         .filter(child => child?.props?.id !== undefined)
         .map(child => {
-          const { id, name, visible } = child.props;
-          return { id, name, visible };
+          const { id: layerId, name, visible } = child.props;
+          return { id: layerId, name, visible };
         })
     : [];
 
@@ -110,11 +110,11 @@ const BaseMap = ({
   );
 
   const adjustHiddenLayers = useCallback(
-    id => {
+    layerId => {
       const updatedLayers = [...hiddenLayers];
       // Delete the layer id if present, add it otherwise
       updatedLayers.includes(id)
-        ? updatedLayers.splice(updatedLayers.indexOf(id), 1)
+        ? updatedLayers.splice(updatedLayers.indexOf(layerId), 1)
         : updatedLayers.push(id);
 
       setHiddenLayers(updatedLayers);
@@ -126,6 +126,7 @@ const BaseMap = ({
     <Map
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...mapLibreProps}
+      id={id}
       latitude={viewState.latitude}
       longitude={viewState.longitude}
       mapLib={maplibregl}
@@ -137,7 +138,6 @@ const BaseMap = ({
       onTouchStart={() => {
         setFakeMobileHover(false);
       }}
-      ref={passedRef}
       style={style}
       zoom={viewState.zoom}
     >

--- a/packages/base-map/src/styled.ts
+++ b/packages/base-map/src/styled.ts
@@ -96,3 +96,10 @@ export const LayerSelector = styled.aside`
     }
   }
 `;
+
+/**
+ * Map container for use with storybook across various packages in this repo.
+ */
+export const StoryMapContainer = styled.div`
+  height: 90vh;
+`;

--- a/packages/endpoints-overlay/package.json
+++ b/packages/endpoints-overlay/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.0-alpha.1",
+    "@opentripplanner/base-map": "^3.0.0-alpha.3",
     "@opentripplanner/location-icon": "^1.4.0",
     "@opentripplanner/core-utils": "^6.0.0",
     "flat": "^5.0.2",

--- a/packages/endpoints-overlay/src/EndpointsOverlay.story.tsx
+++ b/packages/endpoints-overlay/src/EndpointsOverlay.story.tsx
@@ -1,4 +1,4 @@
-import BaseMap from "@opentripplanner/base-map";
+import BaseMap, { Styled as BaseMapStyled } from "@opentripplanner/base-map";
 import { UserLocationAndType } from "@opentripplanner/types";
 import React, { ReactElement } from "react";
 import { action } from "@storybook/addon-actions";
@@ -9,7 +9,7 @@ import { Dog } from "@styled-icons/fa-solid/Dog";
 import EndpointsOverlay from ".";
 
 // BaseMap props
-const center = [45.5215, -122.686202];
+const center: [number, number] = [45.5215, -122.686202];
 const zoom = 16;
 
 // EndpointsOverlay props
@@ -44,11 +44,13 @@ function CatDogIcon({ type }: UserLocationAndType) {
 const withMap = (
   Story: ComponentStory<typeof EndpointsOverlay>
 ): ReactElement => (
-  <BaseMap center={center} forceMaxHeight zoom={zoom}>
-    {/* For some reason, <Story /> does not work with snapshots,
+  <BaseMapStyled.StoryMapContainer>
+    <BaseMap center={center} zoom={zoom}>
+      {/* For some reason, <Story /> does not work with snapshots,
         so use the function syntax instead. */}
-    {Story()}
-  </BaseMap>
+      {Story()}
+    </BaseMap>
+  </BaseMapStyled.StoryMapContainer>
 );
 
 export default {

--- a/packages/park-and-ride-overlay/package.json
+++ b/packages/park-and-ride-overlay/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.0-alpha.1",
+    "@opentripplanner/base-map": "^3.0.0-alpha.3",
     "@opentripplanner/from-to-location-picker": "^2.1.2"
   },
   "peerDependencies": {

--- a/packages/park-and-ride-overlay/src/ParkAndRideOverlay.story.js
+++ b/packages/park-and-ride-overlay/src/ParkAndRideOverlay.story.js
@@ -1,4 +1,4 @@
-import BaseMap from "@opentripplanner/base-map";
+import BaseMap, { Styled as BaseMapStyled } from "@opentripplanner/base-map";
 import React from "react";
 import { action } from "@storybook/addon-actions";
 
@@ -14,11 +14,13 @@ export default {
 };
 
 export const Default = () => (
-  <BaseMap center={center} forceMaxHeight zoom={zoom}>
-    <ParkAndRideOverlay
-      parkAndRideLocations={parkAndRideLocations}
-      setLocation={action("setLocation")}
-      visible
-    />
-  </BaseMap>
+  <BaseMapStyled.StoryMapContainer>
+    <BaseMap center={center} zoom={zoom}>
+      <ParkAndRideOverlay
+        parkAndRideLocations={parkAndRideLocations}
+        setLocation={action("setLocation")}
+        visible
+      />
+    </BaseMap>
+  </BaseMapStyled.StoryMapContainer>
 );

--- a/packages/route-viewer-overlay/package.json
+++ b/packages/route-viewer-overlay/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@mapbox/polyline": "^1.1.0",
     "react-map-gl": "^7.0.15",
-    "@opentripplanner/base-map": "^3.0.0-alpha.1",
+    "@opentripplanner/base-map": "^3.0.0-alpha.3",
     "@opentripplanner/core-utils": "^6.0.0",
     "point-in-polygon": "^1.1.0"
   },

--- a/packages/route-viewer-overlay/src/RouteViewerOverlay.story.js
+++ b/packages/route-viewer-overlay/src/RouteViewerOverlay.story.js
@@ -1,4 +1,4 @@
-import BaseMap from "@opentripplanner/base-map";
+import BaseMap, { Styled as BaseMapStyled } from "@opentripplanner/base-map";
 import React from "react";
 
 import routeData from "../__mocks__/mock-route.json";
@@ -29,14 +29,16 @@ export default {
 };
 
 const Template = args => (
-  <BaseMap center={args.center} forceMaxHeight zoom={args.zoom}>
-    <RouteViewerOverlay
-      clipToPatternStops={args.clipToPatternStops}
-      path={args.path}
-      routeData={args.routeData}
-    />
-    {args.extraLayer}
-  </BaseMap>
+  <BaseMapStyled.StoryMapContainer>
+    <BaseMap center={args.center} zoom={args.zoom}>
+      <RouteViewerOverlay
+        clipToPatternStops={args.clipToPatternStops}
+        path={args.path}
+        routeData={args.routeData}
+      />
+      {args.extraLayer}
+    </BaseMap>
+  </BaseMapStyled.StoryMapContainer>
 );
 
 export const Default = Template.bind({});

--- a/packages/stop-viewer-overlay/package.json
+++ b/packages/stop-viewer-overlay/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.0-alpha.1",
+    "@opentripplanner/base-map": "^3.0.0-alpha.3",
     "@opentripplanner/core-utils": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/stop-viewer-overlay/src/StopViewerOverlay.story.tsx
+++ b/packages/stop-viewer-overlay/src/StopViewerOverlay.story.tsx
@@ -1,4 +1,4 @@
-import BaseMap from "@opentripplanner/base-map";
+import BaseMap, { Styled as BaseMapStyled } from "@opentripplanner/base-map";
 import React from "react";
 
 import { Marker } from "react-map-gl";
@@ -25,15 +25,23 @@ export default {
 };
 
 export const Default = (): JSX.Element => (
-  <BaseMap center={center} forceMaxHeight zoom={zoom}>
-    <StopViewerOverlay stop={fakeStop} StopMarker={DefaultStopMarker} visible />
-  </BaseMap>
+  <BaseMapStyled.StoryMapContainer>
+    <BaseMap center={center} zoom={zoom}>
+      <StopViewerOverlay
+        stop={fakeStop}
+        StopMarker={DefaultStopMarker}
+        visible
+      />
+    </BaseMap>
+  </BaseMapStyled.StoryMapContainer>
 );
 
 const WithCustomMarker = (): JSX.Element => (
-  <BaseMap center={center} forceMaxHeight zoom={zoom}>
-    <StopViewerOverlay stop={fakeStop} StopMarker={CustomMarker} visible />
-  </BaseMap>
+  <BaseMapStyled.StoryMapContainer>
+    <BaseMap center={center} zoom={zoom}>
+      <StopViewerOverlay stop={fakeStop} StopMarker={CustomMarker} visible />
+    </BaseMap>
+  </BaseMapStyled.StoryMapContainer>
 );
 // Can be disabled as this is a storybook-only marker
 const disableA11yParameters = {

--- a/packages/stops-overlay/package.json
+++ b/packages/stops-overlay/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.0-alpha.1",
+    "@opentripplanner/base-map": "^3.0.0-alpha.3",
     "@opentripplanner/from-to-location-picker": "^2.1.2",
     "flat": "^5.0.2"
   },

--- a/packages/stops-overlay/src/StopsOverlay.story.tsx
+++ b/packages/stops-overlay/src/StopsOverlay.story.tsx
@@ -1,4 +1,4 @@
-import BaseMap from "@opentripplanner/base-map";
+import BaseMap, { Styled as BaseMapStyled } from "@opentripplanner/base-map";
 
 import React from "react";
 import { action } from "@storybook/addon-actions";
@@ -17,15 +17,17 @@ const Example = ({
   minZoom = 15
 }: StopProps & { mapCenter?: [number, number] }) => {
   return (
-    <BaseMap center={mapCenter} forceMaxHeight>
-      <StopsOverlay
-        minZoom={minZoom}
-        setLocation={setLocation}
-        setViewedStop={setViewedStop}
-        stops={stops}
-        visible
-      />
-    </BaseMap>
+    <BaseMapStyled.StoryMapContainer>
+      <BaseMap center={mapCenter}>
+        <StopsOverlay
+          minZoom={minZoom}
+          setLocation={setLocation}
+          setViewedStop={setViewedStop}
+          stops={stops}
+          visible
+        />
+      </BaseMap>
+    </BaseMapStyled.StoryMapContainer>
   );
 };
 

--- a/packages/transit-vehicle-overlay/package.json
+++ b/packages/transit-vehicle-overlay/package.json
@@ -9,7 +9,7 @@
   "module": "esm/index.js",
   "private": false,
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.0-alpha.1",
+    "@opentripplanner/base-map": "^3.0.0-alpha.3",
     "@opentripplanner/core-utils": "^6.0.0",
     "@opentripplanner/icons": "1.2.2",
     "flat": "^5.0.2"

--- a/packages/transit-vehicle-overlay/src/index.story.tsx
+++ b/packages/transit-vehicle-overlay/src/index.story.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import BaseMap from "@opentripplanner/base-map";
+import BaseMap, { Styled as BaseMapStyled } from "@opentripplanner/base-map";
 import TransitVehicleOverlay from ".";
 
 import vehicleData from "../__mocks__/tm_all.json";
@@ -7,11 +7,12 @@ import vehicleData from "../__mocks__/tm_all.json";
 const PORTLAND: [number, number] = [45.523, -122.671];
 
 export const simpleExample = () => {
-  console.log(vehicleData.resultSet.vehicle[0]);
   return (
-    <BaseMap forceMaxHeight center={PORTLAND}>
-      <TransitVehicleOverlay vehicles={[vehicleData.resultSet.vehicle[0]]} />
-    </BaseMap>
+    <BaseMapStyled.StoryMapContainer>
+      <BaseMap center={PORTLAND}>
+        <TransitVehicleOverlay vehicles={[vehicleData.resultSet.vehicle[0]]} />
+      </BaseMap>
+    </BaseMapStyled.StoryMapContainer>
   );
 };
 

--- a/packages/transitive-overlay/package.json
+++ b/packages/transitive-overlay/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.1",
-    "@opentripplanner/base-map": "^3.0.0-alpha.1",
+    "@opentripplanner/base-map": "^3.0.0-alpha.3",
     "@opentripplanner/itinerary-body": "^4.0.0",
     "@opentripplanner/core-utils": "^6.0.0",
     "lodash.isequal": "^4.5.0",

--- a/packages/transitive-overlay/src/TransitiveOverlay.story.js
+++ b/packages/transitive-overlay/src/TransitiveOverlay.story.js
@@ -1,4 +1,4 @@
-import BaseMap from "@opentripplanner/base-map";
+import BaseMap, { Styled as BaseMapStyled } from "@opentripplanner/base-map";
 import EndpointsOverlay from "@opentripplanner/endpoints-overlay";
 import React from "react";
 import { action } from "@storybook/addon-actions";
@@ -63,13 +63,22 @@ function getCustomRouteLabel(itineraryLeg) {
   return null; // null or undefined or empty string will tell transitive-js not to render a route label
 }
 
+const withMapContainer = Story => (
+  <BaseMapStyled.StoryMapContainer>
+    {/* For some reason, <Story /> does not work with snapshots,
+        so use the function syntax instead. */}
+    {Story()}
+  </BaseMapStyled.StoryMapContainer>
+);
+
 export default {
   title: "TransitiveOverlay",
+  decorators: [withMapContainer],
   component: TransitiveOverlay
 };
 
 export const WalkingItinerary = () => (
-  <BaseMap forceMaxHeight center={[45.518841, -122.679302]} zoom={19}>
+  <BaseMap center={[45.518841, -122.679302]} zoom={19}>
     <EndpointsOverlay
       fromLocation={getFromLocation(walkOnlyItinerary)}
       setLocation={setLocation}
@@ -86,7 +95,7 @@ export const WalkingItinerary = () => (
 );
 
 export const BikeOnlyItinerary = () => (
-  <BaseMap forceMaxHeight center={[45.520441, -122.68302]} zoom={16}>
+  <BaseMap center={[45.520441, -122.68302]} zoom={16}>
     <EndpointsOverlay
       fromLocation={getFromLocation(bikeOnlyItinerary)}
       setLocation={setLocation}
@@ -101,7 +110,7 @@ export const BikeOnlyItinerary = () => (
 );
 
 export const WalkTransitWalkItinerary = () => (
-  <BaseMap forceMaxHeight center={[45.520441, -122.68302]} zoom={16}>
+  <BaseMap center={[45.520441, -122.68302]} zoom={16}>
     <EndpointsOverlay
       fromLocation={getFromLocation(walkTransitWalkItinerary)}
       setLocation={setLocation}
@@ -118,7 +127,7 @@ export const WalkTransitWalkItinerary = () => (
 );
 
 export const WalkTransitWalkItineraryWithNoIntermediateStops = () => (
-  <BaseMap forceMaxHeight center={[45.525841, -122.649302]} zoom={13}>
+  <BaseMap center={[45.525841, -122.649302]} zoom={13}>
     <EndpointsOverlay
       fromLocation={getFromLocation(
         walkTransitWalkItineraryNoIntermediateStops
@@ -138,7 +147,7 @@ export const WalkTransitWalkItineraryWithNoIntermediateStops = () => (
 );
 
 export const BikeTransitBikeItinerary = () => (
-  <BaseMap forceMaxHeight center={[45.520441, -122.68302]} zoom={16}>
+  <BaseMap center={[45.520441, -122.68302]} zoom={16}>
     <EndpointsOverlay
       fromLocation={getFromLocation(bikeTransitBikeItinerary)}
       setLocation={setLocation}
@@ -155,7 +164,7 @@ export const BikeTransitBikeItinerary = () => (
 );
 
 export const WalkInterlinedTransitItinerary = () => (
-  <BaseMap forceMaxHeight center={[45.511841, -122.679302]} zoom={14}>
+  <BaseMap center={[45.511841, -122.679302]} zoom={14}>
     <EndpointsOverlay
       fromLocation={getFromLocation(walkInterlinedTransitItinerary)}
       setLocation={setLocation}
@@ -172,7 +181,7 @@ export const WalkInterlinedTransitItinerary = () => (
 );
 
 export const WalkTransitTransferItinerary = () => (
-  <BaseMap forceMaxHeight center={[45.505841, -122.631302]} zoom={14}>
+  <BaseMap center={[45.505841, -122.631302]} zoom={14}>
     <EndpointsOverlay
       fromLocation={getFromLocation(walkTransitWalkTransitWalkItinerary)}
       setLocation={setLocation}
@@ -190,7 +199,7 @@ export const WalkTransitTransferItinerary = () => (
 );
 
 export const BikeRentalItinerary = () => (
-  <BaseMap forceMaxHeight center={[45.508841, -122.631302]} zoom={14}>
+  <BaseMap center={[45.508841, -122.631302]} zoom={14}>
     <EndpointsOverlay
       fromLocation={getFromLocation(bikeRentalItinerary)}
       setLocation={setLocation}
@@ -205,7 +214,7 @@ export const BikeRentalItinerary = () => (
 );
 
 export const EScooterRentalItinerary = injectIntl(({ intl }) => (
-  <BaseMap forceMaxHeight center={[45.52041, -122.675302]} zoom={16}>
+  <BaseMap center={[45.52041, -122.675302]} zoom={16}>
     <EndpointsOverlay
       fromLocation={getFromLocation(eScooterRentalItinerary)}
       setLocation={setLocation}
@@ -223,7 +232,7 @@ export const EScooterRentalItinerary = injectIntl(({ intl }) => (
 ));
 
 export const ParkAndRideItinerary = () => (
-  <BaseMap forceMaxHeight center={[45.515841, -122.75302]} zoom={13}>
+  <BaseMap center={[45.515841, -122.75302]} zoom={13}>
     <EndpointsOverlay
       fromLocation={getFromLocation(parkAndRideItinerary)}
       setLocation={setLocation}
@@ -240,7 +249,7 @@ export const ParkAndRideItinerary = () => (
 );
 
 export const BikeRentalTransitItinerary = () => (
-  <BaseMap forceMaxHeight center={[45.538841, -122.6302]} zoom={12}>
+  <BaseMap center={[45.538841, -122.6302]} zoom={12}>
     <EndpointsOverlay
       fromLocation={getFromLocation(bikeRentalTransitBikeRentalItinerary)}
       setLocation={setLocation}
@@ -258,7 +267,7 @@ export const BikeRentalTransitItinerary = () => (
 );
 
 export const EScooterRentalTransitItinerary = injectIntl(({ intl }) => (
-  <BaseMap forceMaxHeight center={[45.538841, -122.6302]} zoom={12}>
+  <BaseMap center={[45.538841, -122.6302]} zoom={12}>
     <EndpointsOverlay
       fromLocation={getFromLocation(
         eScooterRentalTransiteScooterRentalItinerary
@@ -278,7 +287,7 @@ export const EScooterRentalTransitItinerary = injectIntl(({ intl }) => (
 ));
 
 export const TncTransitItinerary = () => (
-  <BaseMap forceMaxHeight center={[45.538841, -122.6302]} zoom={12}>
+  <BaseMap center={[45.538841, -122.6302]} zoom={12}>
     <EndpointsOverlay
       fromLocation={getFromLocation(tncTransitTncItinerary)}
       setLocation={setLocation}
@@ -295,7 +304,7 @@ export const TncTransitItinerary = () => (
 );
 
 export const WalkTransitWalkItineraryAndCustomLabelStyles = () => (
-  <BaseMap forceMaxHeight center={[45.520441, -122.68302]} zoom={16}>
+  <BaseMap center={[45.520441, -122.68302]} zoom={16}>
     <EndpointsOverlay
       fromLocation={getFromLocation(walkTransitWalkItinerary)}
       setLocation={setLocation}
@@ -327,7 +336,7 @@ export const WalkTransitWalkItineraryAndCustomLabelStyles = () => (
   </BaseMap>
 );
 export const FlexItinerary = () => (
-  <BaseMap forceMaxHeight center={[33.749, -84.388]} zoom={11}>
+  <BaseMap center={[33.749, -84.388]} zoom={11}>
     <EndpointsOverlay
       fromLocation={getFromLocation(flexItinerary)}
       setLocation={setLocation}
@@ -342,7 +351,7 @@ export const FlexItinerary = () => (
 );
 
 export const OTP2ScooterItinerary = injectIntl(({ intl }) => (
-  <BaseMap forceMaxHeight center={[33.749, -84.388]} zoom={11}>
+  <BaseMap center={[33.749, -84.388]} zoom={11}>
     <EndpointsOverlay
       fromLocation={getFromLocation(otp2ScooterItinerary)}
       setLocation={setLocation}

--- a/packages/trip-viewer-overlay/package.json
+++ b/packages/trip-viewer-overlay/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.0",
-    "@opentripplanner/base-map": "^3.0.0-alpha.1",
+    "@opentripplanner/base-map": "^3.0.0-alpha.3",
     "@opentripplanner/core-utils": "^6.0.0"
   },
   "peerDependencies": {

--- a/packages/trip-viewer-overlay/src/TripViewerOverlay.story.tsx
+++ b/packages/trip-viewer-overlay/src/TripViewerOverlay.story.tsx
@@ -1,4 +1,4 @@
-import BaseMap from "@opentripplanner/base-map";
+import BaseMap, { Styled as BaseMapStyled } from "@opentripplanner/base-map";
 import React from "react";
 
 import tripData from "../__mocks__/mock-trip.json";
@@ -13,21 +13,25 @@ export default {
 };
 
 export const Default = (): JSX.Element => (
-  <BaseMap forceMaxHeight center={center} zoom={zoom}>
-    <TripViewerOverlay tripData={tripData} visible />
-  </BaseMap>
+  <BaseMapStyled.StoryMapContainer>
+    <BaseMap center={center} zoom={zoom}>
+      <TripViewerOverlay tripData={tripData} visible />
+    </BaseMap>
+  </BaseMapStyled.StoryMapContainer>
 );
 
 export const WithPathStyling = (): JSX.Element => (
-  <BaseMap forceMaxHeight center={center} zoom={zoom}>
-    <TripViewerOverlay
-      path={{
-        color: "#000",
-        opacity: 0.2,
-        weight: 5
-      }}
-      tripData={tripData}
-      visible
-    />
-  </BaseMap>
+  <BaseMapStyled.StoryMapContainer>
+    <BaseMap center={center} zoom={zoom}>
+      <TripViewerOverlay
+        path={{
+          color: "#000",
+          opacity: 0.2,
+          weight: 5
+        }}
+        tripData={tripData}
+        visible
+      />
+    </BaseMap>
+  </BaseMapStyled.StoryMapContainer>
 );

--- a/packages/vehicle-rental-overlay/package.json
+++ b/packages/vehicle-rental-overlay/package.json
@@ -19,7 +19,7 @@
     "url": "git+https://github.com/opentripplanner/otp-ui.git"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.0-alpha.1",
+    "@opentripplanner/base-map": "^3.0.0-alpha.3",
     "@opentripplanner/core-utils": "^6.0.0",
     "@opentripplanner/from-to-location-picker": "^2.1.2",
     "@styled-icons/fa-solid": "^10.34.0",

--- a/packages/vehicle-rental-overlay/src/VehicleRentalOverlay.story.tsx
+++ b/packages/vehicle-rental-overlay/src/VehicleRentalOverlay.story.tsx
@@ -1,4 +1,4 @@
-import BaseMap from "@opentripplanner/base-map";
+import BaseMap, { Styled as BaseMapStyled } from "@opentripplanner/base-map";
 import React from "react";
 import { action } from "@storybook/addon-actions";
 import { boolean } from "@storybook/addon-knobs";
@@ -53,18 +53,20 @@ const ZoomControlledMapWithVehicleRentalOverlay = ({
 }: StoryProps) => (
   // Caution, <BaseMap> must be a direct parent of <VehicleRentalOverlay>.
   // Therefore, do not place <BaseMap> in a decorator at this time.
-  <BaseMap center={center} forceMaxHeight zoom={INITIAL_ZOOM}>
-    <VehicleRentalOverlay
-      id="test"
-      configCompanies={configCompanies}
-      companies={companies}
-      getStationName={getStationName}
-      setLocation={setLocation}
-      refreshVehicles={refreshVehicles}
-      stations={stations}
-      visible={visible}
-    />
-  </BaseMap>
+  <BaseMapStyled.StoryMapContainer>
+    <BaseMap center={center} zoom={INITIAL_ZOOM}>
+      <VehicleRentalOverlay
+        id="test"
+        configCompanies={configCompanies}
+        companies={companies}
+        getStationName={getStationName}
+        setLocation={setLocation}
+        refreshVehicles={refreshVehicles}
+        stations={stations}
+        visible={visible}
+      />
+    </BaseMap>
+  </BaseMapStyled.StoryMapContainer>
 );
 
 function customStationName(_, station) {

--- a/packages/zoom-based-markers/package.json
+++ b/packages/zoom-based-markers/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@opentripplanner/core-utils": "^6.0.0",
-    "@opentripplanner/base-map": "^3.0.0-alpha.1"
+    "@opentripplanner/base-map": "^3.0.0-alpha.3"
   },
   "devDependencies": {
     "@opentripplanner/types": "^2.0.0"

--- a/packages/zoom-based-markers/src/ZoomBasedMarker.story.tsx
+++ b/packages/zoom-based-markers/src/ZoomBasedMarker.story.tsx
@@ -123,19 +123,20 @@ const Example = (props: ExampleProps) => {
 
   const { symbols, symbolTransform } = props;
   return (
-    <BaseMap
-      center={mapCenter}
-      forceMaxHeight
-      onViewportChanged={handleViewportChanged}
-      zoom={zoom}
-    >
-      <ZoomBasedMarkers
-        entities={mockStops}
-        symbols={symbols}
-        symbolTransform={symbolTransform}
+    <BaseMapStyles.StoryMapContainer>
+      <BaseMap
+        center={mapCenter}
+        onViewportChanged={handleViewportChanged}
         zoom={zoom}
-      />
-    </BaseMap>
+      >
+        <ZoomBasedMarkers
+          entities={mockStops}
+          symbols={symbols}
+          symbolTransform={symbolTransform}
+          zoom={zoom}
+        />
+      </BaseMap>
+    </BaseMapStyles.StoryMapContainer>
   );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3054,10 +3054,10 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
-"@opentripplanner/base-map@^3.0.0-alpha.1":
-  version "3.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/base-map/-/base-map-3.0.0-alpha.1.tgz#6ab96ce1f33ae377367777e2fc7f4b0d6789cb24"
-  integrity sha512-GMiWSITX4hbs6darpOJEVL0De97ghI5f3FhZS6XyQlrlB1NS7o/ixbEFIpCLCF4dewjcNE9nKOCBijZPaF3mAw==
+"@opentripplanner/base-map@^3.0.0-alpha.3":
+  version "3.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/base-map/-/base-map-3.0.0-alpha.3.tgz#7343e7e075865cc5e31f5267d9b52ee580b55398"
+  integrity sha512-LRcRjboRuE4Q5dBaHUmKvCMSIwvPTxURm37mSk9/BAHJlszDYC4yG3Jg1N+0B6a3mAx2S8kpwNDMXrgYBfvDfA==
   dependencies:
     "@opentripplanner/types" "^2.0.0"
     mapbox-gl "npm:empty-npm-package@1.0.0"


### PR DESCRIPTION
This PR suggests a way to remove the somewhat "artificial" `forceMaxHeight` and `passedRef` props from the `BaseMap` component from #420, see if these changes are useful to you. (does not cover propagating changes to other packages, snapshots, and other refactors such as having a storybook-wide decorator for the various map overlays).