### PR TITLE
fix: support bounds updating on small screens

### DIFF
--- a/packages/route-viewer-overlay/src/index.tsx
+++ b/packages/route-viewer-overlay/src/index.tsx
@@ -76,7 +76,7 @@ const RouteViewerOverlay = (props: Props): JSX.Element => {
 
         current?.fitBounds(bounds, {
           duration: 500,
-          padding: 200
+          padding: window.innerWidth > 500 ? 200 : undefined
         });
 
         if (props.mapCenterCallback) {

--- a/packages/transitive-overlay/src/index.tsx
+++ b/packages/transitive-overlay/src/index.tsx
@@ -113,7 +113,7 @@ const TransitiveCanvasOverlay = ({
     if (bounds.length === 4 && bounds.every(Number.isFinite)) {
       map?.fitBounds(bounds, {
         duration: 500,
-        padding: 200
+        padding: window.innerWidth > 500 ? 200 : undefined
       });
     }
   };

--- a/packages/transitive-overlay/tsconfig.json
+++ b/packages/transitive-overlay/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "lib": ["es2019"],
+    "lib": ["es2019", "dom"],
     "outDir": "./lib",
     "rootDir": "./src",
     "skipLibCheck": true


### PR DESCRIPTION
The 200 units padding caused some problems on smaller screens where maplibre refused to update the bounds. This PR checks the screen width and only adds the padding if the window width is large enough to accommodate it.