### PR TITLE
ci(codespell): Exclude i18n folders from codespell.

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -12,5 +12,5 @@ jobs:
       - uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true
-          # skip git, yarn, mocks, and i18n non-English resources.
-          skip: ./.git,yarn.lock,*__mocks__/*,*__snapshots__/*,*i18n/fr*
+          # skip git, yarn, mocks, and i18n resources.
+          skip: ./.git,yarn.lock,*__mocks__/*,*__snapshots__/*,*i18n/

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           check_filenames: true
           # skip git, yarn, mocks, and i18n resources.
-          skip: ./.git,yarn.lock,*__mocks__/*,*__snapshots__/*,*i18n/
+          skip: ./.git,yarn.lock,*__mocks__/*,*__snapshots__/*,*i18n/*


### PR DESCRIPTION
This PR excludes all i18n resources from codespell. This is done so we don't have to add language exclusions to `codespell.yml` each time someone adds a translation (via Weblate or regular PRs). This PR echoes https://github.com/opentripplanner/otp-react-redux/pull/686 and https://github.com/opentripplanner/otp-react-redux/pull/686#pullrequestreview-1160287923