### PR TITLE
Remove longDateFormat

### DIFF
--- a/packages/core-utils/src/__tests__/__mocks__/config.json
+++ b/packages/core-utils/src/__tests__/__mocks__/config.json
@@ -49,7 +49,6 @@
   },
   "dateTime": {
     "timeFormat": "h:mm a",
-    "dateFormat": "MM/DD/YYYY",
-    "longDateFormat": "MMMM D, YYYY"
+    "dateFormat": "MM/DD/YYYY"
   }
 }

--- a/packages/core-utils/src/time.ts
+++ b/packages/core-utils/src/time.ts
@@ -38,6 +38,7 @@ export function getDateFormat(config: Config): string {
   return config?.dateTime?.dateFormat || OTP_API_DATE_FORMAT;
 }
 
+/** @deprecated */
 export function getLongDateFormat(config: Config): string {
   return config?.dateTime?.longDateFormat || "D MMMM YYYY";
 }

--- a/packages/itinerary-body/src/__mocks__/config.json
+++ b/packages/itinerary-body/src/__mocks__/config.json
@@ -13,8 +13,7 @@
   ],
   "dateTime": {
     "timeFormat": "h:mm a",
-    "dateFormat": " MM/DD/YYYY",
-    "longDateFormat": "MMMM D, YYYY"
+    "dateFormat": " MM/DD/YYYY"
   },
   "transitOperators": [
     {

--- a/packages/trip-details/package.json
+++ b/packages/trip-details/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@opentripplanner/core-utils": "^7.0.0",
     "@styled-icons/fa-solid": "^10.34.0",
-    "date-fns": "^2.29.1",
     "flat": "^5.0.2",
     "react-animate-height": "^3.0.4"
   },

--- a/packages/trip-details/src/TripDetails.story.tsx
+++ b/packages/trip-details/src/TripDetails.story.tsx
@@ -1,6 +1,6 @@
-import { format } from "date-fns";
 import flatten from "flat";
 import React, { ReactElement } from "react";
+import { FormattedDate } from "react-intl";
 import {
   ComponentMeta,
   ComponentStory,
@@ -102,8 +102,6 @@ const fareByLegLayout: FareTableLayout[] = [
   }
 ];
 
-const longDateFormat = "MMMM d, yyyy";
-
 const englishFareKeyMap = {
   regular: "Transit Fare",
   student: "Student Fare",
@@ -148,8 +146,14 @@ const CustomDepartureDetails = ({
   departureDate
 }: DepartureDetailsProps): ReactElement => (
   <>
-    Custom messages about {format(departureDate, longDateFormat)} can be
-    constructed dynamically using any markup.
+    Custom messages about{" "}
+    <FormattedDate
+      value={departureDate}
+      year="numeric"
+      month="long"
+      day="numeric"
+    />{" "}
+    can be constructed dynamically using any markup.
   </>
 );
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -141,6 +141,7 @@ export type Config = {
   dateTime: {
     timeFormat?: string;
     dateFormat?: string;
+    /** @deprecated */
     longDateFormat?: string;
   };
   homeTimezone: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7392,7 +7392,7 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-date-fns@^2.23.0, date-fns@^2.28.0, date-fns@^2.29.1:
+date-fns@^2.23.0, date-fns@^2.28.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.1.tgz#9667c2615525e552b5135a3116b95b1961456e60"
   integrity sha512-dlLD5rKaKxpFdnjrs+5azHDFOPEu4ANy/LTh04A1DTzMM7qoajmKCBc8pkKRFT41CNzw+4gQh79X5C+Jq27HAw==


### PR DESCRIPTION
This PR deprecates fields and functions that use `longDateFormat` from the OTP configs and removes such references in tests. `longDateFormat` became unused after merging #281.

Requires #436 for CI tests to pass.
