### PR TITLE
Core Utils: add text color generation

### DIFF
--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -29,6 +29,7 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^4.0.0"
+    "@opentripplanner/types": "^4.0.0",
+    "@types/chroma-js": "^2.1.4"
   }
 }

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -17,6 +17,7 @@
     "@styled-icons/foundation": "^10.34.0",
     "@turf/along": "^6.0.1",
     "bowser": "^2.7.0",
+    "chroma-js": "^2.4.2",
     "date-fns": "^2.28.0",
     "date-fns-tz": "^1.2.2",
     "lodash.clonedeep": "^4.5.0",

--- a/packages/core-utils/src/__tests__/route.js
+++ b/packages/core-utils/src/__tests__/route.js
@@ -193,6 +193,10 @@ describe("util > route", () => {
       expect(getMostReadableTextColor("#00FF00", "#ffffff")).toBe("#000000");
       expect(getMostReadableTextColor("#321b26", "#000000")).toBe("#ffffff");
       expect(getMostReadableTextColor("#321b26", "9e4141")).toBe("#ffffff");
+
+      expect(getMostReadableTextColor("#f00", "#f00")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#fff", "#fff")).toBe("#000000");
+      expect(getMostReadableTextColor("#000", "#000")).toBe("#ffffff");
     });
   });
 });

--- a/packages/core-utils/src/__tests__/route.js
+++ b/packages/core-utils/src/__tests__/route.js
@@ -1,4 +1,5 @@
 import {
+  getMostReadableTextColor,
   getTransitOperatorFromLeg,
   getTransitOperatorFromOtpRoute,
   makeRouteComparator
@@ -133,6 +134,60 @@ describe("util > route", () => {
 
     it("should sort based off of route type", () => {
       expect(sortRoutes(route12, route13)).toMatchSnapshot();
+    });
+  });
+
+  describe("route text color generation", () => {
+    it("should not modify appropriate color pairings", () => {
+      expect(getMostReadableTextColor("#EE352E", "#ffffff")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#00933C", "#ffffff")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#b933ad", "#ffffff")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#808183", "#ffffff")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#0039a6", "#ffffff")).toBe("#ffffff");
+
+      // Both work
+      expect(getMostReadableTextColor("#ff6319", "#ffffff")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#ff6319", "#000000")).toBe("#000000");
+      expect(getMostReadableTextColor("#6cbe45", "#ffffff")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#6cbe45", "#000000")).toBe("#000000");
+      expect(getMostReadableTextColor("#a7a9ac", "#ffffff")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#a7a9ac", "#000000")).toBe("#000000");
+      expect(getMostReadableTextColor("#FF00FF", "#ffffff")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#FF00FF", "#000000")).toBe("#000000");
+
+      expect(getMostReadableTextColor("#996633", "#ffffff")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#fccc0a", "#000000")).toBe("#000000");
+
+      expect(getMostReadableTextColor("#0075B2", "#ffffff")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#D4A723", "#000000")).toBe("#000000");
+      expect(getMostReadableTextColor("#009D4B", "#ffffff")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#CE242B", "#ffffff")).toBe("#ffffff");
+
+      expect(getMostReadableTextColor("#00FF00", "#000000")).toBe("#000000");
+      expect(getMostReadableTextColor("#009999", "#ffffff")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#009999", "#000000")).toBe("#000000");
+
+      expect(getMostReadableTextColor("#E32400", "#FFFFFF")).toBe("#FFFFFF");
+      expect(getMostReadableTextColor("#d18881", "#000000")).toBe("#000000");
+    });
+
+    it("should modify inappropriate color pairings", () => {
+      expect(getMostReadableTextColor("#EE352E", "#000000")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#00933C", "#000000")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#b933ad", "#000000")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#808183", "#000000")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#0039a6", "#000000")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#996633", "#000000")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#fccc0a", "#ffffff")).toBe("#000000");
+
+      expect(getMostReadableTextColor("#0075B2", "#000000")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#D4A723", "#ffffff")).toBe("#000000");
+      expect(getMostReadableTextColor("#009D4B", "#000000")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#CE242B", "#000000")).toBe("#ffffff");
+
+      expect(getMostReadableTextColor("#00FF00", "#ffffff")).toBe("#000000");
+      expect(getMostReadableTextColor("#321b26", "#000000")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#321b26", "brown")).toBe("#ffffff");
     });
   });
 });

--- a/packages/core-utils/src/__tests__/route.js
+++ b/packages/core-utils/src/__tests__/route.js
@@ -169,6 +169,8 @@ describe("util > route", () => {
 
       expect(getMostReadableTextColor("#E32400", "#FFFFFF")).toBe("#FFFFFF");
       expect(getMostReadableTextColor("#d18881", "#000000")).toBe("#000000");
+
+      expect(getMostReadableTextColor("#004080", "#FFFFFF")).toBe("#FFFFFF");
     });
 
     it("should modify inappropriate color pairings", () => {
@@ -187,7 +189,7 @@ describe("util > route", () => {
 
       expect(getMostReadableTextColor("#00FF00", "#ffffff")).toBe("#000000");
       expect(getMostReadableTextColor("#321b26", "#000000")).toBe("#ffffff");
-      expect(getMostReadableTextColor("#321b26", "brown")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#321b26", "9e4141")).toBe("#ffffff");
     });
   });
 });

--- a/packages/core-utils/src/__tests__/route.js
+++ b/packages/core-utils/src/__tests__/route.js
@@ -137,6 +137,8 @@ describe("util > route", () => {
     });
   });
 
+  // These color pairings are taken from real agencies.
+  // See the method jsdoc for more details.
   describe("route text color generation", () => {
     it("should not modify appropriate color pairings", () => {
       expect(getMostReadableTextColor("#EE352E", "#ffffff")).toBe("#ffffff");
@@ -145,7 +147,8 @@ describe("util > route", () => {
       expect(getMostReadableTextColor("#808183", "#ffffff")).toBe("#ffffff");
       expect(getMostReadableTextColor("#0039a6", "#ffffff")).toBe("#ffffff");
 
-      // Both work
+      // Both colors are readable and used by transit agencies.
+      // The function accepts both colors.
       expect(getMostReadableTextColor("#ff6319", "#ffffff")).toBe("#ffffff");
       expect(getMostReadableTextColor("#ff6319", "#000000")).toBe("#000000");
       expect(getMostReadableTextColor("#6cbe45", "#ffffff")).toBe("#ffffff");
@@ -154,6 +157,8 @@ describe("util > route", () => {
       expect(getMostReadableTextColor("#a7a9ac", "#000000")).toBe("#000000");
       expect(getMostReadableTextColor("#FF00FF", "#ffffff")).toBe("#ffffff");
       expect(getMostReadableTextColor("#FF00FF", "#000000")).toBe("#000000");
+      expect(getMostReadableTextColor("#009999", "#ffffff")).toBe("#ffffff");
+      expect(getMostReadableTextColor("#009999", "#000000")).toBe("#000000");
 
       expect(getMostReadableTextColor("#996633", "#ffffff")).toBe("#ffffff");
       expect(getMostReadableTextColor("#fccc0a", "#000000")).toBe("#000000");
@@ -164,8 +169,6 @@ describe("util > route", () => {
       expect(getMostReadableTextColor("#CE242B", "#ffffff")).toBe("#ffffff");
 
       expect(getMostReadableTextColor("#00FF00", "#000000")).toBe("#000000");
-      expect(getMostReadableTextColor("#009999", "#ffffff")).toBe("#ffffff");
-      expect(getMostReadableTextColor("#009999", "#000000")).toBe("#000000");
 
       expect(getMostReadableTextColor("#E32400", "#FFFFFF")).toBe("#FFFFFF");
       expect(getMostReadableTextColor("#d18881", "#000000")).toBe("#000000");

--- a/packages/core-utils/src/core-utils.story.tsx
+++ b/packages/core-utils/src/core-utils.story.tsx
@@ -40,20 +40,12 @@ export const RouteColorTester = (): JSX.Element => {
       {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
       <label>
         Foreground Color
-        <input
-          type="color"
-          value={fg}
-          onChange={e => setFg(e.target.value)}
-        ></input>
+        <input onChange={e => setFg(e.target.value)} type="color" value={fg} />
       </label>
       {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
       <label>
         Background Color
-        <input
-          type="color"
-          value={bg}
-          onChange={e => setBg(e.target.value)}
-        ></input>
+        <input onChange={e => setBg(e.target.value)} type="color" value={bg} />
       </label>
     </>
   );

--- a/packages/core-utils/src/core-utils.story.tsx
+++ b/packages/core-utils/src/core-utils.story.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { getMostReadableTextColor } from "./route";
+
+export default {
+  title: "core-utils"
+};
+
+const ColorBlock = styled.div<{ bg: string; fg: string }>`
+  background: ${props => props.bg};
+  color: ${props => props.fg};
+  padding: 10px;
+`;
+
+const ColorBlockWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+`;
+
+const ColorPair = ({ fg, bg }: { fg: string; bg: string }) => {
+  return (
+    <ColorBlockWrapper>
+      <ColorBlock fg={fg} bg={bg}>
+        Provided color pair
+      </ColorBlock>
+      <ColorBlock fg={getMostReadableTextColor(bg, fg)} bg={bg}>
+        Corrected color pair
+      </ColorBlock>
+    </ColorBlockWrapper>
+  );
+};
+
+export const RouteColorTester = (): JSX.Element => {
+  const [fg, setFg] = useState("#333333");
+  const [bg, setBg] = useState("#cbeb55");
+  return (
+    <>
+      <ColorPair bg={bg} fg={fg}></ColorPair>
+      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+      <label>
+        Foreground Color
+        <input
+          type="color"
+          value={fg}
+          onChange={e => setFg(e.target.value)}
+        ></input>
+      </label>
+      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+      <label>
+        Background Color
+        <input
+          type="color"
+          value={bg}
+          onChange={e => setBg(e.target.value)}
+        ></input>
+      </label>
+    </>
+  );
+};
+// Disable color contrast checking for the uncorrected color pairs
+RouteColorTester.parameters = {
+  a11y: { config: { rules: [{ id: "color-contrast", reviewOnFail: true }] } }
+};

--- a/packages/core-utils/src/core-utils.story.tsx
+++ b/packages/core-utils/src/core-utils.story.tsx
@@ -60,5 +60,6 @@ export const RouteColorTester = (): JSX.Element => {
 };
 // Disable color contrast checking for the uncorrected color pairs
 RouteColorTester.parameters = {
-  a11y: { config: { rules: [{ id: "color-contrast", reviewOnFail: true }] } }
+  a11y: { config: { rules: [{ id: "color-contrast", reviewOnFail: true }] } },
+  storyshots: { disable: true }
 };

--- a/packages/core-utils/src/route.ts
+++ b/packages/core-utils/src/route.ts
@@ -428,16 +428,15 @@ export function makeRouteComparator(
 }
 
 /**
- * Tests if a pair of colors is readable. If it is, that readble color is returned.
+ * Tests if a pair of colors is readable. If it is, that readable color is returned.
  * If it is not, a more appropriate alternative is returned.
  *
  * Uses algorithm based on combined luminance. Values have been derived from
  * looking at real agency color pairings. These pairings are difficult to
  * generate for, as some colors see both white and black used by different agencies.
  *
- * This method therefore can accept black and white for the same background color.
+ * This method therefore can accept multiple colors (including black and white) for the same background color.
  *
- * When generating colors, white is preferred.
  * @param backgroundColor     A hex string, usually the "routeColor"
  * @param proposedTextColor   A hex string, usually the "routeTextColor"
  */
@@ -445,14 +444,15 @@ export function getMostReadableTextColor(
   backgroundColor: string,
   proposedTextColor = "#ffffff"
 ): string {
-  if (!backgroundColor.includes("#")) {
+  if (!backgroundColor.startsWith("#")) {
     backgroundColor = `#${backgroundColor}`;
   }
-  if (!proposedTextColor.includes("#")) {
+  if (!proposedTextColor.startsWith("#")) {
     proposedTextColor = `#${proposedTextColor}`;
   }
 
   // Check if proposed color is readable
+  // Luminance thresholds have been selected based on actual transit agency colors
   const fgLuminance = chroma(proposedTextColor).luminance();
   const bgLuminance = chroma(backgroundColor).luminance();
   if (bgLuminance + fgLuminance < 1.41 && bgLuminance + fgLuminance > 0.25) {
@@ -460,5 +460,6 @@ export function getMostReadableTextColor(
   }
 
   // Return black or white based on luminance of background color
+  // When generating colors, white is preferred.
   return chroma(backgroundColor).luminance() < 0.4 ? "#ffffff" : "#000000";
 }

--- a/packages/core-utils/src/route.ts
+++ b/packages/core-utils/src/route.ts
@@ -443,7 +443,7 @@ export function makeRouteComparator(
  */
 export function getMostReadableTextColor(
   backgroundColor: string,
-  proposedTextColor: string
+  proposedTextColor = "#ffffff"
 ): string {
   // Check if proposed color is readable
   const fgLuminance = chroma(proposedTextColor).luminance();

--- a/packages/core-utils/src/route.ts
+++ b/packages/core-utils/src/route.ts
@@ -455,7 +455,11 @@ export function getMostReadableTextColor(
   // Luminance thresholds have been selected based on actual transit agency colors
   const fgLuminance = chroma(proposedTextColor).luminance();
   const bgLuminance = chroma(backgroundColor).luminance();
-  if (bgLuminance + fgLuminance < 1.41 && bgLuminance + fgLuminance > 0.25) {
+  if (
+    bgLuminance + fgLuminance < 1.41 &&
+    bgLuminance + fgLuminance > 0.25 &&
+    Math.abs(bgLuminance - fgLuminance) > 0.2
+  ) {
     return proposedTextColor;
   }
 

--- a/packages/core-utils/src/route.ts
+++ b/packages/core-utils/src/route.ts
@@ -1,4 +1,5 @@
 import { Leg, Route, TransitOperator } from "@opentripplanner/types";
+import chroma from "chroma-js";
 /**
  * Returns the transit operator (if an exact match is found) from the transit
  * operators config value. It is critical to use both the feedId and agencyId in
@@ -424,4 +425,33 @@ export function makeRouteComparator(
     makeStringValueComparator(obj => obj.shortName),
     makeStringValueComparator(obj => obj.longName)
   );
+}
+
+/**
+ * Tests if a pair of colors is readable. If it is, that readble color is returned.
+ * If it is not, a more appropriate alternative is returned.
+ *
+ * Uses algorithm based on combined luminance. Values have been derived from
+ * looking at real agency color pairings. These pairings are difficult to
+ * generate for, as some colors see both white and black used by different agencies.
+ *
+ * This method therefore can accept black and white for the same background color.
+ *
+ * When generating colors, white is preferred.
+ * @param backgroundColor     A hex string, usually the "routeColor"
+ * @param proposedTextColor   A hex string, usually the "routeTextColor"
+ */
+export function getMostReadableTextColor(
+  backgroundColor: string,
+  proposedTextColor: string
+): string {
+  // Check if proposed color is readable
+  const fgLuminance = chroma(proposedTextColor).luminance();
+  const bgLuminance = chroma(backgroundColor).luminance();
+  if (bgLuminance + fgLuminance < 1.41 && bgLuminance + fgLuminance > 0.25) {
+    return proposedTextColor;
+  }
+
+  // Return black or white based on luminance of background color
+  return chroma(backgroundColor).luminance() < 0.4 ? "#ffffff" : "#000000";
 }

--- a/packages/core-utils/src/route.ts
+++ b/packages/core-utils/src/route.ts
@@ -445,6 +445,13 @@ export function getMostReadableTextColor(
   backgroundColor: string,
   proposedTextColor = "#ffffff"
 ): string {
+  if (!backgroundColor.includes("#")) {
+    backgroundColor = `#${backgroundColor}`;
+  }
+  if (!proposedTextColor.includes("#")) {
+    proposedTextColor = `#${proposedTextColor}`;
+  }
+
   // Check if proposed color is readable
   const fgLuminance = chroma(proposedTextColor).luminance();
   const bgLuminance = chroma(backgroundColor).luminance();

--- a/packages/location-field/src/types.ts
+++ b/packages/location-field/src/types.ts
@@ -155,7 +155,7 @@ export interface LocationFieldProps {
   locationType: LocationType;
   /**
    * A list of stopIds of the stops that should be shown as being nearby. These
-   * must be referencable in the stopsIndex prop.
+   * must be referenceable in the stopsIndex prop.
    */
   nearbyStops?: string[];
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -4293,6 +4293,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/chroma-js@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@types/chroma-js/-/chroma-js-2.1.4.tgz#52e3a8453000cdb9ad76357c2c47dbed702d136f"
+  integrity sha512-l9hWzP7cp7yleJUI7P2acmpllTJNYf5uU6wh50JzSIZt3fFHe+w2FM6w9oZGBTYzjjm2qHdnQvI+fF/JF/E5jQ==
+
 "@types/color-convert@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/color-convert/-/color-convert-2.0.0.tgz#8f5ee6b9e863dcbee5703f5a517ffb13d3ea4e22"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6502,6 +6502,11 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
+chroma-js@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-2.4.2.tgz#dffc214ed0c11fa8eefca2c36651d8e57cbfb2b0"
+  integrity sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A==
+
 chrome-trace-event@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"


### PR DESCRIPTION
This PR adds a new method to determine a readable text color for a background color. Rather than use standard benchmarks or methods, this method instead uses a carefully calibrated luminance based approach to "approve" color combinations that real agencies use (and that look appealing). The goal is to approve GTFS-based color combinations when they make sense, while being able to supply reasonable alternatives when the GTFS data is missing or of poor quality.

#### Looking for feedback on:

Use of Chroma. It's much smaller than tinycolor, but since otp-rr still uses tinycolor even after using this perhaps it makes more sense to use that larger library here? It's a 14kb pre-compression difference, so not sure if it's the biggest thing to worry about.