### PR TITLE
Trip Details: make calorie display optional

### DIFF
--- a/packages/trip-details/src/index.tsx
+++ b/packages/trip-details/src/index.tsx
@@ -119,6 +119,7 @@ export function TripDetails({
   CaloriesDetails = DefaultCaloriesDetails,
   className = "",
   defaultFareKey = "regular",
+  displayCalories = true,
   DepartureDetails = null,
   FareDetails = null,
   fareDetailsLayout,
@@ -299,7 +300,7 @@ export function TripDetails({
             summary={fare}
           />
         )}
-        {caloriesBurned > 0 && (
+        {displayCalories && caloriesBurned > 0 && (
           <TripDetail
             icon={<Heartbeat size={17} />}
             summary={

--- a/packages/trip-details/src/types.ts
+++ b/packages/trip-details/src/types.ts
@@ -79,6 +79,11 @@ export interface TripDetailsProps {
    */
   DepartureDetails?: React.ElementType<DepartureDetailsProps>;
   /**
+   * If this is set to true, a row will be added to the trip details displaying how
+   * many calories were burned on the active legs of the trip.
+   */
+  displayCalories?: boolean;
+  /**
    * Slot for a custom component to render the expandable section for fares.
    */
   FareDetails?: React.ElementType<FareDetailsProps>;


### PR DESCRIPTION
There was previously no way to disable the calorie display in the trip details. This PR corrects this in a backwards compatible way (no prop specified = calories displayed)