### PR TITLE
feat(printable-itinerary): Add Stop ID to printable itinerary

### DIFF
--- a/packages/printable-itinerary/i18n/en-US.yml
+++ b/packages/printable-itinerary/i18n/en-US.yml
@@ -15,6 +15,6 @@ otpUi:
       estimatedWaitTime: "Estimated wait time for pickup: <strong>{duration}</strong>"
       header: <strong>Take {company}</strong> to <strong>{place}</strong>
     TransitLeg:
-      alight: Get off at <strong>{place}</strong> at <strong>{time, time, short}</strong>
-      board: Board at <strong>{place}</strong> at <strong>{time, time, short}</strong>
+      alight: Get off at <strong>{place}</strong> ({stopId}) at <strong>{time, time, short}</strong>
+      board: Board at <strong>{place}</strong> ({stopId}) at <strong>{time, time, short}</strong>
       continuesAs: Continues as {routeDescription}

--- a/packages/printable-itinerary/src/transit-leg.tsx
+++ b/packages/printable-itinerary/src/transit-leg.tsx
@@ -20,6 +20,27 @@ export default function TransitLeg({
   LegIcon,
   interlineFollows
 }: Props): ReactElement {
+  const stopIdFrom = (
+    <FormattedMessage
+      defaultMessage={defaultMessages["otpUi.TransitLegBody.stopId"]}
+      description="Displays the stop ID"
+      id="otpUi.TransitLegBody.stopId"
+      values={{
+        stopId: leg.from.stopCode || leg.stopId.split(":")[1]
+      }}
+    />
+  );
+  const stopIdTo = (
+    <FormattedMessage
+      defaultMessage={defaultMessages["otpUi.TransitLegBody.stopId"]}
+      description="Displays the stop ID"
+      id="otpUi.TransitLegBody.stopId"
+      values={{
+        stopId: leg.to.stopCode
+      }}
+    />
+  );
+
   const routeDescription = (
     <>
       <strong>{leg.routeShortName}</strong> <S.RouteLongName leg={leg} />
@@ -35,6 +56,7 @@ export default function TransitLeg({
       id="otpUi.PrintableItinerary.TransitLeg.alight"
       values={{
         place: leg.to.name,
+        stopId: stopIdTo,
         strong: strongText,
         time: leg.endTime
       }}
@@ -88,6 +110,7 @@ export default function TransitLeg({
               id="otpUi.PrintableItinerary.TransitLeg.board"
               values={{
                 place: leg.from.name,
+                stopId: stopIdFrom,
                 strong: strongText,
                 time: leg.startTime
               }}


### PR DESCRIPTION
Adds Stop ID to the printable itineraries

Using this instead of https://github.com/opentripplanner/otp-ui/pull/449, so that it bases off main branch.