### PR TITLE
Refactor Flex Reduction to be Optional

### DIFF
--- a/packages/core-utils/src/query.js
+++ b/packages/core-utils/src/query.js
@@ -144,7 +144,9 @@ function isParamApplicable(paramInfo, query, config) {
  * Helper method which replaces OTP flex modes with single FLEX mode that's
  * more useful and easier to work with.
  */
-export function reduceOtpFlexModes(modes) {
+export function reduceOtpFlexModes(modes, enabled = true) {
+  if (!enabled) return modes;
+
   return modes.reduce((prev, cur) => {
     const newModes = prev;
     // Add the current mode if it is not a flex mode
@@ -187,7 +189,10 @@ export function expandOtpFlexMode(mode) {
  * default values.
  */
 export function isNotDefaultQuery(query, config) {
-  const activeModes = reduceOtpFlexModes(query.mode.split(",").sort());
+  const activeModes = reduceOtpFlexModes(
+    query.mode.split(",").sort(),
+    config.modes?.mergeFlex
+  );
   if (
     activeModes.length !== 2 ||
     activeModes[0] !== "TRANSIT" ||
@@ -466,7 +471,8 @@ export function getRoutingParams(config, currentQuery, ignoreRealtimeUpdates) {
   }
 
   // Replace FLEX placeholder with OTP flex modes
-  if (params.mode) {
+  // Explicit false check allows avoiding a breaking change -- undefined is true
+  if (params.mode && config.modes?.mergeFlex !== false) {
     // Ensure query is in reduced format to avoid replacing twice
     const reducedMode = reduceOtpFlexModes(params.mode.split(",")).join(",");
     params.mode = expandOtpFlexMode(reducedMode);


### PR DESCRIPTION
Edit: this seems to be blocked by #430.

A while ago we introduced "flex mode reducing". This feature allowed `core-utils` users to have a single mode `FLEX` which was automatically expanded/reduced to `FLEX_EGRESS,FLEX_ACCESS,FLEX_DIRECT`. 

This feature makes it really easy to add flex as a travel mode. However, it makes it difficult to use any of these OTP modes on their own. 

This PR makes this reduction optional, so that a user who wants to handle each OTP mode individually is able to. To remain backwards-compatible, the default behavior is the current behavior. Unit tests ensure that default behavior is unchanged. 