### PR TITLE
Improve Itinerary and CO2 Types

### DIFF
--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -501,15 +501,15 @@ const CARBON_INTENSITY_DEFAULTS = {
 };
 
 /**
- * @param  {itinerary} itinerary OTP trip itinierary
+ * @param  {itinerary} itinerary OTP trip itinierary, only legs is required.
  * @param  {carbonIntensity} carbonIntensity carbon intensity by mode in grams/meter
  * @param {units} units units to be used in return value
  * @return Amount of carbon in chosen unit
  */
 export function calculateEmissions(
-  itinerary: Itinerary,
+  itinerary: Partial<Itinerary> & Pick<Itinerary, "legs">,
   carbonIntensity: Record<string, number> = {},
-  units?: string
+  units?: "ounce" | "kilogram" | "pound" | "gram"
 ): number {
   // Apply defaults for any values that we don't have.
   const carbonIntensityWithDefaults = {

--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -4,9 +4,10 @@ import {
   Config,
   ElevationProfile,
   FlexBookingInfo,
-  Itinerary,
+  ItineraryOnlyLegsRequired,
   LatLngArray,
   Leg,
+  MassUnitOption,
   Money,
   Place,
   Step,
@@ -212,7 +213,9 @@ export function getCompanyFromLeg(leg: Leg): string {
   return null;
 }
 
-export function getItineraryBounds(itinerary: Itinerary): LatLngArray[] {
+export function getItineraryBounds(
+  itinerary: ItineraryOnlyLegsRequired
+): LatLngArray[] {
   let coords = [];
   itinerary.legs.forEach(leg => {
     const legCoords = polyline
@@ -407,7 +410,7 @@ export function getTNCLocation(leg: Leg, type: string): string {
 }
 
 export function calculatePhysicalActivity(
-  itinerary: Itinerary
+  itinerary: ItineraryOnlyLegsRequired
 ): {
   bikeDuration: number;
   caloriesBurned: number;
@@ -433,7 +436,9 @@ export function calculatePhysicalActivity(
  * these values and currency info.
  * It is assumed that the same currency is used for all TNC legs.
  */
-export function calculateTncFares(itinerary: Itinerary): TncFare {
+export function calculateTncFares(
+  itinerary: ItineraryOnlyLegsRequired
+): TncFare {
   return itinerary.legs
     .filter(leg => leg.mode === "CAR" && leg.hailedCar && leg.tncData)
     .reduce(
@@ -508,9 +513,9 @@ const CARBON_INTENSITY_DEFAULTS = {
  */
 export function calculateEmissions(
   // This type makes all the properties from Itinerary optional except legs.
-  itinerary: Partial<Itinerary> & Pick<Itinerary, "legs">,
+  itinerary: ItineraryOnlyLegsRequired,
   carbonIntensity: Record<string, number> = {},
-  units?: "ounce" | "kilogram" | "pound" | "gram"
+  units?: MassUnitOption
 ): number {
   // Apply defaults for any values that we don't have.
   const carbonIntensityWithDefaults = {

--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -501,12 +501,13 @@ const CARBON_INTENSITY_DEFAULTS = {
 };
 
 /**
- * @param  {itinerary} itinerary OTP trip itinierary, only legs is required.
- * @param  {carbonIntensity} carbonIntensity carbon intensity by mode in grams/meter
+ * @param {itinerary} itinerary OTP trip itinierary, only legs is required.
+ * @param {carbonIntensity} carbonIntensity carbon intensity by mode in grams/meter
  * @param {units} units units to be used in return value
  * @return Amount of carbon in chosen unit
  */
 export function calculateEmissions(
+  // This type makes all the properties from Itinerary optional except legs.
   itinerary: Partial<Itinerary> & Pick<Itinerary, "legs">,
   carbonIntensity: Record<string, number> = {},
   units?: "ounce" | "kilogram" | "pound" | "gram"

--- a/packages/trip-details/src/types.ts
+++ b/packages/trip-details/src/types.ts
@@ -1,6 +1,6 @@
 // Prettier does not recognize the import type syntax.
 // eslint-disable-next-line prettier/prettier
-import type { FareDetails, Money, Itinerary, Leg, Fare, } from "@opentripplanner/types";
+import type { FareDetails, Money, Itinerary, Leg, Fare, MassUnitOption, } from "@opentripplanner/types";
 import type { ReactElement } from "react";
 
 export interface CaloriesDetailsProps {
@@ -11,7 +11,7 @@ export interface CaloriesDetailsProps {
 
 export interface CO2ConfigType {
   carbonIntensity?: { [index: string]: number };
-  units?: string;
+  units?: MassUnitOption;
   enabled?: boolean;
 }
 

--- a/packages/trip-details/src/types.ts
+++ b/packages/trip-details/src/types.ts
@@ -1,6 +1,6 @@
 // Prettier does not recognize the import type syntax.
 // eslint-disable-next-line prettier/prettier
-import type { FareDetails, Money, Itinerary, Leg, Fare, MassUnitOption, } from "@opentripplanner/types";
+import type { MassUnitOption, Fare, Leg, FareDetails, Itinerary, Money } from "@opentripplanner/types";
 import type { ReactElement } from "react";
 
 export interface CaloriesDetailsProps {

--- a/packages/trip-details/src/types.ts
+++ b/packages/trip-details/src/types.ts
@@ -10,7 +10,7 @@ export interface CaloriesDetailsProps {
 }
 
 export interface CO2ConfigType {
-  carbonIntensity?: { [index: string]: number };
+  carbonIntensity?: Record<string, number>;
   units?: MassUnitOption;
   enabled?: boolean;
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -400,6 +400,13 @@ export type Itinerary = {
   walkTime: number;
 };
 
+/**
+ * In many places all we need from the Itinerary is the legs,
+ * this type makes all the other types optional except legs.
+ */
+export type ItineraryOnlyLegsRequired = Partial<Itinerary> &
+  Pick<Itinerary, "legs">;
+
 export type ElevationProfile = {
   maxElev: number;
   minElev: number;
@@ -696,3 +703,8 @@ export type GradationMap = Record<
   number,
   { color: string; icon?: ReactElement; text?: string }
 >;
+
+/**
+ * Options for units of mass (used in CO2 calculation config)
+ */
+export type MassUnitOption = "ounce" | "kilogram" | "pound" | "gram";


### PR DESCRIPTION
This PR adds a new type for mass units, and also a "looser" Itinerary type that makes all fields optional except legs, since in most places that is the only property we need. This will make Typescript happier when we are making "fake" itineraries in OTP-RR and in testing. 