### PR TITLE
feature(itinerary-body): Add shouldAnimate param on all use of AnimateHeight

### DIFF
--- a/packages/itinerary-body/src/TransitLegBody/index.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/index.tsx
@@ -44,6 +44,7 @@ interface Props {
   setViewedTrip: SetViewedTripFunction;
   showAgencyInfo: boolean;
   showViewTripButton: boolean;
+  shouldAnimate: boolean;
   timeZone: string;
   TransitLegSubheader?: FunctionComponent<TransitLegSubheaderProps>;
   TransitLegSummary: FunctionComponent<TransitLegSummaryProps>;
@@ -145,6 +146,7 @@ class TransitLegBody extends Component<Props, State> {
       setViewedTrip,
       showAgencyInfo,
       showViewTripButton,
+      shouldAnimate = true,
       timeZone,
       TransitLegSubheader,
       TransitLegSummary,
@@ -259,7 +261,10 @@ class TransitLegBody extends Component<Props, State> {
           )}
 
           {/* The Alerts body, if visible */}
-          <AnimateHeight duration={500} height={expandAlerts ? "auto" : 0}>
+          <AnimateHeight
+            duration={shouldAnimate ? 500 : 0}
+            height={expandAlerts ? "auto" : 0}
+          >
             <AlertsBody
               alerts={leg.alerts}
               AlertIcon={AlertBodyIcon}
@@ -287,7 +292,10 @@ class TransitLegBody extends Component<Props, State> {
                 )}
               </S.TransitLegDetailsHeader>
               {/* IntermediateStops expanded body */}
-              <AnimateHeight duration={500} height={stopsExpanded ? "auto" : 0}>
+              <AnimateHeight
+                duration={shouldAnimate ? 500 : 0}
+                height={stopsExpanded ? "auto" : 0}
+              >
                 <S.TransitLegExpandedBody>
                   <IntermediateStops stops={leg.intermediateStops} />
                   {fareForLeg && (

--- a/packages/trip-details/src/trip-detail.tsx
+++ b/packages/trip-details/src/trip-detail.tsx
@@ -9,6 +9,7 @@ type Props = {
   description?: ReactElement | string;
   icon: ReactElement;
   summary: ReactElement | string;
+  shouldAnimate: boolean;
 };
 
 type State = {
@@ -38,7 +39,7 @@ export default class TripDetail extends Component<Props, State> {
   };
 
   render(): ReactElement {
-    const { icon, summary, description } = this.props;
+    const { icon, summary, description, shouldAnimate = true } = this.props;
     const { expanded } = this.state;
     return (
       <S.TripDetail>
@@ -51,7 +52,10 @@ export default class TripDetail extends Component<Props, State> {
             </S.ExpandButton>
           )}
         </S.TripDetailSummary>
-        <AnimateHeight duration={300} height={expanded ? "auto" : 0}>
+        <AnimateHeight
+          duration={shouldAnimate ? 300 : 0}
+          height={expanded ? "auto" : 0}
+        >
           <S.TripDetailDescription>
             <S.HideButton onClick={this.onHideClick}>
               <TimesCircle size="0.92em" />


### PR DESCRIPTION
The intent behind conditionally animating collapsing content is to help address accessibility concerns around when the user wants to toggle motion off via their operating systems settings. More information on [prefers-reduce-motion](https://web.dev/prefers-reduced-motion/). 