### PR TITLE
Remove momentjs (2/2)

### DIFF
--- a/packages/itinerary-body/package.json
+++ b/packages/itinerary-body/package.json
@@ -16,8 +16,8 @@
     "@opentripplanner/location-icon": "^1.4.0",
     "@styled-icons/fa-solid": "^10.34.0",
     "@styled-icons/foundation": "^10.34.0",
+    "date-fns": "^2.28.0",
     "flat": "^5.0.2",
-    "moment": "^2.24.0",
     "react-resize-detector": "^4.2.1",
     "velocity-react": "^1.4.3"
   },

--- a/packages/itinerary-body/package.json
+++ b/packages/itinerary-body/package.json
@@ -17,6 +17,7 @@
     "@styled-icons/fa-solid": "^10.34.0",
     "@styled-icons/foundation": "^10.34.0",
     "date-fns": "^2.28.0",
+    "date-fns-tz": "^1.2.2",
     "flat": "^5.0.2",
     "react-resize-detector": "^4.2.1",
     "velocity-react": "^1.4.3"

--- a/packages/itinerary-body/src/ItineraryBody/place-row.tsx
+++ b/packages/itinerary-body/src/ItineraryBody/place-row.tsx
@@ -121,6 +121,7 @@ export default function PlaceRow({
                 setViewedTrip={setViewedTrip}
                 showAgencyInfo={showAgencyInfo}
                 showViewTripButton={showViewTripButton}
+                timeZone={config.homeTimezone}
                 TransitLegSubheader={TransitLegSubheader}
                 TransitLegSummary={TransitLegSummary}
                 transitOperator={coreUtils.route.getTransitOperatorFromLeg(

--- a/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
@@ -40,7 +40,7 @@ export default function AlertsBody({
             // The difference is expressed in calendar days based on the agency's time zone.
             // Note: Previously, we used moment.diff(..., "days"), which reports the number of whole 24-hour periods
             // between two timestamps/dates (not considering timezones or daylight time changes).
-            const today = toDate(getCurrentDate(timeZone), getUserTimezone());
+            const today = toDate(getCurrentDate(timeZone));
             const compareDate = utcToZonedTime(
               new Date(effectiveStartDate),
               timeZone

--- a/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
@@ -1,4 +1,4 @@
-import moment from "moment";
+import { differenceInDays } from "date-fns";
 import { Alert } from "@opentripplanner/types";
 import React, { FunctionComponent, ReactElement } from "react";
 import { FormattedMessage } from "react-intl";
@@ -31,9 +31,15 @@ export default function AlertsBody({
           ) => {
             // If alert is effective as of +/- one day, use today, tomorrow, or
             // yesterday with time. Otherwise, use long date format.
-            // FIXME: adding 24 hours to a date that is "today" can lead moment to
-            // report the result to still be "today" (see OTP-RR story).
-            const dayDiff = moment(effectiveStartDate).diff(moment(), "days");
+            const dayDiff = differenceInDays(
+              new Date(effectiveStartDate),
+              new Date()
+            );
+
+            // TODO: Express the difference in calendar days based on the agency's time zone.
+            // Note: Previously, we used moment.diff(..., "days"), which reports the number of whole 24-hour periods
+            // between two timestamps/dates (not considering timezones or daylight time changes).
+
             return (
               <S.TransitAlert key={i} href={alertUrl}>
                 <S.TransitAlertIconContainer>

--- a/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
@@ -1,4 +1,6 @@
-import { differenceInDays } from "date-fns";
+import { differenceInCalendarDays } from "date-fns";
+import { toDate, utcToZonedTime } from "date-fns-tz";
+import coreUtils from "@opentripplanner/core-utils";
 import { Alert } from "@opentripplanner/types";
 import React, { FunctionComponent, ReactElement } from "react";
 import { FormattedMessage } from "react-intl";
@@ -6,14 +8,18 @@ import { FormattedMessage } from "react-intl";
 import * as S from "../styled";
 import { defaultMessages } from "../util";
 
+const { getUserTimezone, getCurrentDate } = coreUtils.time;
+
 interface Props {
   alerts: Alert[];
   AlertIcon?: FunctionComponent;
+  timeZone?: string;
 }
 
 export default function AlertsBody({
   alerts,
-  AlertIcon = S.DefaultAlertBodyIcon
+  AlertIcon = S.DefaultAlertBodyIcon,
+  timeZone = getUserTimezone()
 }: Props): ReactElement {
   return (
     <S.TransitAlerts>
@@ -31,14 +37,15 @@ export default function AlertsBody({
           ) => {
             // If alert is effective as of +/- one day, use today, tomorrow, or
             // yesterday with time. Otherwise, use long date format.
-            const dayDiff = differenceInDays(
-              new Date(effectiveStartDate),
-              new Date()
-            );
-
-            // TODO: Express the difference in calendar days based on the agency's time zone.
+            // The difference is expressed in calendar days based on the agency's time zone.
             // Note: Previously, we used moment.diff(..., "days"), which reports the number of whole 24-hour periods
             // between two timestamps/dates (not considering timezones or daylight time changes).
+            const today = toDate(getCurrentDate(timeZone), getUserTimezone());
+            const compareDate = utcToZonedTime(
+              new Date(effectiveStartDate),
+              timeZone
+            );
+            const dayDiff = differenceInCalendarDays(compareDate, today);
 
             return (
               <S.TransitAlert key={i} href={alertUrl}>

--- a/packages/itinerary-body/src/TransitLegBody/index.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/index.tsx
@@ -42,6 +42,7 @@ interface Props {
   setViewedTrip: SetViewedTripFunction;
   showAgencyInfo: boolean;
   showViewTripButton: boolean;
+  timeZone: string;
   TransitLegSubheader?: FunctionComponent<TransitLegSubheaderProps>;
   TransitLegSummary: FunctionComponent<TransitLegSummaryProps>;
   transitOperator?: TransitOperator;
@@ -98,6 +99,7 @@ class TransitLegBody extends Component<Props, State> {
       setViewedTrip,
       showAgencyInfo,
       showViewTripButton,
+      timeZone,
       TransitLegSubheader,
       TransitLegSummary,
       transitOperator
@@ -210,7 +212,11 @@ class TransitLegBody extends Component<Props, State> {
             leave={{ animation: "slideUp" }}
           >
             {expandAlerts && (
-              <AlertsBody alerts={leg.alerts} AlertIcon={AlertBodyIcon} />
+              <AlertsBody
+                alerts={leg.alerts}
+                AlertIcon={AlertBodyIcon}
+                timeZone={timeZone}
+              />
             )}
           </VelocityTransitionGroup>
           {/* The "Ride X Min / X Stops" Row, including IntermediateStops body */}

--- a/packages/itinerary-body/src/stories/OtpRrItineraryBody.story.tsx
+++ b/packages/itinerary-body/src/stories/OtpRrItineraryBody.story.tsx
@@ -37,11 +37,11 @@ if (!isRunningJest()) {
   // for illustration outside of the CI environment.
   const alerts = walkTransitWalkItinerary.legs[1].alerts;
   const todayWithTime = new Date();
-  // todayWithTime.setUTCHours(14, 48, 25);
+  todayWithTime.setUTCHours(14, 48, 25);
   const now = todayWithTime.valueOf();
   alerts[0].effectiveStartDate = now; // Today
   alerts[1].effectiveStartDate = now - 24 * 3600000; // Yesterday
-  alerts[2].effectiveStartDate = now + 24 * 3600000 + 10000; // Tomorrow (with some lag until stories render)
+  alerts[2].effectiveStartDate = now + 24 * 3600000 + 10000; // Tomorrow
 }
 
 interface StoryWrapperProps {

--- a/packages/itinerary-body/src/stories/OtpRrItineraryBody.story.tsx
+++ b/packages/itinerary-body/src/stories/OtpRrItineraryBody.story.tsx
@@ -37,13 +37,11 @@ if (!isRunningJest()) {
   // for illustration outside of the CI environment.
   const alerts = walkTransitWalkItinerary.legs[1].alerts;
   const todayWithTime = new Date();
-  todayWithTime.setUTCHours(14, 48, 25);
+  // todayWithTime.setUTCHours(14, 48, 25);
   const now = todayWithTime.valueOf();
   alerts[0].effectiveStartDate = now; // Today
   alerts[1].effectiveStartDate = now - 24 * 3600000; // Yesterday
-  // FIXME: Fix the criterion that decides what constitutes "tomorrow"
-  // (Adding 24 hours so that a timestamp occurs next day may not be enough).
-  alerts[2].effectiveStartDate = now + 36 * 3600000; // Tomorrow
+  alerts[2].effectiveStartDate = now + 24 * 3600000 + 10000; // Tomorrow (with some lag until stories render)
 }
 
 interface StoryWrapperProps {

--- a/packages/trip-form/package.json
+++ b/packages/trip-form/package.json
@@ -16,8 +16,8 @@
     "@styled-icons/boxicons-regular": "^10.38.0",
     "@styled-icons/fa-regular": "^10.34.0",
     "@styled-icons/fa-solid": "^10.34.0",
+    "date-fns": "^2.28.0",
     "flat": "^5.0.2",
-    "moment": "^2.17.1",
     "react-indiana-drag-scroll": "^2.0.1",
     "react-inlinesvg": "^2.3.0"
   },

--- a/packages/trip-form/src/DateTimeSelector/index.tsx
+++ b/packages/trip-form/src/DateTimeSelector/index.tsx
@@ -1,6 +1,6 @@
 import CSS from "csstype";
+import { format, parse } from "date-fns";
 import flatten from "flat";
-import moment from "moment";
 import coreUtils from "@opentripplanner/core-utils";
 import React, { ChangeEvent, ReactElement, ReactNode, useCallback } from "react";
 import { FormattedMessage } from "react-intl";
@@ -25,6 +25,7 @@ const {
   getCurrentTime,
   getUserTimezone,
   OTP_API_DATE_FORMAT,
+  OTP_API_DATE_FORMAT_DATE_FNS,
   OTP_API_TIME_FORMAT
 } = coreUtils.time;
 
@@ -97,6 +98,11 @@ function isInputTypeSupported(type: string): boolean {
 const supportsDateTimeInputs = isInputTypeSupported("date") && isInputTypeSupported("time");
 
 /**
+ * Reference date for parsing.
+ */
+const referenceDate = new Date();
+
+/**
  * The `DateTimeSelector` component lets the OTP user chose a departure or arrival date/time.
  * (The departure can be right now.)
  *
@@ -150,9 +156,7 @@ export default function DateTimeSelector({
 
   const handleTimeChangeLegacy = useCallback(
     (evt: ChangeEvent<HTMLInputElement>): void => {
-      const newTime = moment(evt.target.value, timeFormatLegacy).format(
-        OTP_API_TIME_FORMAT
-      );
+      const newTime = format(parse(evt.target.value, timeFormatLegacy, referenceDate), OTP_API_TIME_FORMAT);
       handleQueryParamChange({ newTime });
     },
     [onQueryParamChange]
@@ -160,9 +164,7 @@ export default function DateTimeSelector({
 
   const handleDateChangeLegacy = useCallback(
     (evt: ChangeEvent<HTMLInputElement>): void => {
-      const newDate = moment(evt.target.value, dateFormatLegacy).format(
-        OTP_API_DATE_FORMAT
-      );
+      const newDate = format(parse(evt.target.value, dateFormatLegacy, referenceDate), OTP_API_DATE_FORMAT_DATE_FNS);
       handleQueryParamChange({ newDate });
     },
     [onQueryParamChange]
@@ -265,9 +267,7 @@ export default function DateTimeSelector({
         <S.DateTimeSelector.DateTimeRow>
           <div>
             <input
-              defaultValue={moment(time, OTP_API_TIME_FORMAT).format(
-                timeFormatLegacy
-              )}
+              defaultValue={format(parse(time, OTP_API_TIME_FORMAT, referenceDate), timeFormatLegacy)}
               onChange={handleTimeChangeLegacy}
               required
               type="text"
@@ -275,9 +275,7 @@ export default function DateTimeSelector({
           </div>
           <div>
             <input
-              defaultValue={moment(date, OTP_API_DATE_FORMAT).format(
-                dateFormatLegacy
-              )}
+              defaultValue={format(parse(date, OTP_API_DATE_FORMAT_DATE_FNS, referenceDate), dateFormatLegacy)}
               onChange={handleDateChangeLegacy}
               required
               type="text"

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -131,6 +131,7 @@ export type Config = {
     dateFormat?: string;
     longDateFormat?: string;
   };
+  homeTimezone: string;
   modes: ConfiguredModes;
   // TODO: add full typing
   map?: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8937,10 +8937,10 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-date-fns@^2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.23.0.tgz#4e886c941659af0cf7b30fafdd1eaa37e88788a9"
-  integrity sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==
+date-fns@^2.28.0, date-fns@^2.23.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
 
 dateformat@^3.0.0:
   version "3.0.3"
@@ -14895,7 +14895,7 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment@^2.17.1, moment@^2.24.0:
+moment@^2.24.0:
   version "2.29.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
   integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8932,12 +8932,17 @@ date-fns-tz@^1.1.4:
   resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.1.4.tgz#38282c2bfab08946a4e9bb89d733451e5525048b"
   integrity sha512-lQ+FF7xUxxRuRqIY7H/lagnT3PhhSnnvtGHzjE5WZKwRyLU7glJfLys05SZ7zHlEr6RXWiqkmgWq4nCkcElR+g==
 
+date-fns-tz@^1.2.2:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.3.6.tgz#4195a58a2f86eda55ea69fb477f3ed8a6e2188ac"
+  integrity sha512-C8q7mErvG4INw1ZwAFmPlGjEo5Sv4udjKVbTc03zpP9cu6cp5AemFzKhz0V68LGcWEtX5mJudzzg3G04emIxLA==
+
 date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-date-fns@^2.28.0, date-fns@^2.23.0:
+date-fns@^2.23.0, date-fns@^2.28.0:
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
   integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==


### PR DESCRIPTION
This PR replaces the momentjs dependency with date-fns on the itinerary-body and trip-form packages.
Minor release versions should be issued as a result.

Fix #359 by determining what constitutes "today", "tomorrow" or "yesterday" by comparing calendar days instead of 24-hour periods in the AlertsBody.
