### PR TITLE
fix(base-map): support onContextMenu in touch env

### DIFF
--- a/packages/base-map/src/index.tsx
+++ b/packages/base-map/src/index.tsx
@@ -80,6 +80,7 @@ const BaseMap = ({
   // On mobile hover is unavailable, so we use this variable to use a two tap process
   // to simulate a hover
   const [fakeMobileHover, setFakeMobileHover] = useState(false);
+  const [longPressTimer, setLongPressTimer] = useState(null);
 
   useEffect(() => {
     callIfValid(onViewportChanged)(viewState);
@@ -121,9 +122,19 @@ const BaseMap = ({
       maxZoom={maxZoom}
       onClick={onClick}
       onContextMenu={onContextMenu}
-      onMove={evt => setViewState(evt.viewState)}
-      onTouchStart={() => {
+      onMove={evt => {
+        setViewState(evt.viewState);
+        clearTimeout(longPressTimer);
+      }}
+      onTouchStart={e => {
         setFakeMobileHover(false);
+        setLongPressTimer(setTimeout(() => onContextMenu(e), 600));
+      }}
+      onTouchCancel={() => {
+        clearTimeout(longPressTimer);
+      }}
+      onTouchEnd={() => {
+        clearTimeout(longPressTimer);
       }}
       style={style}
       zoom={viewState.zoom}


### PR DESCRIPTION
Right clicking is not possible with a touch environment, so we fake it by handling long presses. The 600ms timeout is based on https://developer.android.com/reference/android/view/ViewConfiguration.html#getLongPressTimeout%28%29