### PR TITLE
Update base-map in pkgs that use its Popup or MarkerWithPopup.

### DIFF
--- a/packages/endpoints-overlay/package.json
+++ b/packages/endpoints-overlay/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.1",
+    "@opentripplanner/base-map": "^3.0.4",
     "@opentripplanner/location-icon": "^1.4.0",
     "@opentripplanner/core-utils": "^7.0.3",
     "flat": "^5.0.2",

--- a/packages/park-and-ride-overlay/package.json
+++ b/packages/park-and-ride-overlay/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.1",
+    "@opentripplanner/base-map": "^3.0.4",
     "@opentripplanner/from-to-location-picker": "^2.1.3"
   },
   "peerDependencies": {

--- a/packages/stop-viewer-overlay/package.json
+++ b/packages/stop-viewer-overlay/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.1",
+    "@opentripplanner/base-map": "^3.0.4",
     "@opentripplanner/core-utils": "^7.0.3"
   },
   "devDependencies": {

--- a/packages/stops-overlay/package.json
+++ b/packages/stops-overlay/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.1",
+    "@opentripplanner/base-map": "^3.0.4",
     "@opentripplanner/from-to-location-picker": "^2.1.3",
     "flat": "^5.0.2"
   },

--- a/packages/transit-vehicle-overlay/package.json
+++ b/packages/transit-vehicle-overlay/package.json
@@ -9,7 +9,7 @@
   "module": "esm/index.js",
   "private": false,
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.1",
+    "@opentripplanner/base-map": "^3.0.4",
     "@opentripplanner/core-utils": "^7.0.3",
     "@opentripplanner/icons": "^1.2.5",
     "flat": "^5.0.2"

--- a/packages/vehicle-rental-overlay/package.json
+++ b/packages/vehicle-rental-overlay/package.json
@@ -19,7 +19,7 @@
     "url": "git+https://github.com/opentripplanner/otp-ui.git"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.1",
+    "@opentripplanner/base-map": "^3.0.4",
     "@opentripplanner/core-utils": "^7.0.3",
     "@opentripplanner/from-to-location-picker": "^2.1.3",
     "@styled-icons/fa-solid": "^10.34.0",

--- a/packages/zoom-based-markers/package.json
+++ b/packages/zoom-based-markers/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@opentripplanner/core-utils": "^7.0.3",
-    "@opentripplanner/base-map": "^3.0.1"
+    "@opentripplanner/base-map": "^3.0.4"
   },
   "devDependencies": {
     "@opentripplanner/types": "^4.0.1"


### PR DESCRIPTION
This PR updates the base-map version for packages that use it's new `Popup` component that displays a shadow.
(Other packages that use the map but not the popups are not touched.)