### PR TITLE
fix(route-viewer-overlay): Use timeout before fitting bounds

### DIFF
--- a/packages/route-viewer-overlay/src/index.tsx
+++ b/packages/route-viewer-overlay/src/index.tsx
@@ -137,8 +137,8 @@ const RouteViewerOverlay = (props: Props): JSX.Element => {
     });
 
     if (bounds && current) {
-      // Use a timeout to wait for other map rendering to finish
-      // before fitting to the route or pattern shape.
+      // Try to fit the map to route bounds immediately. If other overlays are still populating contents
+      // and/or the map skips/aborts fitting for any reason, try fitting bounds again after a short delay.
       const fitBounds = () => util.fitMapBounds(current, bounds);
       fitBounds();
       timeout = setTimeout(fitBounds, 250);

--- a/packages/route-viewer-overlay/src/index.tsx
+++ b/packages/route-viewer-overlay/src/index.tsx
@@ -139,7 +139,9 @@ const RouteViewerOverlay = (props: Props): JSX.Element => {
     if (bounds && current) {
       // Use a timeout to wait for other map rendering to finish
       // before fitting to the route or pattern shape.
-      timeout = setTimeout(() => util.fitMapBounds(current, bounds), 500);
+      const fitBounds = () => util.fitMapBounds(current, bounds);
+      fitBounds();
+      timeout = setTimeout(fitBounds, 250);
       if (props.mapCenterCallback) {
         props.mapCenterCallback();
       }

--- a/packages/route-viewer-overlay/src/index.tsx
+++ b/packages/route-viewer-overlay/src/index.tsx
@@ -99,6 +99,7 @@ const RouteViewerOverlay = (props: Props): JSX.Element => {
   useEffect(() => {
     // if pattern geometry updated, update the map points
     let bounds;
+    let timeout;
     if (isGeometryComplete(routeData)) {
       const allPoints: LngLatLike[] = patterns.reduce((acc, ptn) => {
         return acc.concat(polyline.decode(ptn.geometry.points));
@@ -136,11 +137,16 @@ const RouteViewerOverlay = (props: Props): JSX.Element => {
     });
 
     if (bounds && current) {
-      util.fitMapBounds(current, bounds);
+      // Use a timeout to wait for other map rendering to finish
+      // before fitting to the route or pattern shape.
+      timeout = setTimeout(() => util.fitMapBounds(current, bounds), 500);
       if (props.mapCenterCallback) {
         props.mapCenterCallback();
       }
     }
+
+    // Clear any timeouts when the component unmounts.
+    return () => clearTimeout(timeout);
   }, [routeData, patterns, current]);
 
   const { clipToPatternStops, path } = props;


### PR DESCRIPTION
Bounds fitting on the route viewer overlay still chokes if there is a large number of features rendered on the map, so in this PR, I am using a timeout before bounds fitting is triggered.