### PR TITLE
fix(core-utils/route): avoid crash on gtfs with no background color

### DIFF
--- a/packages/core-utils/src/route.ts
+++ b/packages/core-utils/src/route.ts
@@ -444,6 +444,8 @@ export function getMostReadableTextColor(
   backgroundColor: string,
   proposedTextColor?: string
 ): string {
+  // Sometimes input will defy the method signature. Therefore we need extra fallbacks
+  if (!backgroundColor) backgroundColor = "#333333";
   if (!proposedTextColor) proposedTextColor = "#ffffff";
 
   if (!backgroundColor.startsWith("#")) {


### PR DESCRIPTION
We had a fix in place for when the text color was somehow invalid, but not one for when the background color is invalid. This PR fixes this.