### PR TITLE
Algorithmically determine whether route_long_name should be shown

### DIFF
--- a/packages/itinerary-body/package.json
+++ b/packages/itinerary-body/package.json
@@ -19,8 +19,9 @@
     "date-fns": "^2.28.0",
     "date-fns-tz": "^1.2.2",
     "flat": "^5.0.2",
+    "react-animate-height": "^3.0.4",
     "react-resize-detector": "^4.2.1",
-    "react-animate-height": "^3.0.4"
+    "string-similarity": "^4.0.4"
   },
   "devDependencies": {
     "@opentripplanner/types": "^4.0.2",

--- a/packages/itinerary-body/src/defaults/route-long-name.tsx
+++ b/packages/itinerary-body/src/defaults/route-long-name.tsx
@@ -25,7 +25,7 @@ export default function RouteLongName({
   style
 }: Props): ReactElement {
   const { headsign, routeLongName } = leg;
-  const badGtfs = compareTwoStrings(headsign || "", routeLongName || "") > 0.5;
+  const badGtfs = compareTwoStrings(headsign || "", routeLongName || "") > 0.25;
   return (
     <span className={className} style={style}>
       {!badGtfs && headsign ? (

--- a/packages/itinerary-body/src/defaults/route-long-name.tsx
+++ b/packages/itinerary-body/src/defaults/route-long-name.tsx
@@ -1,6 +1,7 @@
 import { Leg } from "@opentripplanner/types";
 import React, { HTMLAttributes, ReactElement } from "react";
 import { FormattedMessage } from "react-intl";
+import { compareTwoStrings } from "string-similarity";
 
 import * as S from "../styled";
 import { defaultMessages } from "../util";
@@ -24,9 +25,10 @@ export default function RouteLongName({
   style
 }: Props): ReactElement {
   const { headsign, routeLongName } = leg;
+  const badGtfs = compareTwoStrings(headsign || "", routeLongName || "") > 0.5;
   return (
     <span className={className} style={style}>
-      {headsign ? (
+      {!badGtfs && headsign ? (
         <FormattedMessage
           defaultMessage={
             defaultMessages["otpUi.TransitLegBody.routeDescription"]
@@ -39,6 +41,8 @@ export default function RouteLongName({
             toPrefix
           }}
         />
+      ) : badGtfs ? (
+        headsign
       ) : (
         routeLongName
       )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2832,6 +2832,33 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
+"@opentripplanner/core-utils@^7.0.10", "@opentripplanner/core-utils@^7.0.5":
+  version "7.0.10"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-7.0.10.tgz#697aa2309cee35716bcc3f38311739a75353172c"
+  integrity sha512-dDioXTuhP+Slg7GRWsLayDgwx0XaLQVDP7NtRGHBQ+pEFjgm66Xq4SkmyV+8UCi1uIDp7v49nTU3gBmnsywicQ==
+  dependencies:
+    "@mapbox/polyline" "^1.1.0"
+    "@opentripplanner/geocoder" "^1.3.2"
+    "@styled-icons/foundation" "^10.34.0"
+    "@turf/along" "^6.0.1"
+    bowser "^2.7.0"
+    chroma-js "^2.4.2"
+    date-fns "^2.28.0"
+    date-fns-tz "^1.2.2"
+    lodash.clonedeep "^4.5.0"
+    lodash.isequal "^4.5.0"
+    qs "^6.9.1"
+
+"@opentripplanner/geocoder@1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/geocoder/-/geocoder-1.3.3.tgz#7ba1f90e59a30d0306ebe641e8394cb60bd1a1d0"
+  integrity sha512-fBTdLg75OZ1Xsr3l1/XJIYlS+IDVPqm2k8fDwLYOFm+NzBo97ZZIdOkOt1ujCg0uJEv+W1KUR1WqOHwaJ0xk4Q==
+  dependencies:
+    "@conveyal/geocoder-arcgis-geojson" "^0.0.3"
+    "@conveyal/lonlat" "^1.4.1"
+    isomorphic-mapzen-search "^1.6.1"
+    lodash.memoize "^4.1.2"
+
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.1":
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.4.tgz#df0d0d855fc527db48aac93c218a0bf4ada41f99"
@@ -15370,7 +15397,7 @@ react-transition-group@^4.3.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@17.0.2, react@^17.0.2:
+react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
@@ -16860,6 +16887,11 @@ string-length@^2.0.0:
   dependencies:
     astral-regex "^1.0.0"
     strip-ansi "^4.0.0"
+
+string-similarity@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-4.0.4.tgz#42d01ab0b34660ea8a018da8f56a3309bb8b2a5b"
+  integrity sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==
 
 string-width@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This PR adds functionality to determine whether route_long_name should be shown next to trip headsign based on the similarity to the trip_headsign. If they are closely overlapping, then the route_long_name is not needed.
For example, "Downtown Seattle / Aurora Village" to "Aurora Village". The rider does not need to know that the bus serves  Downtown Seattle in the other direction, they only need to know what will appear on the bus headsign. 

Meanwhile, in places like San Francisco, where bus routes have names and numbers, the name should not have much overlap with the headsign and therefore it should be shown.