### PR TITLE
fix(base-map): Add helper methods to fit map to bounds

### DIFF
--- a/packages/base-map/src/index.tsx
+++ b/packages/base-map/src/index.tsx
@@ -3,7 +3,7 @@ import { Map, MapProps } from "react-map-gl";
 import maplibregl, { Event } from "maplibre-gl";
 
 import * as Styled from "./styled";
-import callIfValid from "./util";
+import * as util from "./util";
 import MarkerWithPopup from "./MarkerWithPopup";
 
 /**
@@ -38,13 +38,11 @@ type Props = React.ComponentPropsWithoutRef<React.ElementType> & {
   // Unknown is used here because of a maplibre/mapbox issue with the true type, MapLayerMouseEvent
   onContextMenu?: (e: unknown) => void;
   /** A callback method which is fired when the map zoom or map bounds change */
-  // TODO: does this cause integration issues?
-  onViewportChanged?: (e: maplibregl.MapLibreEvent) => void;
+  onViewportChanged?: (e: State) => void;
   /** An initial zoom value for the map */
   zoom?: number;
 };
 type State = {
-  fitBoundsOptions?: Record<string, number | string | boolean>;
   latitude: number;
   longitude: number;
   zoom: number;
@@ -65,13 +63,6 @@ const BaseMap = ({
   zoom: initZoom = 12
 }: Props): JSX.Element => {
   const [viewState, setViewState] = React.useState<State>({
-    fitBoundsOptions: {
-      animate: true,
-      duration: 300,
-      essential: false,
-      maxDuration: 600,
-      padding: 200
-    },
     latitude: center?.[0],
     longitude: center?.[1],
     zoom: initZoom
@@ -83,7 +74,9 @@ const BaseMap = ({
   const [longPressTimer, setLongPressTimer] = useState(null);
 
   useEffect(() => {
-    callIfValid(onViewportChanged)(viewState);
+    if (typeof onViewportChanged === "function") {
+      onViewportChanged(viewState);
+    }
   }, [viewState]);
 
   useEffect(() => {
@@ -203,4 +196,4 @@ const LayerWrapper = (props: LayerProps): JSX.Element => {
 
 export const Popup = Styled.Popup;
 
-export { LayerWrapper, MarkerWithPopup, Styled };
+export { LayerWrapper, MarkerWithPopup, Styled, util };

--- a/packages/base-map/src/util.ts
+++ b/packages/base-map/src/util.ts
@@ -1,9 +1,38 @@
+import { LngLatBoundsLike, MapRef, PaddingOptions } from "react-map-gl";
+
 /**
- * Checks if a parameter is actually a function.
- * @param {*} fn The function to call.
- * @returns fn if fn is a function, or a dummy function.
+ * Computes padding dimensions based on roughly 1/20 of the map's canvas dimensions
+ * (under a 2:1 canvas-to-screen pixel ratio).
+ * @param map The map where the bounds fitting is to occur.
+ * @returns The object with the computed padding dimensions.
  */
-export default function callIfValid(fn) {
-  if (typeof fn === "function") return fn;
-  return () => {};
+export function getFitBoundsPadding(map: MapRef): PaddingOptions {
+  const canvas = map.getCanvas();
+  // @ts-expect-error getPixelRatio not defined in MapRef type.
+  const pixelRatio = map.getPixelRatio();
+  const horizPadding = canvas.width / pixelRatio / 10;
+  const vertPadding = canvas.height / pixelRatio / 10;
+
+  return {
+    bottom: vertPadding,
+    left: horizPadding,
+    right: horizPadding,
+    top: vertPadding
+  };
+}
+
+/**
+ * Helper function used in several packages to fit a map to the given bounds,
+ * using padding based on map canvas size.
+ * @param map The map where the bounds fitting is to occur.
+ * @param bounds The bounds to be fit.
+ */
+export function fitMapBounds(map: MapRef, bounds: LngLatBoundsLike): void {
+  map.fitBounds(bounds, {
+    duration: 500,
+    padding: getFitBoundsPadding(map)
+  });
+
+  // Often times, the map is not updated right away, so try to force an update.
+  map.triggerRepaint();
 }

--- a/packages/base-map/src/util.ts
+++ b/packages/base-map/src/util.ts
@@ -4,14 +4,18 @@ import { LngLatBoundsLike, MapRef, PaddingOptions } from "react-map-gl";
  * Computes padding dimensions based on roughly 1/20 of the map's canvas dimensions
  * (under a 2:1 canvas-to-screen pixel ratio).
  * @param map The map where the bounds fitting is to occur.
+ * @param paddingRatio The ratio of the canvas dimensions set aside for padding.
  * @returns The object with the computed padding dimensions.
  */
-export function getFitBoundsPadding(map: MapRef): PaddingOptions {
+export function getFitBoundsPadding(
+  map: MapRef,
+  paddingRatio = 0.1
+): PaddingOptions {
   const canvas = map.getCanvas();
   // @ts-expect-error getPixelRatio not defined in MapRef type.
   const pixelRatio = map.getPixelRatio();
-  const horizPadding = canvas.width / pixelRatio / 10;
-  const vertPadding = canvas.height / pixelRatio / 10;
+  const horizPadding = (canvas.width * paddingRatio) / pixelRatio;
+  const vertPadding = (canvas.height * paddingRatio) / pixelRatio;
 
   return {
     bottom: vertPadding,

--- a/packages/base-map/tsconfig.json
+++ b/packages/base-map/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "lib": ["es2019"],
+    "lib": ["es2019", "dom"],
     "outDir": "./lib",
     "rootDir": "./src",
     "skipLibCheck": true


### PR DESCRIPTION
This fix-release PR adds helper methods to compute padding of a mapbox `MapRef` and fit bounds on a map using the padding parameters and attempt forcing a redraw. Such methods are used in the route viewer (I want to reuse this with #485), trip viewer, and transitive overlays.
