### PR TITLE
docs(README): Add i18n and Weblate overview [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,17 @@ Language-specific content is located in YML files under the `i18n` folder of pac
 
 ### Contributing translations
 
-OTP-UI now uses [Weblate](https://www.weblate.org) to manage translations!
+OTP-UI now uses [Hosted Weblate](https://www.weblate.org) to manage translations!
+
+<figure>
+  <a href="https://hosted.weblate.org/engage/otp-react-redux/">
+    <img src="https://hosted.weblate.org/widgets/otp-react-redux/-/horizontal-auto.svg" alt="Translation status" />
+  </a>
+  <figcaption>Translation status for
+    <a href="https://hosted.weblate.org/engage/otp-react-redux/">OTP-react-redux and OTP-UI on Hosted Weblate</a>
+  </figcaption>
+</figure>
+
 Translations from the community are welcome and very much appreciated,
 please see instructions at https://hosted.weblate.org/projects/otp-react-redux/.
 Community input from Weblate will appear as pull requests with changes to files in the applicable `i18n` folders for our review.

--- a/README.md
+++ b/README.md
@@ -89,3 +89,20 @@ The following table lists the last major version of each package which uses rast
 | `types`                   | 3                                      |
 | `vehicle-rental-overlay`  | 1                                      |
 | `zoom-based-markers`      | 1                                      |
+
+## Internationalization
+
+OTP-UI uses `react-intl` from the [`formatjs`](https://github.com/formatjs/formatjs) library for internationalization.
+Both `react-intl` and `formatjs` take advantage of native internationalization features provided by web browsers.
+
+Language-specific content is located in YML files under the `i18n` folder of packages that have internationalizable content
+(e.g. `en-US.yml` for American English, `fr.yml` for generic French, etc.).
+
+### Contributing translations
+
+OTP-UI now uses [Weblate](https://www.weblate.org) to manage translations!
+Translations from the community are welcome and very much appreciated,
+please see instructions at https://hosted.weblate.org/projects/otp-react-redux/.
+Community input from Weblate will appear as pull requests with changes to files in the applicable `i18n` folders for our review.
+
+If changes to a specific language file is needed but not enabled in Weblate, please open an issue or a pull request with the changes needed.


### PR DESCRIPTION
This PR contains a now required mention of/link to Weblate as part of their open-source hosting plan, and adds an i18n overview section.