### PR TITLE
Maplibre transitive paths

### DIFF
--- a/packages/transitive-overlay/src/TransitiveOverlay.story.js
+++ b/packages/transitive-overlay/src/TransitiveOverlay.story.js
@@ -179,7 +179,7 @@ export const WalkInterlinedTransitItinerary = () => (
   </>
 );
 WalkInterlinedTransitItinerary.decorators = [
-  withMap([45.511841, -122.679302], 14)
+  withMap([47.703022, -122.328041], 12.5)
 ];
 
 export const WalkTransitTransferItinerary = () => (
@@ -366,7 +366,7 @@ export const FlexItinerary = () => (
     />
   </>
 );
-FlexItinerary.decorators = [withMap([33.749, -84.388], 11)];
+FlexItinerary.decorators = [withMap([40.038487, -105.0529011], 11)];
 
 export const OTP2ScooterItinerary = injectIntl(({ intl }) => (
   <>

--- a/packages/transitive-overlay/src/index.tsx
+++ b/packages/transitive-overlay/src/index.tsx
@@ -128,8 +128,32 @@ const TransitiveCanvasOverlay = ({
 
   return (
     <Source data={geojson} id="itinerary" type="geojson">
+      {/* Create a layer for each line type
+          (conditional expressions are not supported for line-dash attributes). */}
       <Layer
-        filter={["==", "type", "street-edge"]}
+        // This layer is for WALK modes - dotted path
+        filter={["all", ["==", "type", "street-edge"], ["==", "mode", "WALK"]]}
+        id="street-edges-walk"
+        layout={{
+          "line-cap": "round",
+          "line-join": "round"
+        }}
+        paint={{
+          // TODO: get from transitive properties
+          "line-color": ["get", "color"],
+          // First parameter of array is the length of the dash which is set to zero,
+          // so that maplibre simply adds the rounded ends to make things look like dots.
+          // Even so, note that maplibre still renders beans instead of dots
+          // (as if maplibre fuses dots together).
+          "line-dasharray": [0, 1.3],
+          "line-opacity": 0.9,
+          "line-width": 6
+        }}
+        type="line"
+      />
+      <Layer
+        // This layer is for other modes - dashed path
+        filter={["all", ["==", "type", "street-edge"], ["!=", "mode", "WALK"]]}
         id="street-edges"
         layout={{
           "line-cap": "butt"
@@ -137,7 +161,6 @@ const TransitiveCanvasOverlay = ({
         paint={{
           // TODO: get from transitive properties
           "line-color": ["get", "color"],
-          // TODO: get from transitive properties
           "line-dasharray": [2, 1],
           // TODO: get from transitive properties
           "line-width": 4,

--- a/packages/transitive-overlay/src/index.tsx
+++ b/packages/transitive-overlay/src/index.tsx
@@ -95,8 +95,9 @@ const TransitiveCanvasOverlay = ({
                 type: "Feature",
                 properties: {
                   color: `#${route.route_color || "000080"}`,
-                  type: "route",
-                  name: route.route_short_name || route.route_long_name || ""
+                  name: route.route_short_name || route.route_long_name || "",
+                  routeType: route.route_type,
+                  type: "route"
                 },
                 geometry: polyline.toGeoJSON(geometry)
               };
@@ -177,7 +178,8 @@ const TransitiveCanvasOverlay = ({
         }}
         paint={{
           "line-color": ["get", "color"],
-          "line-width": 8,
+          // Apply a thinner line (width = 6) for bus routes (route_type = 3), set width to 10 otherwise.
+          "line-width": ["match", ["get", "routeType"], 3, 6, 10],
           "line-opacity": 1
         }}
         type="line"


### PR DESCRIPTION
This PR improves rendering of transitive paths:
- Walk paths are rendered as dots (or beans).
- A thinner line is applied to bus paths vs a thicker line for other transit modes.
- Map center is fixed for some stories.
