### PR TITLE
Support empty transitive data

### DIFF
--- a/packages/transitive-overlay/src/TransitiveOverlay.story.js
+++ b/packages/transitive-overlay/src/TransitiveOverlay.story.js
@@ -52,6 +52,8 @@ export default {
   component: TransitiveOverlay
 };
 
+export const Empty = () => <TransitiveOverlay transitiveData={null} visible />;
+
 export const WalkingItinerary = () => (
   <>
     <EndpointsOverlay


### PR DESCRIPTION
Fix a regression introduced by #452, and future proof the handling of null transitive data input.