### PR TITLE
feat(itinerary-body): add support for displaying only route_headsign

### DIFF
--- a/packages/itinerary-body/src/ItineraryBody/index.tsx
+++ b/packages/itinerary-body/src/ItineraryBody/index.tsx
@@ -25,6 +25,7 @@ const ItineraryBody = ({
   LineColumnContent,
   mapillaryCallback,
   mapillaryKey,
+  onlyShowTripHeadsign,
   PlaceName,
   RouteDescription,
   routingType = "ITINERARY",
@@ -78,6 +79,7 @@ const ItineraryBody = ({
           LineColumnContent={LineColumnContent}
           mapillaryCallback={mapillaryCallback}
           mapillaryKey={mapillaryKey}
+          onlyShowTripHeadsign={onlyShowTripHeadsign}
           PlaceName={PlaceName}
           RouteDescription={RouteDescription}
           routingType={routingType}

--- a/packages/itinerary-body/src/ItineraryBody/place-row.tsx
+++ b/packages/itinerary-body/src/ItineraryBody/place-row.tsx
@@ -31,6 +31,7 @@ export default function PlaceRow({
   LegIcon,
   legIndex,
   LineColumnContent,
+  onlyShowTripHeadsign,
   mapillaryCallback,
   mapillaryKey,
   PlaceName,
@@ -118,6 +119,7 @@ export default function PlaceRow({
                 leg={leg}
                 LegIcon={LegIcon}
                 legIndex={legIndex}
+                onlyShowTripHeadsign={onlyShowTripHeadsign}
                 RouteDescription={RouteDescription}
                 setActiveLeg={setActiveLeg}
                 setViewedTrip={setViewedTrip}

--- a/packages/itinerary-body/src/TransitLegBody/index.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/index.tsx
@@ -39,6 +39,7 @@ interface Props {
   leg: Leg;
   LegIcon: LegIconComponent;
   legIndex: number;
+  onlyShowTripHeadsign?: boolean;
   RouteDescription: FunctionComponent<RouteDescriptionProps>;
   setActiveLeg: SetActiveLegFunction;
   setViewedTrip: SetViewedTripFunction;
@@ -134,13 +135,14 @@ class TransitLegBody extends Component<Props, State> {
 
   render(): ReactElement {
     const {
-      AlertToggleIcon = S.DefaultAlertToggleIcon,
       AlertBodyIcon,
+      AlertToggleIcon = S.DefaultAlertToggleIcon,
       alwaysCollapseAlerts,
       fare,
       intl,
       leg,
       LegIcon,
+      onlyShowTripHeadsign,
       RouteDescription,
       setViewedTrip,
       showAgencyInfo,
@@ -182,6 +184,7 @@ class TransitLegBody extends Component<Props, State> {
               leg={leg}
               LegIcon={LegIcon}
               transitOperator={transitOperator}
+              onlyShowTripHeadsign={onlyShowTripHeadsign}
             />
           </S.LegClickable>
 

--- a/packages/itinerary-body/src/defaults/route-description.tsx
+++ b/packages/itinerary-body/src/defaults/route-description.tsx
@@ -6,7 +6,8 @@ import { RouteDescriptionProps } from "../types";
 import RouteLongName from "./route-long-name";
 
 export default function RouteDescription({
-  leg
+  leg,
+  onlyShowTripHeadsign
 }: RouteDescriptionProps): ReactElement {
   const { routeShortName } = leg;
   return (
@@ -19,7 +20,7 @@ export default function RouteDescription({
         </div>
       )}
       <S.LegDescriptionRouteLongName>
-        <RouteLongName leg={leg} />
+        <RouteLongName leg={leg} onlyShowHeadsign={onlyShowTripHeadsign} />
       </S.LegDescriptionRouteLongName>
     </S.LegDescriptionForTransit>
   );

--- a/packages/itinerary-body/src/defaults/route-long-name.tsx
+++ b/packages/itinerary-body/src/defaults/route-long-name.tsx
@@ -7,6 +7,8 @@ import { defaultMessages } from "../util";
 
 interface Props extends HTMLAttributes<HTMLSpanElement> {
   leg: Leg;
+  /** If true, hides route_long_name in transit legs, only showing headsign. */
+  onlyShowHeadsign?: boolean;
 }
 
 /**
@@ -21,12 +23,15 @@ function toPrefix(contents: ReactElement): ReactElement {
 export default function RouteLongName({
   className,
   leg,
-  style
+  style,
+  onlyShowHeadsign
 }: Props): ReactElement {
   const { headsign, routeLongName } = leg;
   return (
     <span className={className} style={style}>
-      {headsign ? (
+      {onlyShowHeadsign ? (
+        headsign || routeLongName
+      ) : headsign ? (
         <FormattedMessage
           defaultMessage={
             defaultMessages["otpUi.TransitLegBody.routeDescription"]

--- a/packages/itinerary-body/src/otp-react-redux/route-description.tsx
+++ b/packages/itinerary-body/src/otp-react-redux/route-description.tsx
@@ -6,7 +6,8 @@ import { RouteDescriptionProps } from "../types";
 
 export default function RouteDescription({
   leg,
-  LegIcon
+  LegIcon,
+  onlyShowTripHeadsign
 }: RouteDescriptionProps): ReactElement {
   const { routeShortName } = leg;
   return (
@@ -22,7 +23,7 @@ export default function RouteDescription({
         )}
       </S.LegIconAndRouteShortName>
       <S.LegDescriptionRouteLongName>
-        <RouteLongName leg={leg} />
+        <RouteLongName leg={leg} onlyShowHeadsign={onlyShowTripHeadsign} />
       </S.LegDescriptionRouteLongName>
     </S.LegDescriptionForTransit>
   );

--- a/packages/itinerary-body/src/stories/OtpRrItineraryBody.story.tsx
+++ b/packages/itinerary-body/src/stories/OtpRrItineraryBody.story.tsx
@@ -46,17 +46,19 @@ if (!isRunningJest()) {
 }
 
 interface StoryWrapperProps {
+  alwaysCollapseAlerts: boolean;
   itinerary: Itinerary;
+  onlyShowTripHeadsign?: boolean;
   showRouteFares: boolean;
   TimeColumnContent: FunctionComponent<TimeColumnContentProps>;
-  alwaysCollapseAlerts: boolean;
 }
 
 function OtpRRItineraryBodyWrapper({
+  alwaysCollapseAlerts,
   itinerary,
+  onlyShowTripHeadsign,
   showRouteFares,
-  TimeColumnContent,
-  alwaysCollapseAlerts
+  TimeColumnContent
 }: StoryWrapperProps): ReactElement {
   return (
     <ItineraryBodyDefaultsWrapper
@@ -64,6 +66,7 @@ function OtpRRItineraryBodyWrapper({
       itinerary={itinerary}
       LegIcon={ClassicLegIcon}
       LineColumnContent={OtpRRLineColumnContent}
+      onlyShowTripHeadsign={onlyShowTripHeadsign}
       PlaceName={OtpRRPlaceName}
       RouteDescription={OtpRRRouteDescription}
       showAgencyInfo
@@ -100,7 +103,10 @@ export const BikeTransitBikeItinerary = (): ReactElement => (
 );
 
 export const WalkInterlinedTransitItinerary = (): ReactElement => (
-  <OtpRRItineraryBodyWrapper itinerary={walkInterlinedTransitItinerary} />
+  <OtpRRItineraryBodyWrapper
+    itinerary={walkInterlinedTransitItinerary}
+    onlyShowTripHeadsign
+  />
 );
 
 export const WalkTransitTransferItinerary = (): ReactElement => (

--- a/packages/itinerary-body/src/stories/itinerary-body-defaults-wrapper.tsx
+++ b/packages/itinerary-body/src/stories/itinerary-body-defaults-wrapper.tsx
@@ -45,6 +45,7 @@ export default class ItineraryBodyDefaultsWrapper extends Component<
       itinerary,
       LegIcon = TriMetLegIcon,
       LineColumnContent,
+      onlyShowTripHeadsign,
       PlaceName,
       RouteDescription,
       showAgencyInfo,
@@ -83,6 +84,7 @@ export default class ItineraryBodyDefaultsWrapper extends Component<
         itinerary={itinerary}
         LegIcon={LegIcon}
         LineColumnContent={LineColumnContent || DefaultLineColumnContent}
+        onlyShowTripHeadsign={onlyShowTripHeadsign}
         mapillaryKey="fake key, but ok because the api response is also fake"
         PlaceName={PlaceName || DefaultPlaceName}
         RouteDescription={RouteDescription || DefaultRouteDescription}

--- a/packages/itinerary-body/src/types.ts
+++ b/packages/itinerary-body/src/types.ts
@@ -18,6 +18,8 @@ export interface RouteDescriptionProps {
   LegIcon: LegIconComponent;
   /** The transit operator associated with the route if available */
   transitOperator: TransitOperator;
+  /** If true, hides route_long_name in transit legs, only showing headsign. */
+  onlyShowTripHeadsign?: boolean;
 }
 
 export type ToRouteAbbreviationFunction = (route: string | number) => string;
@@ -211,6 +213,11 @@ interface ItineraryBodySharedProps {
    * - stopsExpanded: whether the intermediate stop display is currently expanded
    */
   TransitLegSummary: FunctionComponent<TransitLegSummaryProps>;
+  /**
+   * If true, only displays the trip headsign or route long name
+   * (if headsign is not available)
+   */
+  onlyShowTripHeadsign?: boolean;
 }
 
 export interface PlaceRowProps


### PR DESCRIPTION
This PR is mostly prop drilling for a small change that allows the trip_headsign to be displayed on its own by default in itinerary-body. With this enabled, the itinerary body will match what is displayed on the bus's headsign, unless trip_headsign is blank, in which case only the route_long_name will be displayed (same as before).