### PR TITLE
fix(geocoder): remove invalid layers from default layers list

### DIFF
--- a/packages/geocoder/src/__snapshots__/index.test.js.snap
+++ b/packages/geocoder/src/__snapshots__/index.test.js.snap
@@ -672,7 +672,7 @@ Object {
   },
   "isomorphicMapzenSearchQuery": Object {
     "api_key": "dummy-mapzen-key",
-    "layers": "address,venue,street,intersection,stops,stations",
+    "layers": "address,venue,street,intersection",
     "text": "Mill Ends",
   },
   "type": "FeatureCollection",

--- a/packages/geocoder/src/geocoders/pelias.ts
+++ b/packages/geocoder/src/geocoders/pelias.ts
@@ -4,7 +4,7 @@ import Geocoder from "./abstract-geocoder";
 import type { AutocompleteQuery, SearchQuery } from "..";
 import type { SingleOrMultiGeocoderResponse } from "./types";
 
-const DEFAULT_LAYERS = "address,venue,street,intersection,stops,stations"
+const DEFAULT_LAYERS = "address,venue,street,intersection"
 
 /**
  * Geocoder implementation for the Pelias geocoder.

--- a/packages/location-field/src/types.ts
+++ b/packages/location-field/src/types.ts
@@ -155,7 +155,7 @@ export interface LocationFieldProps {
   locationType: LocationType;
   /**
    * A list of stopIds of the stops that should be shown as being nearby. These
-   * must be referencable in the stopsIndex prop.
+   * must be referenceable in the stopsIndex prop.
    */
   nearbyStops?: string[];
   /**


### PR DESCRIPTION
#447 contained a bug which sent invalid requests to the geocoder. This PR resolves this oversight.