### PR TITLE
Fix Reverse Geocoding (follow up #487)

### DIFF
--- a/packages/geocoder/src/geocoders/photon.ts
+++ b/packages/geocoder/src/geocoders/photon.ts
@@ -82,8 +82,7 @@ export default class PhotonGeocoder extends Geocoder {
       return response as MultiGeocoderResponse;
     }
 
-    const lat = response.point.lat;
-    const lon = response.point.lng;
+    const { lat, lon } = response.point;
 
     const firstFeature = response.features[0];
     return {


### PR DESCRIPTION
Reverse Geocoding with Photon does not show proper results when used with otp-react-redux (still coordinates are shown).

This should fix this issue - the returned point contains a field named "lon" not "lng", so lon was undefined here.