### PR TITLE
fix(trip-form): Give a default selection to all TripOptions categories

### DIFF
--- a/packages/trip-form/src/TripOptions.story.tsx
+++ b/packages/trip-form/src/TripOptions.story.tsx
@@ -4,7 +4,9 @@ import React, { Component, ReactElement, useState } from "react";
 import TripOptions from "./TripOptions";
 
 import commonCompanies from "./__mocks__/companies";
-import commonModes from "./__mocks__/modes-en";
+import commonModes, {
+  modesWithCompanyFirstMixedCategory
+} from "./__mocks__/modes-en";
 
 const onQueryParamChange = action("onQueryParamChange");
 
@@ -43,19 +45,46 @@ class PanelWrapper extends Component {
 
 export default {
   component: TripOptions,
-  title: "TripOptions"
+  title: "TripOptions",
+  args: {
+    featuredItemOverlayBackButton: true,
+    supportedCompanies: commonCompanies
+  },
+  parameters: {
+    // TODO: resolve a11y issues
+    a11y: {
+      config: {
+        rules: [
+          { id: "color-contrast", enabled: false },
+          { id: "duplicate-id-aria", enabled: false },
+          { id: "duplicate-id", enabled: false }
+        ]
+      }
+    }
+  }
 };
 
-export const tripOptions = (): ReactElement => (
+const Template = args => (
   <PanelWrapper>
-    <TripOptions
-      featuredItemOverlayBackButton
-      supportedCompanies={commonCompanies}
-      supportedModes={commonModes}
-    />
+    {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+    <TripOptions {...args} />
   </PanelWrapper>
 );
-export const tripOptionsWithCustomIconsAndCloseButton = (): ReactElement => {
+
+export const Default = Template.bind({});
+Default.args = {
+  supportedModes: commonModes
+};
+
+// This story serves as a regression test for a bug that led to
+// categories in the structure the "CAR" category in this data to fail
+// to be given a default selection
+export const CompanyFirstMixedCategory = Template.bind({});
+CompanyFirstMixedCategory.args = {
+  supportedModes: modesWithCompanyFirstMixedCategory
+};
+
+export const CustomIconsAndCloseButton = (): ReactElement => {
   const [featuredOverlayShown, setFeaturedOverlayShown] = useState(false);
 
   return (
@@ -94,24 +123,8 @@ export const tripOptionsWithCustomIconsAndCloseButton = (): ReactElement => {
   );
 };
 
-// TODO: resolve a11y issues
-const disableA11yParameters = {
-  a11y: {
-    config: {
-      rules: [
-        { id: "color-contrast", enabled: false },
-        { id: "duplicate-id-aria", enabled: false },
-        { id: "duplicate-id", enabled: false }
-      ]
-    }
-  }
-};
-
-tripOptions.parameters = disableA11yParameters;
-
-// Disable storyshot for this story, as it is mostly the same as TripOptions except with
-// a hook that storyshot can't handle
-tripOptionsWithCustomIconsAndCloseButton.parameters = {
-  storyshots: { disable: true },
-  ...disableA11yParameters
+// Disable storyshot for this story, as it is mostly the same as TripOptions
+// except with a hook that storyshot can't handle
+CustomIconsAndCloseButton.parameters = {
+  storyshots: { disable: true }
 };

--- a/packages/trip-form/src/TripOptions/ModeRow.tsx
+++ b/packages/trip-form/src/TripOptions/ModeRow.tsx
@@ -108,10 +108,15 @@ const ModeRow = ({
           }
 
           let mode = getCategoryPrimaryMode(category);
+
+          // If the category has a single mode select companies from all
+          // options, if the category has mixed modes select the company
+          // (if any) associated with first option
           const companies =
-            typeof category.mode === "undefined"
-              ? ""
-              : category.options?.map(o => o.company).join(",") || "";
+            (category.mode
+              ? category.options?.map(o => o.company).join(",")
+              : category.options?.[0]?.company) || "";
+
           if (category.type === "access") {
             mode = isChecked
               ? selectedTransitString

--- a/packages/trip-form/src/__mocks__/modes-en.ts
+++ b/packages/trip-form/src/__mocks__/modes-en.ts
@@ -1,3 +1,5 @@
+import cloneDeep from "lodash.clonedeep";
+
 import bikeImage from "./static/bike.svg";
 import carImage from "./static/car.svg";
 import scooterImage from "./static/scooter.svg";
@@ -196,25 +198,17 @@ const commonModes = {
 
 // This variant of the data adds an option with a company as the first
 // option in the "CAR" category that has mixed modes ("CAR_PARK", "CAR_HAIL")
-export const modesWithCompanyFirstMixedCategory = {
-  ...commonModes,
-  categories: commonModes.categories.map(c => {
-    const nextCategory = { ...c };
-
-    if (c.id === "CAR") {
-      nextCategory.options = [
-        {
-          company: "LYFT",
-          mode: "CAR_HAIL",
-          label: "Lyft",
-          url: "https://www.lyft.com"
-        },
-        ...nextCategory.options
-      ];
-    }
-
-    return nextCategory;
-  })
-};
+const modesWithCompanyFirstMixedCategory = cloneDeep(commonModes);
+modesWithCompanyFirstMixedCategory.categories.forEach(c => {
+  if (c.id === "CAR") {
+    c.options.unshift({
+      company: "LYFT",
+      mode: "CAR_HAIL",
+      label: "Lyft",
+      url: "https://www.lyft.com"
+    });
+  }
+});
 
 export default commonModes;
+export { modesWithCompanyFirstMixedCategory };

--- a/packages/trip-form/src/__mocks__/modes-en.ts
+++ b/packages/trip-form/src/__mocks__/modes-en.ts
@@ -194,4 +194,27 @@ const commonModes = {
   ]
 };
 
+// This variant of the data adds an option with a company as the first
+// option in the "CAR" category that has mixed modes ("CAR_PARK", "CAR_HAIL")
+export const modesWithCompanyFirstMixedCategory = {
+  ...commonModes,
+  categories: commonModes.categories.map(c => {
+    const nextCategory = { ...c };
+
+    if (c.id === "CAR") {
+      nextCategory.options = [
+        {
+          company: "LYFT",
+          mode: "CAR_HAIL",
+          label: "Lyft",
+          url: "https://www.lyft.com"
+        },
+        ...nextCategory.options
+      ];
+    }
+
+    return nextCategory;
+  })
+};
+
 export default commonModes;

--- a/packages/trip-form/src/__mocks__/modes-en.ts
+++ b/packages/trip-form/src/__mocks__/modes-en.ts
@@ -199,16 +199,14 @@ const commonModes = {
 // This variant of the data adds an option with a company as the first
 // option in the "CAR" category that has mixed modes ("CAR_PARK", "CAR_HAIL")
 const modesWithCompanyFirstMixedCategory = cloneDeep(commonModes);
-modesWithCompanyFirstMixedCategory.categories.forEach(c => {
-  if (c.id === "CAR") {
-    c.options.unshift({
-      company: "LYFT",
-      mode: "CAR_HAIL",
-      label: "Lyft",
-      url: "https://www.lyft.com"
-    });
-  }
-});
+modesWithCompanyFirstMixedCategory.categories
+  .find(c => c.id === "CAR")
+  .options.unshift({
+    company: "LYFT",
+    mode: "CAR_HAIL",
+    label: "Lyft",
+    url: "https://www.lyft.com"
+  });
 
 export default commonModes;
 export { modesWithCompanyFirstMixedCategory };


### PR DESCRIPTION
A bug exists in the `TripOptions` component for which if there is a category that has mixed modes (e.g. an option with mode "CAR_HAIL" and an option with mode "CAR_PARK") and the first option has non-null company attribute value the category is not given a default selection (i.e. there is no selection on the category when it is initially opened).  The change made to `ModeRow` resolves this issue.

I've also added a story to with mode data containing a category that reproduces this bug (when the fix is not applied) and did some clean up to TripOptions stories by creating and re-using a template and moving some default config into the default export