### PR TITLE
fix(core-utils): prefer 24 hour time parsing

### DIFF
--- a/packages/core-utils/src/query.js
+++ b/packages/core-utils/src/query.js
@@ -34,6 +34,8 @@ export const defaultParams = [
  */
 const TIME_FORMATS = [
   "HH:mm:ss",
+  "HH:mm",
+  "H:mm",
   "h:mm:ss a",
   "h:mm:ssa",
   "h:mm a",

--- a/packages/core-utils/src/query.js
+++ b/packages/core-utils/src/query.js
@@ -43,8 +43,7 @@ const TIME_FORMATS = [
   "h:mm",
   "HHmm",
   "hmm",
-  "ha",
-  OTP_API_TIME_FORMAT // 'HH:mm'
+  "ha"
 ];
 
 /* A function to retrieve a property value from an entry in the query-params


### PR DESCRIPTION
This PR resolves the infamous "am/pm" bug we've been seeing. Times such as `8:24` were being parsed as 8pm instead of 8am when the processing happened after 12pm because 12 hour time was being assumed. This PR corrects this.