### PR TITLE
fix(SSR): isInputTypeSupported() and use of 'document' breaks TORA build

### DIFF
--- a/packages/trip-form/src/DateTimeSelector/index.tsx
+++ b/packages/trip-form/src/DateTimeSelector/index.tsx
@@ -90,14 +90,10 @@ interface DepartArriveOption {
  */
 function isInputTypeSupported(type: string): boolean {
   let retVal = false;
-  try {
-    if (typeof document !== "undefined") {
-      const input = document.createElement("input");
-      input.setAttribute("type", type);
-      retVal = input.type === type;
-    }
-  } catch {
-    retVal = false;
+  if (typeof document !== "undefined") {
+    const input = document.createElement("input");
+    input.setAttribute("type", type);
+    retVal = input.type === type;
   }
   return retVal;
 }

--- a/packages/trip-form/src/DateTimeSelector/index.tsx
+++ b/packages/trip-form/src/DateTimeSelector/index.tsx
@@ -89,13 +89,12 @@ interface DepartArriveOption {
  * @param {*} type One of the HTML5 input types.
  */
 function isInputTypeSupported(type: string): boolean {
-  let retVal = false;
-  if (typeof document !== "undefined") {
-    const input = document.createElement("input");
-    input.setAttribute("type", type);
-    retVal = input.type === type;
-  }
-  return retVal;
+  // SSR: use of 'document' variable is only valid in a browser (not server-side)
+  if (typeof document === "undefined") return false;
+
+  const input = document.createElement("input");
+  input.setAttribute("type", type);
+  return input.type === type;
 }
 
 const supportsDateTimeInputs = isInputTypeSupported("date") && isInputTypeSupported("time");

--- a/packages/trip-form/src/DateTimeSelector/index.tsx
+++ b/packages/trip-form/src/DateTimeSelector/index.tsx
@@ -89,9 +89,17 @@ interface DepartArriveOption {
  * @param {*} type One of the HTML5 input types.
  */
 function isInputTypeSupported(type: string): boolean {
-  const input = document.createElement("input");
-  input.setAttribute("type", type);
-  return input.type === type;
+  let retVal = false;
+  try {
+    if (typeof document !== "undefined") {
+      const input = document.createElement("input");
+      input.setAttribute("type", type);
+      retVal = input.type === type;
+    }
+  } catch {
+    retVal = false;
+  }
+  return retVal;
 }
 
 const supportsDateTimeInputs = isInputTypeSupported("date") && isInputTypeSupported("time");


### PR DESCRIPTION
this hides a use of 'document' from our SSR / yarn build, which otherwise complains about the use of an unknown (server-side) variable.