### PR TITLE
Common fit bounds

### DIFF
--- a/packages/route-viewer-overlay/package.json
+++ b/packages/route-viewer-overlay/package.json
@@ -20,14 +20,13 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.0",
-    "@opentripplanner/base-map": "^3.0.4",
+    "@opentripplanner/base-map": "^3.0.6",
     "@opentripplanner/core-utils": "^7.0.5",
     "point-in-polygon": "^1.1.0"
   },
   "devDependencies": {
     "@opentripplanner/types": "^4.0.2",
-    "point-in-polygon": "^1.1.0",
-    "prop-types": "^15.7.2"
+    "point-in-polygon": "^1.1.0"
   },
   "peerDependencies": {
     "react": "^16.14.0"

--- a/packages/route-viewer-overlay/src/RouteViewerOverlay.story.tsx
+++ b/packages/route-viewer-overlay/src/RouteViewerOverlay.story.tsx
@@ -77,7 +77,7 @@ OTP2RouteOutsideOfInitialView.args = {
   routeData: routeDataOtp2
 };
 
-export const WithChangingPath = () => <WithChangingRoute />;
+export const WithChangingPath = (): JSX.Element => <WithChangingRoute />;
 
 export const FlexRoute = Template.bind({});
 FlexRoute.args = {

--- a/packages/route-viewer-overlay/src/index.tsx
+++ b/packages/route-viewer-overlay/src/index.tsx
@@ -1,3 +1,4 @@
+import { util } from "@opentripplanner/base-map";
 import { Stop } from "@opentripplanner/types";
 import { LngLatBounds } from "maplibre-gl";
 import { Layer, LngLatLike, Source, useMap } from "react-map-gl";
@@ -79,25 +80,7 @@ const RouteViewerOverlay = (props: Props): JSX.Element => {
 
     // if pattern geometry updated, update the map points
     if (bounds && current) {
-      const canvas = current.getCanvas();
-      // @ts-expect-error getPixelRatio not defined in MapRef type.
-      const pixelRatio = current.getPixelRatio();
-      const horizPadding = canvas.width / pixelRatio / 10;
-      const vertPadding = canvas.height / pixelRatio / 10;
-
-      current.fitBounds(bounds, {
-        duration: 500,
-        padding: {
-          left: horizPadding,
-          right: horizPadding,
-          top: vertPadding,
-          bottom: vertPadding
-        }
-      });
-
-      // Often times, the map is not updated right away, so try to force an update.
-      current.triggerRepaint();
-
+      util.fitMapBounds(current, bounds);
       if (props.mapCenterCallback) {
         props.mapCenterCallback();
       }

--- a/packages/transitive-overlay/package.json
+++ b/packages/transitive-overlay/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.1",
-    "@opentripplanner/base-map": "^3.0.4",
+    "@opentripplanner/base-map": "^3.0.6",
     "@opentripplanner/itinerary-body": "^4.1.3",
     "@opentripplanner/core-utils": "^7.0.5",
     "lodash.isequal": "^4.5.0",

--- a/packages/transitive-overlay/src/TransitiveOverlay.story.tsx
+++ b/packages/transitive-overlay/src/TransitiveOverlay.story.tsx
@@ -52,7 +52,7 @@ export default {
   component: TransitiveOverlay
 };
 
-export const WalkingItinerary = () => (
+export const WalkingItinerary = (): JSX.Element => (
   <>
     <EndpointsOverlay
       fromLocation={getFromLocation(walkOnlyItinerary)}
@@ -70,7 +70,7 @@ export const WalkingItinerary = () => (
 );
 WalkingItinerary.decorators = [withMap([45.518841, -122.679302], 19)];
 
-export const BikeOnlyItinerary = () => (
+export const BikeOnlyItinerary = (): JSX.Element => (
   <>
     <EndpointsOverlay
       fromLocation={getFromLocation(bikeOnlyItinerary)}
@@ -86,7 +86,7 @@ export const BikeOnlyItinerary = () => (
 );
 BikeOnlyItinerary.decorators = [withMap([45.520441, -122.68302], 16)];
 
-export const WalkTransitWalkItinerary = () => (
+export const WalkTransitWalkItinerary = (): JSX.Element => (
   <>
     <EndpointsOverlay
       fromLocation={getFromLocation(walkTransitWalkItinerary)}
@@ -104,7 +104,7 @@ export const WalkTransitWalkItinerary = () => (
 );
 WalkTransitWalkItinerary.decorators = [withMap([45.520441, -122.68302], 16)];
 
-export const WalkTransitWalkItineraryWithNoIntermediateStops = () => (
+export const WalkTransitWalkItineraryWithNoIntermediateStops = (): JSX.Element => (
   <>
     <EndpointsOverlay
       fromLocation={getFromLocation(
@@ -127,7 +127,7 @@ WalkTransitWalkItineraryWithNoIntermediateStops.decorators = [
   withMap([45.525841, -122.649302], 13)
 ];
 
-export const BikeTransitBikeItinerary = () => (
+export const BikeTransitBikeItinerary = (): JSX.Element => (
   <>
     <EndpointsOverlay
       fromLocation={getFromLocation(bikeTransitBikeItinerary)}
@@ -145,7 +145,7 @@ export const BikeTransitBikeItinerary = () => (
 );
 BikeTransitBikeItinerary.decorators = [withMap([45.520441, -122.68302], 16)];
 
-export const WalkInterlinedTransitItinerary = () => (
+export const WalkInterlinedTransitItinerary = (): JSX.Element => (
   <>
     <EndpointsOverlay
       fromLocation={getFromLocation(walkInterlinedTransitItinerary)}
@@ -165,7 +165,7 @@ WalkInterlinedTransitItinerary.decorators = [
   withMap([47.703022, -122.328041], 12.5)
 ];
 
-export const WalkTransitTransferItinerary = () => (
+export const WalkTransitTransferItinerary = (): JSX.Element => (
   <>
     <EndpointsOverlay
       fromLocation={getFromLocation(walkTransitWalkTransitWalkItinerary)}
@@ -186,7 +186,7 @@ WalkTransitTransferItinerary.decorators = [
   withMap([45.505841, -122.631302], 14)
 ];
 
-export const BikeRentalItinerary = () => (
+export const BikeRentalItinerary = (): JSX.Element => (
   <>
     <EndpointsOverlay
       fromLocation={getFromLocation(bikeRentalItinerary)}
@@ -221,7 +221,7 @@ export const EScooterRentalItinerary = injectIntl(({ intl }) => (
 ));
 EScooterRentalItinerary.decorators = [withMap([45.52041, -122.675302], 16)];
 
-export const ParkAndRideItinerary = () => (
+export const ParkAndRideItinerary = (): JSX.Element => (
   <>
     <EndpointsOverlay
       fromLocation={getFromLocation(parkAndRideItinerary)}
@@ -239,7 +239,7 @@ export const ParkAndRideItinerary = () => (
 );
 ParkAndRideItinerary.decorators = [withMap([45.515841, -122.75302], 13)];
 
-export const BikeRentalTransitItinerary = () => (
+export const BikeRentalTransitItinerary = (): JSX.Element => (
   <>
     <EndpointsOverlay
       fromLocation={getFromLocation(bikeRentalTransitBikeRentalItinerary)}
@@ -281,7 +281,7 @@ EScooterRentalTransitItinerary.decorators = [
   withMap([45.538841, -122.6302], 12)
 ];
 
-export const TncTransitItinerary = () => (
+export const TncTransitItinerary = (): JSX.Element => (
   <>
     <EndpointsOverlay
       fromLocation={getFromLocation(tncTransitTncItinerary)}
@@ -299,7 +299,7 @@ export const TncTransitItinerary = () => (
 );
 TncTransitItinerary.decorators = [withMap([45.538841, -122.6302], 12)];
 
-export const FlexItinerary = () => (
+export const FlexItinerary = (): JSX.Element => (
   <>
     <EndpointsOverlay
       fromLocation={getFromLocation(flexItinerary)}

--- a/packages/transitive-overlay/src/index.tsx
+++ b/packages/transitive-overlay/src/index.tsx
@@ -1,4 +1,5 @@
 import { SymbolLayout } from "mapbox-gl";
+import { util } from "@opentripplanner/base-map";
 import React, { useEffect } from "react";
 import { Layer, Source, useMap } from "react-map-gl";
 import polyline from "@mapbox/polyline";
@@ -182,10 +183,10 @@ const TransitiveCanvasOverlay = ({
     const b = bbox(geoJson);
     const bounds: [number, number, number, number] = [b[0], b[1], b[2], b[3]];
 
-    if (bounds.length === 4 && bounds.every(Number.isFinite)) {
-      map?.fitBounds(bounds, {
+    if (map && bounds.length === 4 && bounds.every(Number.isFinite)) {
+      map.fitBounds(bounds, {
         duration: 500,
-        padding: window.innerWidth > 500 ? 200 : undefined
+        padding: util.getFitBoundsPadding(map, 0.2)
       });
     }
   };

--- a/packages/trip-viewer-overlay/package.json
+++ b/packages/trip-viewer-overlay/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.0",
-    "@opentripplanner/base-map": "^3.0.4",
+    "@opentripplanner/base-map": "^3.0.6",
     "@opentripplanner/core-utils": "^7.0.5"
   },
   "peerDependencies": {

--- a/packages/trip-viewer-overlay/src/index.tsx
+++ b/packages/trip-viewer-overlay/src/index.tsx
@@ -1,5 +1,6 @@
 import polyline from "@mapbox/polyline";
 import { LngLatBounds } from "maplibre-gl";
+import { util } from "@opentripplanner/base-map";
 import { Layer, Source, useMap } from "react-map-gl";
 import React, { useEffect, useMemo } from "react";
 
@@ -32,11 +33,8 @@ const TripViewerOverlay = (props: Props): JSX.Element => {
 
   const { current: map } = useMap();
   useEffect(() => {
-    if (bounds.length === 4 && bounds.every(Number.isFinite)) {
-      map?.fitBounds(bounds, {
-        duration: 500,
-        padding: 200
-      });
+    if (map && bounds.length === 4 && bounds.every(Number.isFinite)) {
+      util.fitMapBounds(map, bounds);
     }
   }, [map, bounds]);
 


### PR DESCRIPTION
This PR updates the route, trip and transitive overlay packages to use the fit bounds methods from #488. This will also fix bounds fitting on mobile for the trip and transitive overlay packages.
 