### PR TITLE
fix: add property to TransitVehicle

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -98,6 +98,7 @@ export type TransitVehicle = {
   routeShortName?: string;
   routeLongName?: string;
   routeType?: string;
+  routeColor?: string;
 
   status?: string;
   reportDate?: string;


### PR DESCRIPTION
Adding routeColor to the vehicle object.

This will help TriMet's usage of OTP-UI by allowing us to remove a hacky file that replicates routeColor for vehicle objects, and instead use the server-provided color everywhere.
