### PR TITLE
Update Internal Dependencies (Sep 2022)

### DIFF
--- a/packages/base-map/package.json
+++ b/packages/base-map/package.json
@@ -14,7 +14,7 @@
     "react-map-gl": "^7.0.15"
   },
   "peerDependencies": {
-    "@opentripplanner/types": "^3.0.0",
+    "@opentripplanner/types": "^4.0.0",
     "react": "^16.14.0",
     "styled-components": "^5.3.0"
   },

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -28,6 +28,6 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^3.0.0"
+    "@opentripplanner/types": "^4.0.0"
   }
 }

--- a/packages/endpoints-overlay/package.json
+++ b/packages/endpoints-overlay/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.0-alpha.3",
+    "@opentripplanner/base-map": "^3.0.0",
     "@opentripplanner/location-icon": "^1.4.0",
     "@opentripplanner/core-utils": "^7.0.0",
     "flat": "^5.0.2",

--- a/packages/endpoints-overlay/package.json
+++ b/packages/endpoints-overlay/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@opentripplanner/base-map": "^3.0.0",
     "@opentripplanner/location-icon": "^1.4.0",
-    "@opentripplanner/core-utils": "^7.0.0",
+    "@opentripplanner/core-utils": "^7.0.1",
     "flat": "^5.0.2",
     "@styled-icons/fa-solid": "^10.34.0"
   },
@@ -29,7 +29,7 @@
     "@types/flat": "^5.0.2"
   },
   "peerDependencies": {
-    "@opentripplanner/types": "^3.0.0",
+    "@opentripplanner/types": "^4.0.0",
     "react": "^16.14.0",
     "react-dom": "^16.8.6",
     "react-intl": "^5.24.6",

--- a/packages/from-to-location-picker/package.json
+++ b/packages/from-to-location-picker/package.json
@@ -13,7 +13,7 @@
     "flat": "^5.0.2"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^3.0.0"
+    "@opentripplanner/types": "^4.0.0"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^7.0.0",
+    "@opentripplanner/core-utils": "^7.0.1",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/itinerary-body/package.json
+++ b/packages/itinerary-body/package.json
@@ -10,9 +10,9 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^7.0.0",
+    "@opentripplanner/core-utils": "^7.0.1",
     "@opentripplanner/humanize-distance": "^1.2.0",
-    "@opentripplanner/icons": "^1.2.2",
+    "@opentripplanner/icons": "^1.2.4",
     "@opentripplanner/location-icon": "^1.4.0",
     "@styled-icons/fa-solid": "^10.34.0",
     "@styled-icons/foundation": "^10.34.0",
@@ -23,7 +23,7 @@
     "react-animate-height": "^3.0.4"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^3.0.0",
+    "@opentripplanner/types": "^4.0.0",
     "@types/flat": "^5.0.2"
   },
   "peerDependencies": {

--- a/packages/location-field/package.json
+++ b/packages/location-field/package.json
@@ -10,9 +10,9 @@
   "private": false,
   "dependencies": {
     "@conveyal/geocoder-arcgis-geojson": "^0.0.3",
-    "@opentripplanner/core-utils": "^7.0.0",
-    "@opentripplanner/geocoder": "^1.2.0",
-    "@opentripplanner/humanize-distance": "^1.1.0",
+    "@opentripplanner/core-utils": "^7.0.1",
+    "@opentripplanner/geocoder": "^1.3.0",
+    "@opentripplanner/humanize-distance": "^1.2.0",
     "@opentripplanner/location-icon": "^1.4.0",
     "@styled-icons/fa-solid": "^10.34.0",
     "throttle-debounce": "^2.1.0"

--- a/packages/park-and-ride-overlay/package.json
+++ b/packages/park-and-ride-overlay/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.0-alpha.3",
+    "@opentripplanner/base-map": "^3.0.0",
     "@opentripplanner/from-to-location-picker": "^2.1.2"
   },
   "peerDependencies": {

--- a/packages/printable-itinerary/package.json
+++ b/packages/printable-itinerary/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/itinerary-body": "^4.0.3"
+    "@opentripplanner/itinerary-body": "^4.0.4"
   },
   "devDependencies": {
     "@opentripplanner/icons": "^1.2.4"

--- a/packages/route-viewer-overlay/package.json
+++ b/packages/route-viewer-overlay/package.json
@@ -21,11 +21,11 @@
   "dependencies": {
     "@mapbox/polyline": "^1.1.0",
     "@opentripplanner/base-map": "^3.0.0",
-    "@opentripplanner/core-utils": "^7.0.0",
+    "@opentripplanner/core-utils": "^7.0.1",
     "point-in-polygon": "^1.1.0"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^3.0.0",
+    "@opentripplanner/types": "^4.0.0",
     "point-in-polygon": "^1.1.0",
     "prop-types": "^15.7.2"
   },

--- a/packages/route-viewer-overlay/package.json
+++ b/packages/route-viewer-overlay/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.0",
-    "@opentripplanner/base-map": "^3.0.0-alpha.3",
+    "@opentripplanner/base-map": "^3.0.0",
     "@opentripplanner/core-utils": "^7.0.0",
     "point-in-polygon": "^1.1.0"
   },

--- a/packages/stop-viewer-overlay/package.json
+++ b/packages/stop-viewer-overlay/package.json
@@ -20,10 +20,10 @@
   },
   "dependencies": {
     "@opentripplanner/base-map": "^3.0.0",
-    "@opentripplanner/core-utils": "^7.0.0"
+    "@opentripplanner/core-utils": "^7.0.1"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^3.0.0"
+    "@opentripplanner/types": "^4.0.0"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/stop-viewer-overlay/package.json
+++ b/packages/stop-viewer-overlay/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.0-alpha.3",
+    "@opentripplanner/base-map": "^3.0.0",
     "@opentripplanner/core-utils": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/stops-overlay/package.json
+++ b/packages/stops-overlay/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.0-alpha.3",
+    "@opentripplanner/base-map": "^3.0.0",
     "@opentripplanner/from-to-location-picker": "^2.1.2",
     "flat": "^5.0.2"
   },

--- a/packages/stops-overlay/package.json
+++ b/packages/stops-overlay/package.json
@@ -24,7 +24,7 @@
     "flat": "^5.0.2"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^3.0.0",
+    "@opentripplanner/types": "^4.0.0",
     "styled-icons": "^10.34.0"
   },
   "peerDependencies": {

--- a/packages/transit-vehicle-overlay/package.json
+++ b/packages/transit-vehicle-overlay/package.json
@@ -9,7 +9,7 @@
   "module": "esm/index.js",
   "private": false,
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.0-alpha.3",
+    "@opentripplanner/base-map": "^3.0.0",
     "@opentripplanner/core-utils": "^7.0.0",
     "@opentripplanner/icons": "1.2.2",
     "flat": "^5.0.2"

--- a/packages/transit-vehicle-overlay/package.json
+++ b/packages/transit-vehicle-overlay/package.json
@@ -10,12 +10,12 @@
   "private": false,
   "dependencies": {
     "@opentripplanner/base-map": "^3.0.0",
-    "@opentripplanner/core-utils": "^7.0.0",
-    "@opentripplanner/icons": "1.2.2",
+    "@opentripplanner/core-utils": "^7.0.1",
+    "@opentripplanner/icons": "1.2.4",
     "flat": "^5.0.2"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^3.0.0"
+    "@opentripplanner/types": "^4.0.0"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/transitive-overlay/package.json
+++ b/packages/transitive-overlay/package.json
@@ -21,14 +21,14 @@
   "dependencies": {
     "@mapbox/polyline": "^1.1.1",
     "@opentripplanner/base-map": "^3.0.0",
-    "@opentripplanner/itinerary-body": "^4.0.0",
-    "@opentripplanner/core-utils": "^7.0.0",
+    "@opentripplanner/itinerary-body": "^4.0.4",
+    "@opentripplanner/core-utils": "^7.0.1",
     "lodash.isequal": "^4.5.0",
     "@turf/bbox": "^6.5.0"
   },
   "devDependencies": {
-    "@opentripplanner/endpoints-overlay": "^1.4.1",
-    "@opentripplanner/types": "^3.0.0"
+    "@opentripplanner/endpoints-overlay": "^2.0.0",
+    "@opentripplanner/types": "^4.0.0"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/transitive-overlay/package.json
+++ b/packages/transitive-overlay/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.1",
-    "@opentripplanner/base-map": "^3.0.0-alpha.3",
+    "@opentripplanner/base-map": "^3.0.0",
     "@opentripplanner/itinerary-body": "^4.0.0",
     "@opentripplanner/core-utils": "^7.0.0",
     "lodash.isequal": "^4.5.0",

--- a/packages/trip-details/package.json
+++ b/packages/trip-details/package.json
@@ -11,14 +11,14 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^7.0.0",
+    "@opentripplanner/core-utils": "^7.0.1",
     "@styled-icons/fa-solid": "^10.34.0",
     "date-fns": "^2.29.1",
     "flat": "^5.0.2",
     "react-animate-height": "^3.0.4"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^3.0.0",
+    "@opentripplanner/types": "^4.0.0",
     "@types/flat": "^5.0.2"
   },
   "peerDependencies": {

--- a/packages/trip-form/package.json
+++ b/packages/trip-form/package.json
@@ -10,8 +10,8 @@
   "types": "lib/index.d.ts",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^7.0.0",
-    "@opentripplanner/icons": "^1.2.2",
+    "@opentripplanner/core-utils": "^7.0.1",
+    "@opentripplanner/icons": "^1.2.4",
     "@styled-icons/bootstrap": "^10.34.0",
     "@styled-icons/boxicons-regular": "^10.38.0",
     "@styled-icons/fa-regular": "^10.34.0",

--- a/packages/trip-viewer-overlay/package.json
+++ b/packages/trip-viewer-overlay/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.0",
-    "@opentripplanner/base-map": "^3.0.0-alpha.3",
+    "@opentripplanner/base-map": "^3.0.0",
     "@opentripplanner/core-utils": "^7.0.0"
   },
   "peerDependencies": {

--- a/packages/trip-viewer-overlay/package.json
+++ b/packages/trip-viewer-overlay/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@mapbox/polyline": "^1.1.0",
     "@opentripplanner/base-map": "^3.0.0",
-    "@opentripplanner/core-utils": "^7.0.0"
+    "@opentripplanner/core-utils": "^7.0.1"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/vehicle-rental-overlay/package.json
+++ b/packages/vehicle-rental-overlay/package.json
@@ -19,7 +19,7 @@
     "url": "git+https://github.com/opentripplanner/otp-ui.git"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.0-alpha.3",
+    "@opentripplanner/base-map": "^3.0.0",
     "@opentripplanner/core-utils": "^7.0.0",
     "@opentripplanner/from-to-location-picker": "^2.1.2",
     "@styled-icons/fa-solid": "^10.34.0",

--- a/packages/vehicle-rental-overlay/package.json
+++ b/packages/vehicle-rental-overlay/package.json
@@ -20,14 +20,14 @@
   },
   "dependencies": {
     "@opentripplanner/base-map": "^3.0.0",
-    "@opentripplanner/core-utils": "^7.0.0",
+    "@opentripplanner/core-utils": "^7.0.1",
     "@opentripplanner/from-to-location-picker": "^2.1.2",
     "@styled-icons/fa-solid": "^10.34.0",
     "flat": "^5.0.2",
     "lodash.memoize": "^4.1.2"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^3.0.0"
+    "@opentripplanner/types": "^4.0.0"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/zoom-based-markers/package.json
+++ b/packages/zoom-based-markers/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@opentripplanner/core-utils": "^7.0.0",
-    "@opentripplanner/base-map": "^3.0.0-alpha.3"
+    "@opentripplanner/base-map": "^3.0.0"
   },
   "devDependencies": {
     "@opentripplanner/types": "^3.0.0"

--- a/packages/zoom-based-markers/package.json
+++ b/packages/zoom-based-markers/package.json
@@ -19,11 +19,11 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/core-utils": "^7.0.0",
+    "@opentripplanner/core-utils": "^7.0.1",
     "@opentripplanner/base-map": "^3.0.0"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^3.0.0"
+    "@opentripplanner/types": "^4.0.0"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2832,47 +2832,6 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
-"@opentripplanner/base-map@^3.0.0-alpha.3":
-  version "3.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/base-map/-/base-map-3.0.0-alpha.3.tgz#7343e7e075865cc5e31f5267d9b52ee580b55398"
-  integrity sha512-LRcRjboRuE4Q5dBaHUmKvCMSIwvPTxURm37mSk9/BAHJlszDYC4yG3Jg1N+0B6a3mAx2S8kpwNDMXrgYBfvDfA==
-  dependencies:
-    "@opentripplanner/types" "^2.0.0"
-    mapbox-gl "npm:empty-npm-package@1.0.0"
-    maplibre-gl "^2.1.9"
-    react-map-gl "^7.0.15"
-
-"@opentripplanner/core-utils@^4.5.0":
-  version "4.11.5"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-4.11.5.tgz#ac90d443009fab02aae971d4ed6c1e0fc7da134f"
-  integrity sha512-oVVfbQqzHaY82cYLRm/GpybCo5LsDa8PTJQDU/w/DJLqSqyYm2I2sitQxk6jvmP6Zq80asdxMRvM8Si8yI77aQ==
-  dependencies:
-    "@mapbox/polyline" "^1.1.0"
-    "@opentripplanner/geocoder" "^1.2.2"
-    "@styled-icons/foundation" "^10.34.0"
-    "@turf/along" "^6.0.1"
-    bowser "^2.7.0"
-    date-fns "^2.23.0"
-    date-fns-tz "^1.1.4"
-    lodash.clonedeep "^4.5.0"
-    lodash.isequal "^4.5.0"
-    moment "^2.24.0"
-    prop-types "^15.7.2"
-    qs "^6.9.1"
-
-"@opentripplanner/icons@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/icons/-/icons-1.2.2.tgz#18c93ce34afe2d83a2f0fc6ecea85aa587d14366"
-  integrity sha512-SwHAGyayHAPSVKIVbY1mNXq+ZLA1If61onE0mATKh+sifKnKpjRWgHeEHDpeZu6Dz0mIXnY82tcNUvArjeSxig==
-  dependencies:
-    "@opentripplanner/core-utils" "^4.5.0"
-    prop-types "^15.7.2"
-
-"@opentripplanner/types@^2.0.0":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/types/-/types-2.0.1.tgz#70cef3df07b8f02bf2dd0fbc036b3bf482e669be"
-  integrity sha512-NX56DXpMqRPlzrjEnNRYkBI5QQxXkc0yR2+JlckAidTtJNRHwDqyhgNvVRKfyJPEz8+7/arCFwMXfknnisuxHw==
-
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.1":
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.4.tgz#df0d0d855fc527db48aac93c218a0bf4ada41f99"
@@ -7382,7 +7341,7 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-fns-tz@^1.1.4, date-fns-tz@^1.2.2:
+date-fns-tz@^1.2.2:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.3.6.tgz#4195a58a2f86eda55ea69fb477f3ed8a6e2188ac"
   integrity sha512-C8q7mErvG4INw1ZwAFmPlGjEo5Sv4udjKVbTc03zpP9cu6cp5AemFzKhz0V68LGcWEtX5mJudzzg3G04emIxLA==
@@ -7392,7 +7351,7 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-date-fns@^2.23.0, date-fns@^2.28.0, date-fns@^2.29.1:
+date-fns@^2.28.0, date-fns@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.1.tgz#9667c2615525e552b5135a3116b95b1961456e60"
   integrity sha512-dlLD5rKaKxpFdnjrs+5azHDFOPEu4ANy/LTh04A1DTzMM7qoajmKCBc8pkKRFT41CNzw+4gQh79X5C+Jq27HAw==
@@ -12937,11 +12896,6 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
-
-moment@^2.24.0:
-  version "2.29.2"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
-  integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
As part of the MapLibreGL upgrade, we need to update all internal dependencies. This PR also fully removes moment.