### PR TITLE
fix(core-utils): Extract utility method to compute a displayed stop id.

### DIFF
--- a/packages/core-utils/src/__tests__/itinerary.js
+++ b/packages/core-utils/src/__tests__/itinerary.js
@@ -1,12 +1,19 @@
 import {
   calculateTncFares,
   getCompanyFromLeg,
+  getDisplayedStopId,
   getTransitFare,
   isTransit
 } from "../itinerary";
 
 const bikeRentalItinerary = require("./__mocks__/bike-rental-itinerary.json");
 const tncItinerary = require("./__mocks__/tnc-itinerary.json");
+
+const basePlace = {
+  lat: 0,
+  lon: 0,
+  name: "stop"
+};
 
 describe("util > itinerary", () => {
   describe("isTransit", () => {
@@ -58,6 +65,50 @@ describe("util > itinerary", () => {
       expect(fareResult.currencyCode).toEqual("USD");
       expect(fareResult.maxTNCFare).toEqual(19);
       expect(fareResult.minTNCFare).toEqual(17);
+    });
+  });
+
+  describe("getDisplayedStopId", () => {
+    it("should return the stop code if one is provided", () => {
+      const place = {
+        ...basePlace,
+        stopCode: "code123",
+        stopId: "xagency:id123"
+      };
+      expect(getDisplayedStopId(place)).toEqual("code123");
+      const stop = {
+        ...basePlace,
+        code: "code123",
+        id: "xagency:id123"
+      };
+      expect(getDisplayedStopId(stop)).toEqual("code123");
+    });
+    it("should return the id part of stopId it contains and agencyId (and no stopCode is provided)", () => {
+      const place = {
+        ...basePlace,
+        stopId: "xagency:id123"
+      };
+      expect(getDisplayedStopId(place)).toEqual("id123");
+      const stop = {
+        ...basePlace,
+        id: "xagency:id123"
+      };
+      expect(getDisplayedStopId(stop)).toEqual("id123");
+    });
+    it("should return the whole stopId it does not contain an agency part (and no stopCode is provided)", () => {
+      const place = {
+        ...basePlace,
+        stopId: "wholeid123"
+      };
+      expect(getDisplayedStopId(place)).toEqual("wholeid123");
+      const stop = {
+        ...basePlace,
+        stopId: "wholeid123"
+      };
+      expect(getDisplayedStopId(stop)).toEqual("wholeid123");
+    });
+    it("should return null if stopId is null (and no stopCode is provided)", () => {
+      expect(getDisplayedStopId(basePlace)).toBeFalsy();
     });
   });
 });

--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -8,7 +8,9 @@ import {
   LatLngArray,
   Leg,
   Money,
+  Place,
   Step,
+  Stop,
   TncFare
 } from "@opentripplanner/types";
 import turfAlong from "@turf/along";
@@ -532,4 +534,21 @@ export function calculateEmissions(
     default:
       return totalCarbon;
   }
+}
+
+/**
+ * Returns the user-facing stop id to display for a stop or place, using the following priority:
+ * 1. stop code,
+ * 2. stop id without the agency id portion, if stop id contains an agency portion,
+ * 3. stop id, whether null or not (this is the fallback case).
+ */
+export function getDisplayedStopId(placeOrStop: Place | Stop): string {
+  let stopId;
+  let stopCode;
+  if ("stopId" in placeOrStop) {
+    ({ stopCode, stopId } = placeOrStop);
+  } else if ("id" in placeOrStop) {
+    ({ code: stopCode, id: stopId } = placeOrStop);
+  }
+  return stopCode || stopId?.split(":")[1] || stopId;
 }


### PR DESCRIPTION
New method `itinerary.getDisplayedStopId` in core-utils, intended to be used in itinerary, printable itinerary packages, and in OTP-RR.