### PR TITLE
Maplibre transitive route labels

### DIFF
--- a/packages/transitive-overlay/package.json
+++ b/packages/transitive-overlay/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@opentripplanner/endpoints-overlay": "^2.0.0",
-    "@opentripplanner/types": "^4.0.0"
+    "@opentripplanner/types": "^4.0.1"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/transitive-overlay/src/index.tsx
+++ b/packages/transitive-overlay/src/index.tsx
@@ -157,7 +157,9 @@ const TransitiveCanvasOverlay = ({
         filter={routeFilter}
         id="routes-labels"
         layout={getRouteLayerLayout("name")}
-        paint={{ "text-color": "#eee" }}
+        paint={{
+          "text-color": ["get", "textColor"]
+        }}
         type="symbol"
       />
       <Layer filter={["==", "type", "place"]} id="places" type="circle" />

--- a/packages/transitive-overlay/src/index.tsx
+++ b/packages/transitive-overlay/src/index.tsx
@@ -79,8 +79,7 @@ const TransitiveCanvasOverlay = ({
           const route = transitiveData.routes.find(
             r => r.route_id === pattern.route_id
           );
-          // Need to concatenate the polylines (arrays of coordinates) from all geometries,
-          // so that labels are rendered spread out evenly and to avoid to close repeats of the label.
+          // Concatenate geometries (arrays of coordinates) to help maplibre spread out labels (not perfect).
           const concatenatedLines = pattern.stops
             .map(stop => stop.geometry)
             .filter(geometry => !!geometry)
@@ -94,8 +93,8 @@ const TransitiveCanvasOverlay = ({
           const routeName =
             route.route_short_name || route.route_long_name || "";
           // HACK: Create an uppercase version of the route name to paint the background, where
-          // spaces are replaced with '!' (~same width as space) to creeate a background with a uniform height.
-          // Also, ensure there is a minimum background width (~3 characters).
+          // spaces are replaced with '!' (~same width as space) to create a background with a uniform height.
+          // Also, ensure there is a minimum background width (3 characters).
           const routeNameUpper = (routeName.length < 3 ? "000" : routeName)
             .toUpperCase()
             .replace(/\s/g, "!");
@@ -170,8 +169,7 @@ const TransitiveCanvasOverlay = ({
         type="line"
       />
       <Layer
-        // This layer renders the background of transit route names with a halo
-        // using that route name in uppercase.
+        // Render a solid background of fixed height using the uppercase route name.
         filter={["==", "type", "route"]}
         id="routes-labels-background"
         layout={{
@@ -185,7 +183,7 @@ const TransitiveCanvasOverlay = ({
         paint={{
           "text-color": ["get", "color"],
           "text-halo-color": ["get", "color"],
-          "text-halo-width": 4 // Max value is 1/4 of text size.
+          "text-halo-width": 4 // Max value is 1/4 of text size per maplibre docs.
         }}
         type="symbol"
       />

--- a/packages/transitive-overlay/src/route-layers.ts
+++ b/packages/transitive-overlay/src/route-layers.ts
@@ -1,0 +1,56 @@
+import polyline from "@mapbox/polyline";
+import { SymbolLayout } from "mapbox-gl";
+import { TransitivePattern, TransitiveRoute } from "@opentripplanner/types";
+
+/**
+ * Create a labeled-line feature for the given transit route pattern.
+ */
+export function patternToRouteFeature(
+  pattern: TransitivePattern,
+  routes: TransitiveRoute[]
+): GeoJSON.Feature<GeoJSON.Geometry, Record<string, unknown>> {
+  const route = routes.find(r => r.route_id === pattern.route_id);
+  // Concatenate geometries (arrays of coordinates) to help maplibre spread out labels (not perfect).
+  const concatenatedLines = pattern.stops
+    .map(stop => stop.geometry)
+    .filter(geometry => !!geometry)
+    .reduce((result, geom, index) => {
+      const coords = polyline.decode(geom);
+      // Remove the first element (except for the first array) because it is a duplicate
+      // of the last element of the previous array.
+      if (index !== 0) coords.shift();
+      return result.concat(coords);
+    }, []);
+  const routeName = route.route_short_name || route.route_long_name || "";
+  // HACK: Create an uppercase version of the route name to paint the background, where
+  // spaces are replaced with '!' (~same width as space) to create a background with a uniform height.
+  // Also, ensure there is a minimum background width (3 characters).
+  const routeNameUpper = (routeName.length < 3 ? "000" : routeName)
+    .toUpperCase()
+    .replace(/\s/g, "!");
+
+  return {
+    geometry: polyline.toGeoJSON(polyline.encode(concatenatedLines)),
+    properties: {
+      color: `#${route.route_color || "000080"}`,
+      name: routeName,
+      nameUpper: routeNameUpper,
+      type: "route"
+    },
+    type: "Feature"
+  };
+}
+
+/**
+ * Obtains common layout options for route label layers.
+ */
+export function getRouteLayerLayout(textField: string): SymbolLayout {
+  return {
+    "symbol-placement": "line-center",
+    "text-allow-overlap": true,
+    "text-field": ["get", textField],
+    "text-ignore-placement": true,
+    "text-rotation-alignment": "viewport",
+    "text-size": 16
+  };
+}

--- a/packages/transitive-overlay/src/route-layers.ts
+++ b/packages/transitive-overlay/src/route-layers.ts
@@ -35,6 +35,7 @@ export function patternToRouteFeature(
       color: `#${route.route_color || "000080"}`,
       name: routeName,
       nameUpper: routeNameUpper,
+      textColor: `#${route.route_text_color || "eee"}`,
       type: "route"
     },
     type: "Feature"

--- a/packages/transitive-overlay/src/route-layers.ts
+++ b/packages/transitive-overlay/src/route-layers.ts
@@ -23,11 +23,14 @@ export function patternToRouteFeature(
     }, []);
   const routeName = route.route_short_name || route.route_long_name || "";
   // HACK: Create an uppercase version of the route name to paint the background, where
-  // spaces are replaced with '!' (~same width as space) to create a background with a uniform height.
+  // - spaces are replaced with '!' (~same width as space)
+  // - "+", "-", certain letters and numbers are replaced with "E" to create a background with a uniform height and fill.
   // Also, ensure there is a minimum background width (3 characters).
-  const routeNameUpper = (routeName.length < 3 ? "000" : routeName)
+  // Disclaimer: height of substitution characters can vary from font to font.
+  const routeNameUpper = (routeName.length < 3 ? "EEE" : routeName)
     .toUpperCase()
-    .replace(/\s/g, "!");
+    .replace(/\s/g, "!")
+    .replace(/[+-0124679FHJLPTVXYZ]/g, "E");
 
   return {
     geometry: polyline.toGeoJSON(polyline.encode(concatenatedLines)),

--- a/packages/transitive-overlay/src/util.ts
+++ b/packages/transitive-overlay/src/util.ts
@@ -236,7 +236,8 @@ export function itineraryToTransitive(
         route_short_name: routeLabel || "",
         route_long_name: leg.routeLongName || "",
         route_type: leg.routeType,
-        route_color: leg.routeColor
+        route_color: leg.routeColor,
+        route_text_color: leg.routeTextColor
       };
 
       // add the pattern to the tdata patterns array

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -312,6 +312,7 @@ export type Leg = {
   routeId?: string;
   routeLongName?: string;
   routeShortName?: string;
+  routeTextColor?: string;
   routeType?: number;
   serviceDate?: string;
   startTime: number;
@@ -523,11 +524,12 @@ export type TransitivePattern = {
 };
 export type TransitiveRoute = {
   agency_id: string;
-  route_id: string;
-  route_short_name: string;
-  route_long_name: string;
-  route_type: number;
   route_color?: string;
+  route_id: string;
+  route_long_name: string;
+  route_short_name: string;
+  route_text_color?: string;
+  route_type: number;
 };
 export type TransitiveStop = {
   stop_id: string;


### PR DESCRIPTION
Blocked by/requires:
- #450
- #451

This PR improves route labels in the transitive overlay:
- horizontal rendering
- better background rendering
- better spacing of route labels when mutliple are rendered by maplibre-gl