### PR TITLE
fix(core-utils): adjust baseline co2 calculation algorithm

### DIFF
--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -521,8 +521,10 @@ export function calculateEmissions(
   const totalCarbon =
     itinerary?.legs?.reduce((total, leg) => {
       return (
-        (leg.distance * carbonIntensityWithDefaults[leg.mode.toLowerCase()] ||
-          0) + total
+        // We estimate that the actual driving distance is 1.34x the "crow-flying" distance
+        (leg.distance *
+          1.34 *
+          carbonIntensityWithDefaults[leg.mode.toLowerCase()] || 0) + total
       );
     }, 0) || 0;
 


### PR DESCRIPTION
The current algorithm provides results that are too far from the "actual" ones based on actual leg length. This PR attempts to improve this by adding a multiplier to the "crow-flight" distance.