### PR TITLE
For Raster Tiles: feat(itinerary-body): add optional param to itinerary for collapsing alerts

### DIFF
--- a/packages/itinerary-body/src/ItineraryBody/index.tsx
+++ b/packages/itinerary-body/src/ItineraryBody/index.tsx
@@ -15,6 +15,7 @@ const ItineraryBody = ({
   accessibilityScoreGradationMap,
   AlertBodyIcon,
   AlertToggleIcon,
+  alwaysCollapseAlerts = false,
   className,
   config,
   diagramVisible,
@@ -58,6 +59,7 @@ const ItineraryBody = ({
           accessibilityScoreGradationMap={accessibilityScoreGradationMap}
           AlertToggleIcon={AlertToggleIcon}
           AlertBodyIcon={AlertBodyIcon}
+          alwaysCollapseAlerts={alwaysCollapseAlerts}
           // eslint-disable-next-line react/no-array-index-key
           key={i + (isDestination ? 1 : 0)}
           config={config}

--- a/packages/itinerary-body/src/ItineraryBody/place-row.tsx
+++ b/packages/itinerary-body/src/ItineraryBody/place-row.tsx
@@ -19,6 +19,7 @@ export default function PlaceRow({
   accessibilityScoreGradationMap,
   AlertBodyIcon,
   AlertToggleIcon,
+  alwaysCollapseAlerts,
   config,
   diagramVisible,
   fare,
@@ -112,6 +113,7 @@ export default function PlaceRow({
               <TransitLegBody
                 AlertBodyIcon={AlertBodyIcon}
                 AlertToggleIcon={AlertToggleIcon}
+                alwaysCollapseAlerts={alwaysCollapseAlerts}
                 fare={fare}
                 leg={leg}
                 LegIcon={LegIcon}

--- a/packages/itinerary-body/src/TransitLegBody/index.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/index.tsx
@@ -32,6 +32,7 @@ import ViewTripButton from "./view-trip-button";
 interface Props {
   AlertBodyIcon?: FunctionComponent;
   AlertToggleIcon?: FunctionComponent;
+  alwaysCollapseAlerts: boolean;
   fare?: Fare;
   intl: IntlShape;
   leg: Leg;
@@ -52,6 +53,8 @@ interface State {
   alertsExpanded: boolean;
   stopsExpanded: boolean;
 }
+
+const maximumAlertCountToShowUncollapsed = 2;
 
 class TransitLegBody extends Component<Props, State> {
   constructor(props) {
@@ -91,6 +94,7 @@ class TransitLegBody extends Component<Props, State> {
     const {
       AlertToggleIcon = S.DefaultAlertToggleIcon,
       AlertBodyIcon,
+      alwaysCollapseAlerts,
       fare,
       intl,
       leg,
@@ -118,8 +122,13 @@ class TransitLegBody extends Component<Props, State> {
         ? transitOperator.logo
         : agencyBrandingUrl;
 
-    const expandAlerts =
-      alertsExpanded || (leg.alerts && leg.alerts.length < 3);
+    const shouldCollapseDueToAlertCount =
+      leg.alerts?.length > maximumAlertCountToShowUncollapsed;
+    // The alerts expansion triangle is shown when `!shouldOnlyShowAlertsExpanded`.
+    // `!leg.alerts` is needed here so the triangle isn't shown when there are 0 alerts.
+    const shouldOnlyShowAlertsExpanded =
+      !(shouldCollapseDueToAlertCount || alwaysCollapseAlerts) || !leg.alerts;
+    const expandAlerts = alertsExpanded || shouldOnlyShowAlertsExpanded;
     const fareForLeg = this.getFareForLeg(leg, fare);
     return (
       <>
@@ -192,7 +201,7 @@ class TransitLegBody extends Component<Props, State> {
           )}
 
           {/* Alerts toggle */}
-          {alerts && alerts.length > 2 && (
+          {!shouldOnlyShowAlertsExpanded && (
             <S.TransitAlertToggle onClick={this.onToggleAlertsClick}>
               <AlertToggleIcon />{" "}
               <FormattedMessage

--- a/packages/itinerary-body/src/stories/OtpRrItineraryBody.story.tsx
+++ b/packages/itinerary-body/src/stories/OtpRrItineraryBody.story.tsx
@@ -46,18 +46,21 @@ if (!isRunningJest()) {
 }
 
 interface StoryWrapperProps {
+  alwaysCollapseAlerts: boolean;
   itinerary: Itinerary;
   showRouteFares: boolean;
   TimeColumnContent: FunctionComponent<TimeColumnContentProps>;
 }
 
 function OtpRRItineraryBodyWrapper({
+  alwaysCollapseAlerts,
   itinerary,
   showRouteFares,
   TimeColumnContent
 }: StoryWrapperProps): ReactElement {
   return (
     <ItineraryBodyDefaultsWrapper
+      alwaysCollapseAlerts={alwaysCollapseAlerts}
       itinerary={itinerary}
       LegIcon={ClassicLegIcon}
       LineColumnContent={OtpRRLineColumnContent}
@@ -156,4 +159,58 @@ export const CustomTimeColumn = (): ReactElement => (
     itinerary={tncTransitTncItinerary}
     TimeColumnContent={CustomTimeColumnContent}
   />
+);
+
+export const ThreeAlertsAlwaysCollapsing = (): ReactElement => (
+  <OtpRRItineraryBodyWrapper
+    alwaysCollapseAlerts
+    itinerary={walkTransitWalkItinerary}
+  />
+);
+
+export const TwoAlertsAlwaysCollapsing = (): ReactElement => (
+  <OtpRRItineraryBodyWrapper
+    alwaysCollapseAlerts
+    itinerary={parkAndRideItinerary}
+  />
+);
+
+export const ZeroAlertsAlwaysCollapsing = (): ReactElement => (
+  <OtpRRItineraryBodyWrapper
+    alwaysCollapseAlerts
+    itinerary={walkInterlinedTransitItinerary}
+  />
+);
+
+export const ThreeAlertsNotAlwaysCollapsing = (): ReactElement => (
+  <OtpRRItineraryBodyWrapper
+    alwaysCollapseAlerts={false}
+    itinerary={walkTransitWalkItinerary}
+  />
+);
+
+export const TwoAlertsNotAlwaysCollapsing = (): ReactElement => (
+  <OtpRRItineraryBodyWrapper
+    alwaysCollapseAlerts={false}
+    itinerary={parkAndRideItinerary}
+  />
+);
+
+export const ZeroAlertsNotAlwaysCollapsing = (): ReactElement => (
+  <OtpRRItineraryBodyWrapper
+    alwaysCollapseAlerts={false}
+    itinerary={walkInterlinedTransitItinerary}
+  />
+);
+
+export const ThreeAlertsWithoutCollapsingProp = (): ReactElement => (
+  <OtpRRItineraryBodyWrapper itinerary={walkTransitWalkItinerary} />
+);
+
+export const TwoAlertsWithoutCollapsingProp = (): ReactElement => (
+  <OtpRRItineraryBodyWrapper itinerary={parkAndRideItinerary} />
+);
+
+export const ZeroAlertsWithoutCollapsingProp = (): ReactElement => (
+  <OtpRRItineraryBodyWrapper itinerary={walkInterlinedTransitItinerary} />
 );

--- a/packages/itinerary-body/src/stories/OtpUiItineraryBody.story.tsx
+++ b/packages/itinerary-body/src/stories/OtpUiItineraryBody.story.tsx
@@ -160,3 +160,57 @@ export const CustomAlertIconsItinerary = (): ReactElement => (
     AlertBodyIcon={styled(Bomb).attrs({ size: 18 })``}
   />
 );
+
+export const ThreeAlertsAlwaysCollapsing = (): ReactElement => (
+  <ItineraryBodyDefaultsWrapper
+    alwaysCollapseAlerts
+    itinerary={walkTransitWalkItinerary}
+  />
+);
+
+export const TwoAlertsAlwaysCollapsing = (): ReactElement => (
+  <ItineraryBodyDefaultsWrapper
+    alwaysCollapseAlerts
+    itinerary={parkAndRideItinerary}
+  />
+);
+
+export const ZeroAlertsAlwaysCollapsing = (): ReactElement => (
+  <ItineraryBodyDefaultsWrapper
+    alwaysCollapseAlerts
+    itinerary={walkInterlinedTransitItinerary}
+  />
+);
+
+export const ThreeAlertsNotAlwaysCollapsing = (): ReactElement => (
+  <ItineraryBodyDefaultsWrapper
+    alwaysCollapseAlerts={false}
+    itinerary={walkTransitWalkItinerary}
+  />
+);
+
+export const TwoAlertsNotAlwaysCollapsing = (): ReactElement => (
+  <ItineraryBodyDefaultsWrapper
+    alwaysCollapseAlerts={false}
+    itinerary={parkAndRideItinerary}
+  />
+);
+
+export const ZeroAlertsNotAlwaysCollapsing = (): ReactElement => (
+  <ItineraryBodyDefaultsWrapper
+    alwaysCollapseAlerts={false}
+    itinerary={walkInterlinedTransitItinerary}
+  />
+);
+
+export const ThreeAlertsWithoutCollapsingProp = (): ReactElement => (
+  <ItineraryBodyDefaultsWrapper itinerary={walkTransitWalkItinerary} />
+);
+
+export const TwoAlertWithoutCollapsingProp = (): ReactElement => (
+  <ItineraryBodyDefaultsWrapper itinerary={parkAndRideItinerary} />
+);
+
+export const ZeroAlertsWithoutCollapsingProp = (): ReactElement => (
+  <ItineraryBodyDefaultsWrapper itinerary={walkInterlinedTransitItinerary} />
+);

--- a/packages/itinerary-body/src/stories/itinerary-body-defaults-wrapper.tsx
+++ b/packages/itinerary-body/src/stories/itinerary-body-defaults-wrapper.tsx
@@ -41,6 +41,7 @@ export default class ItineraryBodyDefaultsWrapper extends Component<
 
   render(): ReactElement {
     const {
+      alwaysCollapseAlerts,
       itinerary,
       LegIcon = TriMetLegIcon,
       LineColumnContent,
@@ -75,6 +76,7 @@ export default class ItineraryBodyDefaultsWrapper extends Component<
       <ItineraryBodyComponent
         AlertBodyIcon={AlertBodyIcon}
         AlertToggleIcon={AlertToggleIcon}
+        alwaysCollapseAlerts={alwaysCollapseAlerts}
         config={config}
         diagramVisible={diagramVisible}
         frameLeg={action("frameLeg")}

--- a/packages/itinerary-body/src/types.ts
+++ b/packages/itinerary-body/src/types.ts
@@ -101,6 +101,8 @@ interface ItineraryBodySharedProps {
    * within a transit leg, if this prop is not supplied a default icon is used
    */
   AlertToggleIcon?: FunctionComponent;
+  /** If true, alerts in a trip leg always open in a collapsed state. */
+  alwaysCollapseAlerts: boolean;
   /**
    * Used for additional styling with styled components for example.
    */


### PR DESCRIPTION
This is identical to https://github.com/opentripplanner/otp-ui/pull/435, but branches off the new `raster-tiles` branch so that we're able to use it. (At the time that 435 was reviewed/merged, I didn't fully understand the branching strategy of this.)

----
From original PR:

This adds an optional param to itineraries, which would force alerts to always open in collapsed form, even if there are 1 or 2 alerts. It also turns a magic number in the code into a named variable, and (hopefully) increases the readability of this code by adding some booleans into some not-immediately-intuitive logic. Also added some stories to storybook to cover the various permutations of this new feature.

Once this goes through review, we'd like to use this functionality at TriMet.
