### PR TITLE
Add type support for route text color in itinerary leg and transitive

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -312,6 +312,7 @@ export type Leg = {
   routeId?: string;
   routeLongName?: string;
   routeShortName?: string;
+  routeTextColor?: string;
   routeType?: number;
   serviceDate?: string;
   startTime: number;
@@ -523,11 +524,12 @@ export type TransitivePattern = {
 };
 export type TransitiveRoute = {
   agency_id: string;
-  route_id: string;
-  route_short_name: string;
-  route_long_name: string;
-  route_type: number;
   route_color?: string;
+  route_id: string;
+  route_long_name: string;
+  route_short_name: string;
+  route_text_color?: string;
+  route_type: number;
 };
 export type TransitiveStop = {
   stop_id: string;


### PR DESCRIPTION
This PR updates types to include route text color attributes provided from OTP itinerary legs into transitive.