### PR TITLE
fix(scripts): Separate language columns

### DIFF
--- a/packages/scripts/src/collect-i18n-messages.ts
+++ b/packages/scripts/src/collect-i18n-messages.ts
@@ -60,7 +60,7 @@ async function collectAndPrintOutMessages({ sourceFiles, ymlFilesByLocale }) {
   Object.keys(messageData).forEach(id => {
     const row = messageData[id];
     const messages = allLocales.map(locale => row[locale]);
-    console.log(`${id},"${row.description}","${messages}"`);
+    console.log(`${id},"${row.description}","${messages.join('","')}"`);
   });
 }
 


### PR DESCRIPTION
This PR fixes the output of the `collect-i18n-messages.ts` script so that contents for each language appears in its own column (as opposed to concatenated).