### PR TITLE
Adjust endpoint icon size

### DIFF
--- a/packages/endpoints-overlay/src/endpoint.tsx
+++ b/packages/endpoints-overlay/src/endpoint.tsx
@@ -160,6 +160,7 @@ const Endpoint = (props: Props): JSX.Element => {
     // We have to use the standard marker here since we need to adjust state
     // after and during drag
     <Marker
+      anchor="center"
       draggable
       latitude={location.lat}
       longitude={location.lon}

--- a/packages/endpoints-overlay/src/index.tsx
+++ b/packages/endpoints-overlay/src/index.tsx
@@ -85,7 +85,7 @@ function DefaultMapMarkerIcon({
   switch (type) {
     case "to": {
       // The fa-solid's "location-dot" icon used here has a width-height ratio of 3/4,
-      // so the desired width for the outline/"stacked" element is 4/3 of the pixels prop.
+      // so the desired width for the outline/"stacked" element is 4/3 of the "apparent" width.
       const toPixels = pixels * 1.3;
       inner = (
         <>

--- a/packages/endpoints-overlay/src/index.tsx
+++ b/packages/endpoints-overlay/src/index.tsx
@@ -80,17 +80,17 @@ function DefaultMapMarkerIcon({
   location,
   type
 }: UserLocationAndType): ReactElement {
-  const pixels = 20;
+  const PIXELS = 20;
   let inner;
   switch (type) {
     case "to": {
       // The fa-solid's "location-dot" icon used here has a width-height ratio of 3/4,
       // so the desired width for the outline/"stacked" element is 4/3 of the "apparent" width.
-      const toPixels = pixels * 1.3;
+      const toPixels = PIXELS * 1.3;
       inner = (
         <>
           <S.StackedToIcon size={toPixels} type={type} />
-          <S.ToIcon size={toPixels - 5} type={type} />
+          <S.ToIcon size={toPixels - 6} type={type} />
         </>
       );
       break;
@@ -99,8 +99,8 @@ function DefaultMapMarkerIcon({
       // Default to the location icon on top of a white background.
       inner = (
         <>
-          <S.StackedCircle size={pixels} />
-          <S.StackedLocationIcon size={pixels} type={type} />
+          <S.StackedCircle size={PIXELS} />
+          <S.StackedLocationIcon size={PIXELS} type={type} />
         </>
       );
       break;

--- a/packages/endpoints-overlay/src/index.tsx
+++ b/packages/endpoints-overlay/src/index.tsx
@@ -80,22 +80,27 @@ function DefaultMapMarkerIcon({
   location,
   type
 }: UserLocationAndType): ReactElement {
+  const pixels = 20;
   let inner;
   switch (type) {
-    case "to":
+    case "to": {
+      // The fa-solid's "location-dot" icon used here has a width-height ratio of 3/4,
+      // so the desired width for the outline/"stacked" element is 4/3 of the pixels prop.
+      const toPixels = pixels * 1.3;
       inner = (
         <>
-          <S.StackedToIcon size={24} type={type} />
-          <S.ToIcon size={20} type={type} />
+          <S.StackedToIcon size={toPixels} type={type} />
+          <S.ToIcon size={toPixels - 5} type={type} />
         </>
       );
       break;
+    }
     default:
       // Default to the location icon on top of a white background.
       inner = (
         <>
-          <S.StackedCircle size={24} />
-          <S.StackedLocationIcon size={24} type={type} />
+          <S.StackedCircle size={pixels} />
+          <S.StackedLocationIcon size={pixels} type={type} />
         </>
       );
       break;
@@ -134,9 +139,9 @@ const EndpointsOverlay = ({
     {intermediatePlaces.map((place, index) => {
       return (
         <Endpoint
-          key={index}
           clearLocation={clearLocation}
           forgetPlace={forgetPlace}
+          key={index}
           location={place}
           locations={locations}
           MapMarkerIcon={MapMarkerIcon}

--- a/packages/endpoints-overlay/src/styled.ts
+++ b/packages/endpoints-overlay/src/styled.ts
@@ -21,7 +21,6 @@ const stacked = css`
   cursor: pointer;
   left: 0;
   position: absolute;
-  text-align: center;
 `;
 
 export const StackedCircle = styled(Circle)`
@@ -35,26 +34,19 @@ export const StackedLocationIcon = styled(LocationIcon)`
 
 export const StackedToIcon = styled(StackedLocationIcon)`
   color: #333;
+  margin-left: -2.5px;
+  margin-top: -2px;
 `;
 
 export const StackedIconContainer = styled.span`
   display: inline-block;
-  height: 2em;
-  line-height: 2em;
-  line-height: inherit;
-  margin-left: -10px;
-  margin-top: -7px;
-  opacity: 1;
-  position: relative;
-  vertical-align: middle;
-  width: 2em;
+  height: 20px;
+  margin-top: 2px;
+  width: 20px;
 `;
 
 export const ToIcon = styled(LocationIcon)`
   ${stacked}
-  line-height: inherit;
-  margin-left: 2px;
-  margin-top: 2px;
 `;
 
 export const IconWrapper = styled.span`

--- a/packages/endpoints-overlay/src/styled.ts
+++ b/packages/endpoints-overlay/src/styled.ts
@@ -34,7 +34,7 @@ export const StackedLocationIcon = styled(LocationIcon)`
 
 export const StackedToIcon = styled(StackedLocationIcon)`
   color: #333;
-  margin-left: -2.5px;
+  margin-left: -3px;
   margin-top: -2px;
 `;
 

--- a/packages/location-field/src/types.ts
+++ b/packages/location-field/src/types.ts
@@ -155,7 +155,7 @@ export interface LocationFieldProps {
   locationType: LocationType;
   /**
    * A list of stopIds of the stops that should be shown as being nearby. These
-   * must be referencable in the stopsIndex prop.
+   * must be referenceable in the stopsIndex prop.
    */
   nearbyStops?: string[];
   /**


### PR DESCRIPTION
This PR adjusts the size of the endpoint icons to match the transit stop and rental place markers in the original transitive overlay, and cleans up the related CSS.