### PR TITLE
Trip-details use CO2 from Itinerary

### DIFF
--- a/packages/location-field/src/types.ts
+++ b/packages/location-field/src/types.ts
@@ -155,7 +155,7 @@ export interface LocationFieldProps {
   locationType: LocationType;
   /**
    * A list of stopIds of the stops that should be shown as being nearby. These
-   * must be referencable in the stopsIndex prop.
+   * must be referenceable in the stopsIndex prop.
    */
   nearbyStops?: string[];
   /**

--- a/packages/trip-details/src/index.tsx
+++ b/packages/trip-details/src/index.tsx
@@ -232,12 +232,6 @@ export function TripDetails({
     walkDuration
   } = coreUtils.itinerary.calculatePhysicalActivity(itinerary);
 
-  const co2 = coreUtils.itinerary.calculateEmissions(
-    itinerary,
-    co2Config?.carbonIntensity,
-    co2Config?.units
-  );
-
   // Parse flex info and generate appropriate strings
   const containsFlex = itinerary.legs.some(coreUtils.itinerary.isFlex);
   const pickupBookingInfo = itinerary.legs
@@ -326,7 +320,7 @@ export function TripDetails({
             }
           />
         )}
-        {co2 > 0 && co2Config?.enabled && (
+        {itinerary.co2 > 0 && co2Config?.enabled && (
           <TripDetail
             icon={<Leaf size={17} />}
             summary={
@@ -338,7 +332,7 @@ export function TripDetails({
                   values={{
                     co2: (
                       <FormattedNumber
-                        value={Math.round(co2)}
+                        value={Math.round(itinerary.co2)}
                         // eslint-disable-next-line react/style-prop-object
                         style="unit"
                         unit={co2Config?.units || "gram"}

--- a/packages/trip-details/src/index.tsx
+++ b/packages/trip-details/src/index.tsx
@@ -232,6 +232,16 @@ export function TripDetails({
     walkDuration
   } = coreUtils.itinerary.calculatePhysicalActivity(itinerary);
 
+  // Calculate CO2 if it's not provided by the itinerary
+  const co2 =
+    itinerary.co2 ||
+    (co2Config.enabled &&
+      coreUtils.itinerary.calculateEmissions(
+        itinerary,
+        co2Config?.carbonIntensity,
+        co2Config?.units
+      ));
+
   // Parse flex info and generate appropriate strings
   const containsFlex = itinerary.legs.some(coreUtils.itinerary.isFlex);
   const pickupBookingInfo = itinerary.legs
@@ -320,7 +330,7 @@ export function TripDetails({
             }
           />
         )}
-        {itinerary.co2 > 0 && co2Config?.enabled && (
+        {co2 > 0 && co2Config?.enabled && (
           <TripDetail
             icon={<Leaf size={17} />}
             summary={
@@ -332,7 +342,7 @@ export function TripDetails({
                   values={{
                     co2: (
                       <FormattedNumber
-                        value={Math.round(itinerary.co2)}
+                        value={Math.round(co2)}
                         // eslint-disable-next-line react/style-prop-object
                         style="unit"
                         unit={co2Config?.units || "gram"}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -381,6 +381,8 @@ export type Fare = {
  * http://otp-docs.ibi-transit.com/api/json_Itinerary.html
  */
 export type Itinerary = {
+  co2?: number;
+  co2VsBaseline?: number;
   duration: number;
   elevationGained: number;
   elevationLost: number;


### PR DESCRIPTION
This makes a change to the trip details package to use the co2 value included in the itinerary that is passed in from OTP-RR. That way this value only gets calculated once, higher up. The co2 property is added to the type to accommodate this change. 