### PR TITLE
fix(core-utils/route.ts): support null text color

### DIFF
--- a/packages/core-utils/src/route.ts
+++ b/packages/core-utils/src/route.ts
@@ -442,8 +442,10 @@ export function makeRouteComparator(
  */
 export function getMostReadableTextColor(
   backgroundColor: string,
-  proposedTextColor = "#ffffff"
+  proposedTextColor?: string
 ): string {
+  if (!proposedTextColor) proposedTextColor = "#ffffff";
+
   if (!backgroundColor.startsWith("#")) {
     backgroundColor = `#${backgroundColor}`;
   }


### PR DESCRIPTION
The previous method of setting a fallback color didn't handle `null` correctly. This explicit `if` corrects this.