### PR TITLE
fix(trip-details): repair co2 regression

### DIFF
--- a/packages/trip-details/src/index.tsx
+++ b/packages/trip-details/src/index.tsx
@@ -236,7 +236,7 @@ export function TripDetails({
   // Calculate CO2 if it's not provided by the itinerary
   const co2 =
     itinerary.co2 ||
-    (co2Config.enabled &&
+    (co2Config?.enabled &&
       coreUtils.itinerary.calculateEmissions(
         itinerary,
         co2Config?.carbonIntensity,


### PR DESCRIPTION
`trip-details` was crashing when `co2config` was missing. This PR repairs this issue.