### PR TITLE
fix(trip-details): add export for fare by leg table

### DIFF
--- a/packages/trip-details/src/TripDetails.story.tsx
+++ b/packages/trip-details/src/TripDetails.story.tsx
@@ -10,7 +10,7 @@ import {
 import styled from "styled-components";
 // The below eslint-disable is due to https://github.com/storybookjs/storybook/issues/13408
 // eslint-disable-next-line import/no-named-as-default
-import TripDetails from ".";
+import TripDetails, { FareLegTable } from ".";
 import * as TripDetailsClasses from "./styled";
 import {
   CaloriesDetailsProps,
@@ -348,3 +348,14 @@ export const FareComponentsItinerary = makeStory({
 });
 
 export const OTP2FlexItinerary = makeStory({ itinerary: flexItinerary });
+
+export const FareLegTableStory = (): ReactElement => {
+  return (
+    <FareLegTable
+      layout={fareByLegLayout}
+      legs={walkInterlinedTransitItinerary.legs}
+      transitFareDetails={walkInterlinedTransitItinerary.fare?.details}
+      transitFares={walkInterlinedTransitItinerary.fare?.fare}
+    />
+  );
+};

--- a/packages/trip-details/src/index.tsx
+++ b/packages/trip-details/src/index.tsx
@@ -404,4 +404,4 @@ export function TripDetails({
 export default TripDetails;
 
 // Rename styled components for export
-export { S as Styled };
+export { S as Styled, FareLegTable };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9221,6 +9221,11 @@ geojson-vt@^3.2.1:
   resolved "https://registry.yarnpkg.com/geojson-vt/-/geojson-vt-3.2.1.tgz#f8adb614d2c1d3f6ee7c4265cad4bbf3ad60c8b7"
   integrity sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==
 
+geojson@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/geojson/-/geojson-0.5.0.tgz#3cd6c96399be65b56ee55596116fe9191ce701c0"
+  integrity sha512-/Bx5lEn+qRF4TfQ5aLu6NH+UKtvIv7Lhc487y/c8BdludrCTpiWf9wyI0RTyqg49MFefIAvFDuEi5Dfd/zgNxQ==
+
 get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"


### PR DESCRIPTION
Community Transit wants to use the fare by leg table in their custom webapp, so we need this fare by leg table to be exported. (I thought it was already exported and I remember there being a story for it, any idea where that went?)