### PR TITLE
fix(map-popup): correct stop viewer link behavior

### DIFF
--- a/packages/map-popup/src/index.tsx
+++ b/packages/map-popup/src/index.tsx
@@ -58,7 +58,7 @@ const StationHubDetails = ({ station }: { station: Station }) => {
   )
 }
 
-const StopDetails = ({ id, setViewedStop }: { id: string, setViewedStop: ({ stopId }: { stopId: string }) => void; }) => {
+const StopDetails = ({ id, setViewedStop }: { id: string, setViewedStop: () => void; }) => {
   return (
     <BaseMapStyled.PopupRow>
         <strong>
@@ -71,7 +71,7 @@ const StopDetails = ({ id, setViewedStop }: { id: string, setViewedStop: ({ stop
             }}
           />
         </strong>
-      <S.ViewStopButton onClick={() => setViewedStop({ stopId: id })}>
+      <S.ViewStopButton onClick={setViewedStop}>
         <FormattedMessage
           defaultMessage={defaultMessages["otpUi.MapPopup.stopViewer"]}
           description="Text for link that opens the stop viewer"
@@ -114,7 +114,7 @@ export function MapPopup({ configCompanies, entity, getEntityName, setLocation, 
       {entityIsStationHub && <StationHubDetails station={entity} />}
 
       {/* render stop viewer link if available */}
-      {setViewedStop && !bikesAvailablePresent && <StopDetails id={stopId} setViewedStop={setViewedStop} />}
+      {setViewedStop && !bikesAvailablePresent && <StopDetails id={stopId} setViewedStop={() => setViewedStop({ stopId: entity.id })} />}
 
       {/* The "Set as [from/to]" ButtonGroup */}
       {setLocation && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2832,6 +2832,16 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
+"@opentripplanner/map-popup@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/map-popup/-/map-popup-1.0.0.tgz#537faa42de5119ab6667e7147b81b868f8832238"
+  integrity sha512-VEaVUJ0uYbLqPTLfFQ/bpHGSCxn44uWagBEq7Z2RTD5UlCEemIR+3g+efVANhIM5Lq1cRRUKbneno0mYdM0QvA==
+  dependencies:
+    "@opentripplanner/base-map" "^3.0.7"
+    "@opentripplanner/core-utils" "^8.0.0"
+    "@opentripplanner/from-to-location-picker" "^2.1.5"
+    flat "^5.0.2"
+
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.1":
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.4.tgz#df0d0d855fc527db48aac93c218a0bf4ada41f99"


### PR DESCRIPTION
The map-popup package brought a regression where the stop viewer link wasn't passing the correct stop id. The issue was using a stripped stop ID instead of the entire thing. This PR corrects this. A follow-up PR will be needed to make use of this update in the packages that depend on it.