### PR TITLE
Add Photon Geocoder

### DIFF
--- a/packages/geocoder/src/apis/photon/index.ts
+++ b/packages/geocoder/src/apis/photon/index.ts
@@ -43,7 +43,7 @@ function run({ options, query, url }: PhotonFetchArgs): Promise<PhotonResponse> 
 
 /**
  * Search for an address using
- * Here's {@link https://developer.here.com/documentation/geocoding-search-api/api-reference-swagger.html|Autocomplete}
+ * Komoot's Photon {@link https://github.com/komoot/photon}
  * service.
  *
  * @param  {Object} $0
@@ -97,8 +97,8 @@ async function autocomplete({
 
 /**
  * Search for an address using
- * HERE's {@link https://developer.here.com/documentation/geocoding-search-api/api-reference-swagger.html|Search}
- * service. NOTE: Here does not support a boundary for Search queries, unlike Pelias.
+ * Komoot's Photon {@link https://github.com/komoot/photon}
+ * service.
  *
  * @param  {Object} $0
  * @param  {Object} $0.focusPoint
@@ -131,7 +131,7 @@ function search({
 
 /**
  * Search for an address using
- * HERE's {@link https://developer.here.com/documentation/geocoding-search-api/api-reference-swagger.html|Search}
+ * Komoot's Photon {@link https://github.com/komoot/photon} reverse
  * service.
  *
  * @param  {Object} $0

--- a/packages/geocoder/src/apis/photon/index.ts
+++ b/packages/geocoder/src/apis/photon/index.ts
@@ -1,0 +1,160 @@
+import { normalize } from "@conveyal/lonlat";
+import { stringify } from "querystring";
+
+// Prettier does not support typescript annotation
+// eslint-disable-next-line prettier/prettier
+import type { LonLatOutput } from "@conveyal/lonlat"
+import type { AutocompleteQuery, ReverseQuery, SearchQuery } from "../../geocoders/types"
+import type { PhotonResponse } from "./types";
+
+const AUTOCOMPLETE_URL =
+    "https://photon.komoot.io/api";
+const GEOCODE_URL = "https://photon.komoot.io/api";
+const REVERSE_URL = "https://photon.komoot.io/reverse";
+
+type PhotonQuery = {
+  lon?: string;
+  lat?: string;
+  in?: string;
+  lang?: string;
+  limit?: number | string;
+  politicalView?: string;
+  q?: string;
+  qq?: string;
+  show?: string;
+};
+
+// These types are standardized for the other geocoders in this library.
+// Perhaps we could extract them out somewhere and reuse them in the other libraries?
+type PhotonFetchArgs = {
+  options: RequestInit; // Built-in Typing
+  query: PhotonQuery;
+  url: string;
+};
+
+function GeocoderException(message: string) {
+  this.message = message;
+  this.name = "GeocoderException";
+}
+
+function run({ options, query, url }: PhotonFetchArgs): Promise<PhotonResponse> {
+  return fetch(`${url}?${stringify(query)}`, options).then(res => res.json());
+}
+
+/**
+ * Search for an address using
+ * Here's {@link https://developer.here.com/documentation/geocoding-search-api/api-reference-swagger.html|Autocomplete}
+ * service.
+ *
+ * @param  {Object} $0
+ * @param  {Object} $0.boundary
+ * @param  {Object} $0.focusPoint
+ * @param  {Object} $0.options                    options to pass to fetch (e.g., custom headers)
+ * @param  {number} [$0.size=20]
+ * @param  {string} $0.text                       query text
+ * @return {Promise}                              A Promise that'll get resolved with the autocomplete result
+ */
+async function autocomplete({
+  boundary,
+  focusPoint,
+  options,
+  size = 20,
+  text
+}: AutocompleteQuery): Promise<PhotonResponse> {
+  // build query
+  const query: PhotonQuery = { limit: size, q: text };
+
+  if (focusPoint) {
+    const { lat, lon }: LonLatOutput = normalize(focusPoint);
+    query.lat = `${lat}`;
+    query.lon = `${lon}`;
+    const res = await run({
+      options,
+      query,
+      url: AUTOCOMPLETE_URL
+    });
+    return res
+  }
+  if (boundary) {
+    const { country, rect } = boundary;
+    if (country) query.in = `countryCode:${country}`;
+    if (rect) {
+      query.in = `bbox:${[
+        rect.minLon,
+        rect.minLat,
+        rect.maxLon,
+        rect.maxLat
+      ].join(",")}`;
+    }
+  }
+
+  return run({
+    options,
+    query,
+    url: AUTOCOMPLETE_URL
+  });
+}
+
+/**
+ * Search for an address using
+ * HERE's {@link https://developer.here.com/documentation/geocoding-search-api/api-reference-swagger.html|Search}
+ * service. NOTE: Here does not support a boundary for Search queries, unlike Pelias.
+ *
+ * @param  {Object} $0
+ * @param  {Object} $0.focusPoint
+ * @param  {Object} $0.options                  options to pass to fetch (e.g., custom headers)
+ * @param  {number} [$0.size=10]
+ * @param  {string} $0.text                      The address text to query for
+ * @return {Promise}                            A Promise that'll get resolved with search result
+ */
+function search({
+  focusPoint,
+  options,
+  size = 10,
+  text
+}: SearchQuery): Promise<PhotonResponse> {
+  if (!text) return Promise.resolve({ items: [] });
+
+  const query: PhotonQuery = {
+    limit: size,
+    q: text
+  };
+
+  if (focusPoint) {
+    const { lat, lon }: LonLatOutput = normalize(focusPoint);
+    query.lat = `${lat}`;
+    query.lon = `${lon}`;
+  }
+
+  return run({ options, query, url: GEOCODE_URL });
+}
+
+/**
+ * Search for an address using
+ * HERE's {@link https://developer.here.com/documentation/geocoding-search-api/api-reference-swagger.html|Search}
+ * service.
+ *
+ * @param  {Object} $0
+ * @param  {Object} $0.point
+ * @param  {Object} $0.options                  options to pass to fetch (e.g., custom headers)
+ * @return {Promise}                            A Promise that'll get resolved with search result
+ */
+function reverse({ options, point }: ReverseQuery): Promise<PhotonResponse> {
+  const query: PhotonQuery = {
+  };
+
+  if (point) {
+    const { lat, lon }: LonLatOutput = normalize(point);
+    query.lat = `${lat}`;
+    query.lon = `${lon}`;
+  } else {
+    throw new GeocoderException("No point provided for reverse geocoder.");
+  }
+
+  return run({ options, query, url: REVERSE_URL }).then(res => ({
+    ...res,
+    point
+  }));
+}
+
+export { autocomplete, reverse, search };

--- a/packages/geocoder/src/apis/photon/index.ts
+++ b/packages/geocoder/src/apis/photon/index.ts
@@ -66,8 +66,8 @@ async function autocomplete({
 
   if (focusPoint) {
     const { lat, lon }: LonLatOutput = normalize(focusPoint);
-    query.lat = `${lat}`;
-    query.lon = `${lon}`;
+    query.lat = lat.toString();
+    query.lon = lon.toString();
     const res = await run({
       options,
       query,
@@ -122,8 +122,8 @@ function search({
 
   if (focusPoint) {
     const { lat, lon }: LonLatOutput = normalize(focusPoint);
-    query.lat = `${lat}`;
-    query.lon = `${lon}`;
+    query.lat = lat.toString();
+    query.lon = lon.toString();
   }
 
   return run({ options, query, url: GEOCODE_URL });
@@ -145,8 +145,8 @@ function reverse({ options, point }: ReverseQuery): Promise<PhotonResponse> {
 
   if (point) {
     const { lat, lon }: LonLatOutput = normalize(point);
-    query.lat = `${lat}`;
-    query.lon = `${lon}`;
+    query.lat = lat.toString();
+    query.lon = lon.toString();
   } else {
     throw new GeocoderException("No point provided for reverse geocoder.");
   }

--- a/packages/geocoder/src/apis/photon/types.ts
+++ b/packages/geocoder/src/apis/photon/types.ts
@@ -1,0 +1,68 @@
+// Prettier does not support typescript annotation
+// eslint-disable-next-line prettier/prettier
+import type { LonLatInput } from "@conveyal/lonlat"
+
+export interface PhotonResponse {
+  items: Item[];
+  point?: LonLatInput; // used in reverse response
+}
+
+export type Rect = {
+  maxLat: number;
+  maxLon: number;
+  minLat: number;
+  minLon: number;
+};
+
+export type Boundary = {
+  country?: string;
+  rect?: Rect;
+};
+
+export interface Item {
+  access: Position[];
+  address: Address;
+  categories: Category[];
+  distance: number;
+  foodTypes: Category[];
+  id: string;
+  position: Position;
+  resultType: string;
+  scoring: Scoring;
+  title: string;
+}
+
+export interface Position {
+  lat: number;
+  lng: number;
+}
+
+export interface Address {
+  city: string;
+  countryCode: string;
+  countryName: string;
+  county: string;
+  district: string;
+  houseNumber: string;
+  label: string;
+  postalCode: string;
+  state: string;
+  stateCode: string;
+  street: string;
+}
+
+export interface Category {
+  id: string;
+  name: string;
+  primary?: boolean;
+}
+
+export interface Scoring {
+  fieldScore: FieldScore;
+  queryScore: number;
+}
+
+export interface FieldScore {
+  district: number;
+  placeName: number;
+}

--- a/packages/geocoder/src/geocoders/photon.ts
+++ b/packages/geocoder/src/geocoders/photon.ts
@@ -33,46 +33,29 @@ export default class PhotonGeocoder extends Geocoder {
       baseUrl,
       boundary,
       focusPoint,
-      options,
-      sources
+      options
     } = this.geocoderConfig;
     return {
       boundary,
       focusPoint,
       options,
-      // explicitly send over null for sources if provided sources is not truthy
-      // in order to avoid default isomorphic-mapzen-search sources form being
-      // applied
-      sources: sources || null,
       url: baseUrl ? `${baseUrl}/autocomplete` : undefined,
       ...query
     };
   }
 
-  /**
-   * Generate a search query specifically for the Pelias API. The
-   * `sources` parameter is a Pelias-specific option.
-   * This function fills in some more fields of the query
-   * from the existing values in the GeocoderConfig.
-   */
   getSearchQuery(query: SearchQuery): SearchQuery {
     const {
       baseUrl,
       boundary,
       focusPoint,
-      options,
-      sources
+      options
     } = this.geocoderConfig;
     return {
       boundary,
       focusPoint,
       options,
-      // explicitly send over null for sources if provided sources is not truthy
-      // in order to avoid default isomorphic-mapzen-search sources form being
-      // applied
-      sources: sources || null,
       url: baseUrl ? `${baseUrl}/search` : undefined,
-      format: false, // keep as returned GeoJSON,
       ...query
     };
   }

--- a/packages/geocoder/src/geocoders/photon.ts
+++ b/packages/geocoder/src/geocoders/photon.ts
@@ -32,12 +32,14 @@ export default class PhotonGeocoder extends Geocoder {
       baseUrl,
       boundary,
       focusPoint,
-      options
+      options,
+      size,
     } = this.geocoderConfig;
     return {
       boundary,
       focusPoint,
       options,
+      size,
       url: baseUrl ? `${baseUrl}/autocomplete` : undefined,
       ...query
     };
@@ -48,12 +50,14 @@ export default class PhotonGeocoder extends Geocoder {
       baseUrl,
       boundary,
       focusPoint,
-      options
+      options,
+      size,
     } = this.geocoderConfig;
     return {
       boundary,
       focusPoint,
       options,
+      size,
       url: baseUrl ? `${baseUrl}/search` : undefined,
       ...query
     };

--- a/packages/geocoder/src/geocoders/photon.ts
+++ b/packages/geocoder/src/geocoders/photon.ts
@@ -9,15 +9,14 @@ import { MultiGeocoderResponse } from "./types";
 const generateLabel = (properties: GeoJsonProperties): string => {
   const propertyList = [];
   ["name", "street", "district", "state", "postcode", "city", "country"].forEach((propertyName) => {
-        if (typeof properties[propertyName] === "undefined") {
-          return;
-        }
-        const value = `${properties[propertyName]}`;
-        if (value.length > 0) {
-          propertyList.push(value);
-        }
-      }
-  )
+    if (typeof properties[propertyName] === "undefined") {
+      return;
+    }
+    const value = `${properties[propertyName]}`;
+    if (value.length > 0) {
+      propertyList.push(value);
+    }
+  })
   return propertyList.join(", ");
 }
 

--- a/packages/geocoder/src/geocoders/photon.ts
+++ b/packages/geocoder/src/geocoders/photon.ts
@@ -79,7 +79,8 @@ export default class PhotonGeocoder extends Geocoder {
       return response as MultiGeocoderResponse;
     }
 
-    const { lat, lon } = response.point;
+    const lat = response.point.lat;
+    const lon = response.point.lng;
 
     const firstFeature = response.features[0];
     return {

--- a/packages/geocoder/src/geocoders/photon.ts
+++ b/packages/geocoder/src/geocoders/photon.ts
@@ -60,6 +60,13 @@ export default class PhotonGeocoder extends Geocoder {
     };
   }
 
+  rewriteAutocompleteResponse(response: MultiGeocoderResponse): MultiGeocoderResponse {
+    response.features.forEach((value) => {
+      value.properties.label = generateLabel(value.properties);
+    })
+    return response;
+  }
+
   /**
    * Rewrite the response into an application-specific data format using the
    * first feature returned from the geocoder.
@@ -69,7 +76,7 @@ export default class PhotonGeocoder extends Geocoder {
       response.features.forEach((value) => {
         value.properties.label = generateLabel(value.properties);
       })
-      return response
+      return response as MultiGeocoderResponse;
     }
 
     const { lat, lon } = response.point;
@@ -83,11 +90,7 @@ export default class PhotonGeocoder extends Geocoder {
     };
   }
 
-  rewriteAutocompleteResponse(response: MultiGeocoderResponse): MultiGeocoderResponse {
-    response.features.forEach((value) => {
-      value.properties.label = generateLabel(value.properties);
-    })
-    return response;
-
+  rewriteSearchResponse(response: MultiGeocoderResponse): MultiGeocoderResponse {
+    return this.rewriteAutocompleteResponse(response) as MultiGeocoderResponse;
   }
 }

--- a/packages/geocoder/src/geocoders/photon.ts
+++ b/packages/geocoder/src/geocoders/photon.ts
@@ -1,0 +1,96 @@
+import Geocoder from "./abstract-geocoder";
+// Prettier does not support typescript annotation
+// eslint-disable-next-line prettier/prettier
+import type { AutocompleteQuery, SearchQuery } from "..";
+import type { SingleOrMultiGeocoderResponse } from "./types";
+import { MultiGeocoderResponse } from "./types";
+
+/**
+ * Geocoder implementation for the Photon geocoder.
+ * See https://photon.io
+ *
+ * @extends Geocoder
+ */
+export default class PhotonGeocoder extends Geocoder {
+  /**
+   * Generate an autocomplete query specifically for the Pelias API. The
+   * `sources` parameter is a Pelias-specific option.
+   * This function fills in some more fields of the query
+   * from the existing values in the GeocoderConfig.
+   */
+  getAutocompleteQuery(query: AutocompleteQuery): AutocompleteQuery {
+    const {
+      baseUrl,
+      boundary,
+      focusPoint,
+      options,
+      sources
+    } = this.geocoderConfig;
+    return {
+      boundary,
+      focusPoint,
+      options,
+      // explicitly send over null for sources if provided sources is not truthy
+      // in order to avoid default isomorphic-mapzen-search sources form being
+      // applied
+      sources: sources || null,
+      url: baseUrl ? `${baseUrl}/autocomplete` : undefined,
+      ...query
+    };
+  }
+
+  /**
+   * Generate a search query specifically for the Pelias API. The
+   * `sources` parameter is a Pelias-specific option.
+   * This function fills in some more fields of the query
+   * from the existing values in the GeocoderConfig.
+   */
+  getSearchQuery(query: SearchQuery): SearchQuery {
+    const {
+      baseUrl,
+      boundary,
+      focusPoint,
+      options,
+      sources
+    } = this.geocoderConfig;
+    return {
+      boundary,
+      focusPoint,
+      options,
+      // explicitly send over null for sources if provided sources is not truthy
+      // in order to avoid default isomorphic-mapzen-search sources form being
+      // applied
+      sources: sources || null,
+      url: baseUrl ? `${baseUrl}/search` : undefined,
+      format: false, // keep as returned GeoJSON,
+      ...query
+    };
+  }
+
+  /**
+   * Rewrite the response into an application-specific data format using the
+   * first feature returned from the geocoder.
+   */
+  rewriteReverseResponse(response): SingleOrMultiGeocoderResponse {
+    if (this.geocoderConfig?.reverseUseFeatureCollection) return response
+
+    const { lat, lon } = response.point;
+
+    const firstFeature = response.features[0];
+    return {
+      lat,
+      lon,
+      name: firstFeature.properties.name,
+      rawGeocodedFeature: firstFeature
+    };
+  }
+
+  rewriteAutocompleteResponse(response: MultiGeocoderResponse): MultiGeocoderResponse {
+    response.features.forEach((value) => {
+      value.properties.label = value.properties.name;
+    })
+
+    return response;
+
+  }
+}

--- a/packages/geocoder/src/index.story.tsx
+++ b/packages/geocoder/src/index.story.tsx
@@ -33,7 +33,7 @@ const GeocoderTester = ({
     setReverseUseFeatureCollection
   ] = useState(false);
 
-  const geocoder = getGeocoder({
+  const hereGeocoder = getGeocoder({
     apiKey: hereApiKey,
     focusPoint,
     reverseUseFeatureCollection,
@@ -70,7 +70,7 @@ const GeocoderTester = ({
   }
 
   const search = async () => {
-    const hereRes = enableHere ? await geocoder[endpoint](searchObj) : null;
+    const hereRes = enableHere ? await hereGeocoder[endpoint](searchObj) : null;
     const peliasRes = enableGeocodeEarth
       ? await peliasGeocoder[endpoint](searchObj)
       : null;

--- a/packages/geocoder/src/index.story.tsx
+++ b/packages/geocoder/src/index.story.tsx
@@ -44,17 +44,17 @@ const GeocoderTester = ({
     apiKey: geocodeEarthApiKey,
     baseUrl: "https://api.geocode.earth/v1",
     focusPoint,
+    reverseUseFeatureCollection,
     size: 1,
-    type: "PELIAS",
-    reverseUseFeatureCollection
+    type: "PELIAS"
   });
 
   const photonGeocoder = getGeocoder({
     baseUrl: "https://photon.komoot.io",
     focusPoint,
+    reverseUseFeatureCollection,
     size: 1,
-    type: "PHOTON",
-    reverseUseFeatureCollection
+    type: "PHOTON"
   });
 
   const searchObj: AnyGeocoderQuery = {

--- a/packages/geocoder/src/index.story.tsx
+++ b/packages/geocoder/src/index.story.tsx
@@ -27,6 +27,7 @@ const GeocoderTester = ({
   const [enableFocusPoint, setEnableFocusPoint] = useState(true);
   const [enableGeocodeEarth, setEnableGeocodeEarth] = useState(true);
   const [enableHere, setEnableHere] = useState(true);
+  const [enablePhoton, setEnablePhoton] = useState(true);
   const [
     reverseUseFeatureCollection,
     setReverseUseFeatureCollection
@@ -48,6 +49,14 @@ const GeocoderTester = ({
     reverseUseFeatureCollection
   });
 
+  const photonGeocoder = getGeocoder({
+    baseUrl: "https://photon.komoot.io",
+    focusPoint,
+    size: 1,
+    type: "PHOTON",
+    reverseUseFeatureCollection
+  });
+
   const searchObj: AnyGeocoderQuery = {
     text: searchTerm
   };
@@ -65,9 +74,13 @@ const GeocoderTester = ({
     const peliasRes = enableGeocodeEarth
       ? await peliasGeocoder[endpoint](searchObj)
       : null;
+    const photonRes = enablePhoton
+      ? await photonGeocoder[endpoint](searchObj)
+      : null;
     onResults({
       hereRes,
-      peliasRes
+      peliasRes,
+      photonRes
     });
   };
 
@@ -194,6 +207,15 @@ const GeocoderTester = ({
             checked={enableHere}
             id="here"
             onChange={e => setEnableHere(e.target.checked)}
+            type="checkbox"
+          />
+        </label>
+        <label htmlFor="photon">
+          Photon (Komoot):
+          <input
+            checked={enablePhoton}
+            id="photon"
+            onChange={e => setEnablePhoton(e.target.checked)}
             type="checkbox"
           />
         </label>

--- a/packages/geocoder/src/index.ts
+++ b/packages/geocoder/src/index.ts
@@ -2,11 +2,13 @@ import * as arcgis from "@conveyal/geocoder-arcgis-geojson";
 import * as pelias from "isomorphic-mapzen-search";
 import memoize from "lodash.memoize";
 import * as here from "./apis/here";
+import * as photon from "./apis/photon";
 
 import ArcGISGeocoder from "./geocoders/arcgis";
 import NoApiGeocoder from "./geocoders/noapi";
 import PeliasGeocoder from "./geocoders/pelias";
 import HereGeocoder from "./geocoders/here";
+import PhotonGeocoder from "./geocoders/photon";
 
 // Prettier does not support typescript annotation
 // eslint-disable-next-line prettier/prettier
@@ -25,8 +27,10 @@ const getGeocoder = memoize((geocoderConfig: GeocoderConfig & { type: string }) 
       return new PeliasGeocoder(pelias, geocoderConfig);
     case "HERE":
       return new HereGeocoder(here, geocoderConfig);
+    case "PHOTON":
+      return new PhotonGeocoder(photon, geocoderConfig);
     default:
-      console.error(`Unkown geocoder type: "${type}". Using NoApiGeocoder.`);
+      console.error(`Unknown geocoder type: "${type}". Using NoApiGeocoder.`);
       return new NoApiGeocoder();
   }
 });


### PR DESCRIPTION
Adds the photon geocoder

See https://github.com/opentripplanner/otp-react-redux/issues/706

Working as a proof of concept within otp-react-redux for autocomplete + reverse geocoding

[ ] Add search type (currently only autocomplete and reverse were tested)
[ ] Add bbox support
[ ] Support base URL overwrite (?)
[ ] Add more tests (?)

Also fixes a typo in the console.err message.