### PR TITLE
chore(deps): Unpin icons version in transit vehicle overlay.

### DIFF
--- a/packages/transit-vehicle-overlay/package.json
+++ b/packages/transit-vehicle-overlay/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@opentripplanner/base-map": "^3.0.0",
     "@opentripplanner/core-utils": "^7.0.1",
-    "@opentripplanner/icons": "1.2.4",
+    "@opentripplanner/icons": "^1.2.4",
     "flat": "^5.0.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7351,7 +7351,7 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-date-fns@^2.23.0, date-fns@^2.28.0:
+date-fns@^2.28.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.1.tgz#9667c2615525e552b5135a3116b95b1961456e60"
   integrity sha512-dlLD5rKaKxpFdnjrs+5azHDFOPEu4ANy/LTh04A1DTzMM7qoajmKCBc8pkKRFT41CNzw+4gQh79X5C+Jq27HAw==


### PR DESCRIPTION
This PR unpins the icons version in the transit-vehicle-overlay package (prevents duplicate icons package downloads).