### PR TITLE
Update Internal Dependencies (Nov 2022)

### DIFF
--- a/packages/base-map/package.json
+++ b/packages/base-map/package.json
@@ -14,7 +14,7 @@
     "react-map-gl": "^7.0.15"
   },
   "peerDependencies": {
-    "@opentripplanner/types": "^4.0.1",
+    "@opentripplanner/types": "^4.0.2",
     "react": "^16.14.0",
     "styled-components": "^5.3.0"
   },

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -30,6 +30,6 @@
   },
   "devDependencies": {
     "@types/chroma-js": "^2.1.4",
-    "@opentripplanner/types": "^4.0.1"
+    "@opentripplanner/types": "^4.0.2"
   }
 }

--- a/packages/endpoints-overlay/package.json
+++ b/packages/endpoints-overlay/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@opentripplanner/base-map": "^3.0.4",
     "@opentripplanner/location-icon": "^1.4.0",
-    "@opentripplanner/core-utils": "^7.0.3",
+    "@opentripplanner/core-utils": "^7.0.5",
     "flat": "^5.0.2",
     "@styled-icons/fa-solid": "^10.34.0"
   },
@@ -29,7 +29,7 @@
     "@types/flat": "^5.0.2"
   },
   "peerDependencies": {
-    "@opentripplanner/types": "^4.0.1",
+    "@opentripplanner/types": "^4.0.2",
     "react": "^16.14.0",
     "react-dom": "^16.8.6",
     "react-intl": "^5.24.6",

--- a/packages/from-to-location-picker/package.json
+++ b/packages/from-to-location-picker/package.json
@@ -13,7 +13,7 @@
     "flat": "^5.0.2"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^4.0.1"
+    "@opentripplanner/types": "^4.0.2"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^7.0.3",
+    "@opentripplanner/core-utils": "^7.0.5",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/itinerary-body/package.json
+++ b/packages/itinerary-body/package.json
@@ -10,9 +10,9 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^7.0.3",
+    "@opentripplanner/core-utils": "^7.0.5",
     "@opentripplanner/humanize-distance": "^1.2.0",
-    "@opentripplanner/icons": "^1.2.5",
+    "@opentripplanner/icons": "^2.0.0",
     "@opentripplanner/location-icon": "^1.4.0",
     "@styled-icons/fa-solid": "^10.34.0",
     "@styled-icons/foundation": "^10.34.0",
@@ -23,7 +23,7 @@
     "react-animate-height": "^3.0.4"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^4.0.1",
+    "@opentripplanner/types": "^4.0.2",
     "@types/flat": "^5.0.2"
   },
   "peerDependencies": {

--- a/packages/location-field/package.json
+++ b/packages/location-field/package.json
@@ -10,7 +10,7 @@
   "private": false,
   "dependencies": {
     "@conveyal/geocoder-arcgis-geojson": "^0.0.3",
-    "@opentripplanner/core-utils": "^7.0.3",
+    "@opentripplanner/core-utils": "^7.0.5",
     "@opentripplanner/geocoder": "^1.3.2",
     "@opentripplanner/humanize-distance": "^1.2.0",
     "@opentripplanner/location-icon": "^1.4.0",

--- a/packages/park-and-ride-overlay/package.json
+++ b/packages/park-and-ride-overlay/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@opentripplanner/base-map": "^3.0.4",
-    "@opentripplanner/from-to-location-picker": "^2.1.3"
+    "@opentripplanner/from-to-location-picker": "^2.1.4"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/printable-itinerary/package.json
+++ b/packages/printable-itinerary/package.json
@@ -10,10 +10,10 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/itinerary-body": "^4.1.1"
+    "@opentripplanner/itinerary-body": "^4.1.3"
   },
   "devDependencies": {
-    "@opentripplanner/icons": "^1.2.5"
+    "@opentripplanner/icons": "^2.0.0"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/route-viewer-overlay/package.json
+++ b/packages/route-viewer-overlay/package.json
@@ -20,12 +20,12 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.0",
-    "@opentripplanner/base-map": "^3.0.1",
-    "@opentripplanner/core-utils": "^7.0.3",
+    "@opentripplanner/base-map": "^3.0.4",
+    "@opentripplanner/core-utils": "^7.0.5",
     "point-in-polygon": "^1.1.0"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^4.0.1",
+    "@opentripplanner/types": "^4.0.2",
     "point-in-polygon": "^1.1.0",
     "prop-types": "^15.7.2"
   },

--- a/packages/stop-viewer-overlay/package.json
+++ b/packages/stop-viewer-overlay/package.json
@@ -20,10 +20,10 @@
   },
   "dependencies": {
     "@opentripplanner/base-map": "^3.0.4",
-    "@opentripplanner/core-utils": "^7.0.3"
+    "@opentripplanner/core-utils": "^7.0.5"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^4.0.1"
+    "@opentripplanner/types": "^4.0.2"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/stops-overlay/package.json
+++ b/packages/stops-overlay/package.json
@@ -20,11 +20,11 @@
   },
   "dependencies": {
     "@opentripplanner/base-map": "^3.0.4",
-    "@opentripplanner/from-to-location-picker": "^2.1.3",
+    "@opentripplanner/from-to-location-picker": "^2.1.4",
     "flat": "^5.0.2"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^4.0.1",
+    "@opentripplanner/types": "^4.0.2",
     "styled-icons": "^10.34.0"
   },
   "peerDependencies": {

--- a/packages/transit-vehicle-overlay/package.json
+++ b/packages/transit-vehicle-overlay/package.json
@@ -10,12 +10,12 @@
   "private": false,
   "dependencies": {
     "@opentripplanner/base-map": "^3.0.4",
-    "@opentripplanner/core-utils": "^7.0.3",
-    "@opentripplanner/icons": "^1.2.5",
+    "@opentripplanner/core-utils": "^7.0.5",
+    "@opentripplanner/icons": "^2.0.0",
     "flat": "^5.0.2"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^4.0.1"
+    "@opentripplanner/types": "^4.0.2"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/transitive-overlay/package.json
+++ b/packages/transitive-overlay/package.json
@@ -20,15 +20,15 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.1",
-    "@opentripplanner/base-map": "^3.0.1",
-    "@opentripplanner/itinerary-body": "^4.1.1",
-    "@opentripplanner/core-utils": "^7.0.3",
+    "@opentripplanner/base-map": "^3.0.4",
+    "@opentripplanner/itinerary-body": "^4.1.3",
+    "@opentripplanner/core-utils": "^7.0.5",
     "lodash.isequal": "^4.5.0",
     "@turf/bbox": "^6.5.0"
   },
   "devDependencies": {
-    "@opentripplanner/endpoints-overlay": "^2.0.1",
-    "@opentripplanner/types": "^4.0.1"
+    "@opentripplanner/endpoints-overlay": "^2.0.4",
+    "@opentripplanner/types": "^4.0.2"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/trip-details/package.json
+++ b/packages/trip-details/package.json
@@ -11,13 +11,13 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^7.0.3",
+    "@opentripplanner/core-utils": "^7.0.5",
     "@styled-icons/fa-solid": "^10.34.0",
     "flat": "^5.0.2",
     "react-animate-height": "^3.0.4"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^4.0.1",
+    "@opentripplanner/types": "^4.0.2",
     "@types/flat": "^5.0.2"
   },
   "peerDependencies": {

--- a/packages/trip-form/package.json
+++ b/packages/trip-form/package.json
@@ -10,8 +10,8 @@
   "types": "lib/index.d.ts",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^7.0.3",
-    "@opentripplanner/icons": "^1.2.5",
+    "@opentripplanner/core-utils": "^7.0.5",
+    "@opentripplanner/icons": "^2.0.0",
     "@styled-icons/bootstrap": "^10.34.0",
     "@styled-icons/boxicons-regular": "^10.38.0",
     "@styled-icons/fa-regular": "^10.34.0",

--- a/packages/trip-viewer-overlay/package.json
+++ b/packages/trip-viewer-overlay/package.json
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.0",
-    "@opentripplanner/base-map": "^3.0.1",
-    "@opentripplanner/core-utils": "^7.0.3"
+    "@opentripplanner/base-map": "^3.0.4",
+    "@opentripplanner/core-utils": "^7.0.5"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/vehicle-rental-overlay/package.json
+++ b/packages/vehicle-rental-overlay/package.json
@@ -20,14 +20,14 @@
   },
   "dependencies": {
     "@opentripplanner/base-map": "^3.0.4",
-    "@opentripplanner/core-utils": "^7.0.3",
-    "@opentripplanner/from-to-location-picker": "^2.1.3",
+    "@opentripplanner/core-utils": "^7.0.5",
+    "@opentripplanner/from-to-location-picker": "^2.1.4",
     "@styled-icons/fa-solid": "^10.34.0",
     "flat": "^5.0.2",
     "lodash.memoize": "^4.1.2"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^4.0.1"
+    "@opentripplanner/types": "^4.0.2"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/zoom-based-markers/package.json
+++ b/packages/zoom-based-markers/package.json
@@ -19,11 +19,11 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/core-utils": "^7.0.3",
+    "@opentripplanner/core-utils": "^7.0.5",
     "@opentripplanner/base-map": "^3.0.4"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^4.0.1"
+    "@opentripplanner/types": "^4.0.2"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6376,9 +6376,9 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219:
-  version "1.0.30001338"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz"
-  integrity sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==
+  version "1.0.30001431"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz"
+  integrity sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The icons code splitting actually made things worse as it in some cases resulted in two different versions of the icons package being installed. This PR resolves this, while also updating all other internal dependencies.