### PR TITLE
Fix itin styles

### DIFF
--- a/packages/itinerary-body/src/styled.tsx
+++ b/packages/itinerary-body/src/styled.tsx
@@ -366,11 +366,7 @@ export const LineColumn = styled.div`
   padding-right: 5px;
 `;
 
-export const LegDetails = styled.span`
-  *:not(.fa) {
-    vertical-align: middle;
-  }
-`;
+export const LegDetails = styled.span``;
 
 export const PlaceRowWrapper = styled.div`
   /* needs to be a flexbox row */

--- a/packages/itinerary-body/src/styled.tsx
+++ b/packages/itinerary-body/src/styled.tsx
@@ -391,6 +391,7 @@ export const PreviewContainer = styled.div<PreviewContainerProps>`
   position: relative;
   text-align: center;
   text-decoration: none;
+  vertical-align: middle;
   width: 75%;
 
   &:hover {


### PR DESCRIPTION
This PR fixes the mis-alignment of items in the transit leg details (see screenshot).
It should maintain the relative position of the elevation chart and the walk/bike summary text.

<img width="370" alt="image" src="https://user-images.githubusercontent.com/56846598/211070788-c2daef33-e12e-4d77-8b50-775b80fac53a.png">
