### PR TITLE
Support Multiple Base Layers in BaseMap

### DIFF
--- a/packages/base-map/src/index.story.tsx
+++ b/packages/base-map/src/index.story.tsx
@@ -185,20 +185,20 @@ export const withMultipleBaseLayers = () => {
   return (
     <Styled.StoryMapContainer>
       <input
+        onChange={e => setMapTilerKey(e.target.value)}
+        placeholder="MapTiler API Key"
         type="text"
         value={mapTilerKey}
-        placeholder="MapTiler API Key"
-        onChange={e => setMapTilerKey(e.target.value)}
       />
       {mapTilerKey && (
         <BaseMap
-          center={center}
           baseLayer={[
             `https://api.maptiler.com/maps/streets/style.json?key=${mapTilerKey}`,
             `https://api.maptiler.com/maps/ocean/style.json?key=${mapTilerKey}`,
             `https://api.maptiler.com/maps/hybrid/style.json?key=${mapTilerKey}`
           ]}
           baseLayerNames={["Streets", "Ocean", "Hybrid"]}
+          center={center}
         />
       )}
     </Styled.StoryMapContainer>
@@ -210,20 +210,20 @@ export const withMultipleBaseLayersAndOptionalLayers = () => {
   return (
     <Styled.StoryMapContainer>
       <input
+        onChange={e => setMapTilerKey(e.target.value)}
+        placeholder="MapTiler API Key"
         type="text"
         value={mapTilerKey}
-        placeholder="MapTiler API Key"
-        onChange={e => setMapTilerKey(e.target.value)}
       />
       {mapTilerKey && (
         <BaseMap
-          center={center}
           baseLayer={[
             `https://api.maptiler.com/maps/streets/style.json?key=${mapTilerKey}`,
             `https://api.maptiler.com/maps/ocean/style.json?key=${mapTilerKey}`,
             `https://api.maptiler.com/maps/hybrid/style.json?key=${mapTilerKey}`
           ]}
           baseLayerNames={["Streets", "Ocean", "Hybrid"]}
+          center={center}
         >
           <AllVehiclesOverlay id="layer-1" />
           <LayerWrapper id="layer-2">

--- a/packages/base-map/src/index.story.tsx
+++ b/packages/base-map/src/index.story.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/button-has-type */
-import React from "react";
+import React, { useState } from "react";
 import {
   AttributionControl,
   MapProvider,
@@ -179,3 +179,31 @@ export const withOptionalControls = () => (
   </BaseMap>
 );
 withOptionalControls.decorators = [withMap()];
+
+export const withMultipleBaseLayers = () => {
+  const [mapTilerKey, setMapTilerKey] = useState("");
+  return (
+    <Styled.StoryMapContainer>
+      <input
+        type="text"
+        value={mapTilerKey}
+        placeholder="MapTiler API Key"
+        onChange={e => setMapTilerKey(e.target.value)}
+      />
+      {mapTilerKey && (
+        <BaseMap
+          center={center}
+          baseLayer={[
+            `https://api.maptiler.com/maps/streets/style.json?key=${mapTilerKey}`,
+            `https://api.maptiler.com/maps/ocean/style.json?key=${mapTilerKey}`,
+            `https://api.maptiler.com/maps/hybrid/style.json?key=${mapTilerKey}`
+          ]}
+          baseLayerNames={["Streets", "Ocean", "Hybrid"]}
+        >
+          {" "}
+          <AllVehiclesOverlay />
+        </BaseMap>
+      )}
+    </Styled.StoryMapContainer>
+  );
+};

--- a/packages/base-map/src/index.story.tsx
+++ b/packages/base-map/src/index.story.tsx
@@ -199,10 +199,7 @@ export const withMultipleBaseLayers = () => {
             `https://api.maptiler.com/maps/hybrid/style.json?key=${mapTilerKey}`
           ]}
           baseLayerNames={["Streets", "Ocean", "Hybrid"]}
-        >
-          {" "}
-          <AllVehiclesOverlay />
-        </BaseMap>
+        />
       )}
     </Styled.StoryMapContainer>
   );

--- a/packages/base-map/src/index.story.tsx
+++ b/packages/base-map/src/index.story.tsx
@@ -204,3 +204,33 @@ export const withMultipleBaseLayers = () => {
     </Styled.StoryMapContainer>
   );
 };
+
+export const withMultipleBaseLayersAndOptionalLayers = () => {
+  const [mapTilerKey, setMapTilerKey] = useState("");
+  return (
+    <Styled.StoryMapContainer>
+      <input
+        type="text"
+        value={mapTilerKey}
+        placeholder="MapTiler API Key"
+        onChange={e => setMapTilerKey(e.target.value)}
+      />
+      {mapTilerKey && (
+        <BaseMap
+          center={center}
+          baseLayer={[
+            `https://api.maptiler.com/maps/streets/style.json?key=${mapTilerKey}`,
+            `https://api.maptiler.com/maps/ocean/style.json?key=${mapTilerKey}`,
+            `https://api.maptiler.com/maps/hybrid/style.json?key=${mapTilerKey}`
+          ]}
+          baseLayerNames={["Streets", "Ocean", "Hybrid"]}
+        >
+          <AllVehiclesOverlay id="layer-1" />
+          <LayerWrapper id="layer-2">
+            <MarkerWithPopup position={[center[0], center[1]]} />
+          </LayerWrapper>
+        </BaseMap>
+      )}
+    </Styled.StoryMapContainer>
+  );
+};

--- a/packages/base-map/src/index.tsx
+++ b/packages/base-map/src/index.tsx
@@ -23,7 +23,9 @@ import MarkerWithPopup from "./MarkerWithPopup";
  */
 type Props = React.ComponentPropsWithoutRef<React.ElementType> & {
   /** A URL pointing to the vector tile specification which should be used as the main map.  */
-  baseLayer?: string;
+  baseLayer?: string | string[];
+  /** A list of names to match onto the base layers */
+  baseLayerNames?: string[];
   /** A [lat, lon] position to center the map at. */
   center?: [number, number];
   /** A unique identifier for the map (useful when using MapProvider) */
@@ -51,6 +53,7 @@ type State = {
 const BaseMap = ({
   // These tiles are free to use, but not in production
   baseLayer = "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
+  baseLayerNames,
   center,
   children,
   id,
@@ -102,6 +105,9 @@ const BaseMap = ({
   const [hiddenLayers, setHiddenLayers] = useState(
     toggleableLayers.filter(layer => !layer?.visible).map(layer => layer.id)
   );
+  const [activeBaseLayer, setActiveBaseLayer] = useState(
+    typeof baseLayer === "object" ? baseLayer?.[0] : baseLayer
+  );
 
   return (
     <Map
@@ -111,7 +117,7 @@ const BaseMap = ({
       latitude={viewState.latitude}
       longitude={viewState.longitude}
       mapLib={maplibregl}
-      mapStyle={baseLayer}
+      mapStyle={activeBaseLayer}
       maxZoom={maxZoom}
       onClick={onClick}
       onContextMenu={onContextMenu}
@@ -132,7 +138,8 @@ const BaseMap = ({
       style={style}
       zoom={viewState.zoom}
     >
-      {toggleableLayers.length > 0 && (
+      {(toggleableLayers.length > 0 ||
+        (typeof baseLayer === "object" && baseLayer.length > 1)) && (
         <Styled.LayerSelector
           onTouchEnd={() => {
             setFakeMobileHover(true);
@@ -143,6 +150,24 @@ const BaseMap = ({
           <ul
             className={`layers-list ${fakeMobileHover && "fake-mobile-hover"}`}
           >
+            {typeof baseLayer === "object" &&
+              baseLayer.map((layer: string, index: number) => {
+                return (
+                  <li key={index}>
+                    {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+                    <label>
+                      <input
+                        type="radio"
+                        checked={activeBaseLayer === layer}
+                        onChange={() => setActiveBaseLayer(layer)}
+                        id={layer}
+                      />
+                      {baseLayerNames?.[index] || layer}
+                    </label>
+                  </li>
+                );
+              })}
+
             {toggleableLayers.map((layer: LayerProps, index: number) => {
               return (
                 <li key={index}>

--- a/packages/base-map/src/index.tsx
+++ b/packages/base-map/src/index.tsx
@@ -22,9 +22,9 @@ import MarkerWithPopup from "./MarkerWithPopup";
  * with an id are added to the control.
  */
 type Props = React.ComponentPropsWithoutRef<React.ElementType> & {
-  /** A URL pointing to the vector tile specification which should be used as the main map.  */
+  /** A URL, or list of URLs pointing to the vector tile specification which should be used as the main map.  */
   baseLayer?: string | string[];
-  /** A list of names to match onto the base layers */
+  /** A list of names to match onto the base layers. Used only if there are multiple entries defined for `BaseLayer` */
   baseLayerNames?: string[];
   /** A [lat, lon] position to center the map at. */
   center?: [number, number];
@@ -139,28 +139,31 @@ const BaseMap = ({
       zoom={viewState.zoom}
     >
       {(toggleableLayers.length > 0 ||
-        (typeof baseLayer === "object" && baseLayer.length > 1)) && (
+        (!!baseLayer &&
+          typeof baseLayer === "object" &&
+          baseLayer.length > 1)) && (
         <Styled.LayerSelector
+          className="filter-group"
+          id="filter-group"
           onTouchEnd={() => {
             setFakeMobileHover(true);
           }}
-          className="filter-group"
-          id="filter-group"
         >
           <ul
             className={`layers-list ${fakeMobileHover && "fake-mobile-hover"}`}
           >
-            {typeof baseLayer === "object" &&
+            {!!baseLayer &&
+              typeof baseLayer === "object" &&
               baseLayer.map((layer: string, index: number) => {
                 return (
                   <li key={index}>
                     {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
                     <label>
                       <input
-                        type="radio"
                         checked={activeBaseLayer === layer}
-                        onChange={() => setActiveBaseLayer(layer)}
                         id={layer}
+                        onChange={() => setActiveBaseLayer(layer)}
+                        type="radio"
                       />
                       {baseLayerNames?.[index] || layer}
                     </label>


### PR DESCRIPTION
This PR adds support for multiple base layers. Configuration is done by allowing `baseLayer` to accept an array of strings instead of just a string.

A new prop `baseLayerNames` is added to allow the control to display pretty names. An alternative might be to use internationalization with the url as a key, but I think it's easier to push that responsibility up a level? Curious for others' thoughts.
<img width="157" alt="Screen Shot 2022-12-02 at 11 33 10 AM" src="https://user-images.githubusercontent.com/86619099/205340434-686394ae-11db-4fa6-b572-fe5a1f4d96b3.png">
