### PR TITLE
Update to coreutils 7

### DIFF
--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -28,6 +28,6 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^3.0.0-alpha.4"
+    "@opentripplanner/types": "^3.0.0"
   }
 }

--- a/packages/endpoints-overlay/package.json
+++ b/packages/endpoints-overlay/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@opentripplanner/location-icon": "^1.4.0",
-    "@opentripplanner/core-utils": "^7.0.0-alpha.3",
+    "@opentripplanner/core-utils": "^7.0.0",
     "flat": "^5.0.2",
     "@styled-icons/fa-solid": "^10.34.0"
   },

--- a/packages/from-to-location-picker/package.json
+++ b/packages/from-to-location-picker/package.json
@@ -12,6 +12,9 @@
     "@opentripplanner/location-icon": "^1.4.0",
     "flat": "^5.0.2"
   },
+  "devDependencies": {
+    "@opentripplanner/types": "^3.0.0"
+  },
   "peerDependencies": {
     "react": "^16.14.0",
     "react-intl": "^5.20.4",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^7.0.0-alpha.3",
+    "@opentripplanner/core-utils": "^7.0.0",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/itinerary-body/package.json
+++ b/packages/itinerary-body/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^7.0.0-alpha.3",
+    "@opentripplanner/core-utils": "^7.0.0",
     "@opentripplanner/humanize-distance": "^1.2.0",
     "@opentripplanner/icons": "^1.2.2",
     "@opentripplanner/location-icon": "^1.4.0",
@@ -23,7 +23,7 @@
     "velocity-react": "^1.4.3"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^3.0.0-alpha.4",
+    "@opentripplanner/types": "^3.0.0",
     "@types/flat": "^5.0.2"
   },
   "peerDependencies": {

--- a/packages/location-field/package.json
+++ b/packages/location-field/package.json
@@ -10,7 +10,7 @@
   "private": false,
   "dependencies": {
     "@conveyal/geocoder-arcgis-geojson": "^0.0.3",
-    "@opentripplanner/core-utils": "^7.0.0-alpha.3",
+    "@opentripplanner/core-utils": "^7.0.0",
     "@opentripplanner/geocoder": "^1.2.0",
     "@opentripplanner/humanize-distance": "^1.1.0",
     "@opentripplanner/location-icon": "^1.4.0",

--- a/packages/route-viewer-overlay/package.json
+++ b/packages/route-viewer-overlay/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.0",
-    "@opentripplanner/core-utils": "^7.0.0-alpha.3",
+    "@opentripplanner/core-utils": "^7.0.0",
     "point-in-polygon": "^1.1.0",
     "prop-types": "^15.7.2"
   },

--- a/packages/stop-viewer-overlay/package.json
+++ b/packages/stop-viewer-overlay/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/core-utils": "^7.0.0-alpha.3",
+    "@opentripplanner/core-utils": "^7.0.0",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/transit-vehicle-overlay/package.json
+++ b/packages/transit-vehicle-overlay/package.json
@@ -9,7 +9,7 @@
   "module": "esm/index.js",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^7.0.0-alpha.3",
+    "@opentripplanner/core-utils": "^7.0.0",
     "@opentripplanner/icons": "^1.2.1",
     "@opentripplanner/zoom-based-markers": "^1.2.1",
     "@turf/helpers": "^6.5.0",

--- a/packages/transitive-overlay/package.json
+++ b/packages/transitive-overlay/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@opentripplanner/itinerary-body": "^4.0.0",
-    "@opentripplanner/core-utils": "^7.0.0-alpha.3",
+    "@opentripplanner/core-utils": "^7.0.0",
     "lodash.isequal": "^4.5.0",
     "transitive-js": "^0.14.1"
   },

--- a/packages/trip-details/package.json
+++ b/packages/trip-details/package.json
@@ -11,13 +11,13 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^7.0.0-alpha.3",
+    "@opentripplanner/core-utils": "^7.0.0",
     "@styled-icons/fa-solid": "^10.34.0",
     "flat": "^5.0.2",
     "velocity-react": "^1.4.3"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^3.0.0-alpha.4",
+    "@opentripplanner/types": "^3.0.0",
     "@types/flat": "^5.0.2"
   },
   "peerDependencies": {

--- a/packages/trip-form/package.json
+++ b/packages/trip-form/package.json
@@ -10,7 +10,7 @@
   "types": "lib/index.d.ts",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^7.0.0-alpha.3",
+    "@opentripplanner/core-utils": "^7.0.0",
     "@opentripplanner/icons": "^1.2.2",
     "@styled-icons/bootstrap": "^10.34.0",
     "@styled-icons/boxicons-regular": "^10.38.0",

--- a/packages/trip-viewer-overlay/package.json
+++ b/packages/trip-viewer-overlay/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.0",
-    "@opentripplanner/core-utils": "^7.0.0-alpha.3",
+    "@opentripplanner/core-utils": "^7.0.0",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/vehicle-rental-overlay/package.json
+++ b/packages/vehicle-rental-overlay/package.json
@@ -18,7 +18,7 @@
     "url": "git+https://github.com/opentripplanner/otp-ui.git"
   },
   "dependencies": {
-    "@opentripplanner/core-utils": "^7.0.0-alpha.3",
+    "@opentripplanner/core-utils": "^7.0.0",
     "@opentripplanner/from-to-location-picker": "^2.1.2",
     "@opentripplanner/zoom-based-markers": "^1.2.1",
     "@styled-icons/fa-solid": "^10.34.0",

--- a/packages/zoom-based-markers/package.json
+++ b/packages/zoom-based-markers/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/core-utils": "^7.0.0-alpha.3"
+    "@opentripplanner/core-utils": "^7.0.0"
   },
   "peerDependencies": {
     "@opentripplanner/base-map": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2787,27 +2787,6 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
-"@opentripplanner/core-utils@^7.0.0-alpha.3":
-  version "7.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-7.0.0-alpha.3.tgz#8f445f1e894f51b32f096730c34ae5e957e40848"
-  integrity sha512-wBVts5rAW0/L1pAUf5eNavEml3zCK1QAXt+8dPa+x23QjvcHSzJipxnH72Kezh1uWgTPRPDiqg3nObxdrDN0dg==
-  dependencies:
-    "@mapbox/polyline" "^1.1.0"
-    "@opentripplanner/geocoder" "^1.2.2"
-    "@styled-icons/foundation" "^10.34.0"
-    "@turf/along" "^6.0.1"
-    bowser "^2.7.0"
-    date-fns "^2.28.0"
-    date-fns-tz "^1.2.2"
-    lodash.clonedeep "^4.5.0"
-    lodash.isequal "^4.5.0"
-    qs "^6.9.1"
-
-"@opentripplanner/types@^3.0.0-alpha.4":
-  version "3.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/types/-/types-3.0.0-alpha.4.tgz#1804267d3bd5b138f1e715964fb238f79372c19b"
-  integrity sha512-6/6WuOQpve8De9Jbc+qweaSmebWO/fQgaheMLL/gLzS67KDPA8AstRN+z39liRvzp+McaHjNNfgD0UCWPZiakA==
-
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.1":
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.4.tgz#df0d0d855fc527db48aac93c218a0bf4ada41f99"


### PR DESCRIPTION
This PR updates packages to use core-utils 7.0.0 and types 3.0.0. Patch releases should occur for all affected packages, except for core-utils that should not have a release

(The types dev dependency for core-utils is updated, but it is identical to the released one, so that does not change `.d.ts` files generated for core-utils.)