### PR TITLE
OTP2 FareProduct / Fare By Leg Support

### DIFF
--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -588,7 +588,7 @@ export function getLegCost(
   leg: Leg,
   category: string,
   container: string
-): { price: Money | undefined; transferAmount?: number } {
+): { price?: Money; transferAmount?: number } {
   if (!leg.fareProducts) return { price: undefined };
   const relevantFareProducts = leg.fareProducts.filter(
     fp => fp.category.name === category && fp.container.name === container
@@ -601,7 +601,7 @@ export function getLegCost(
 
   return {
     price: totalCost,
-    transferAmount: transferFareProduct?.amount?.cents || undefined
+    transferAmount: transferFareProduct?.amount?.cents
   };
 }
 

--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -559,9 +559,9 @@ export function getDisplayedStopId(placeOrStop: Place | Stop): string {
 export function getLegsWithFares(itinerary: Itinerary): Leg[] {
   return itinerary.legs.map((leg, i) => ({
     ...leg,
-    legProducts: itinerary.fare.legProducts.filter(lp =>
-      lp.legIndicies.includes(i)
-    )
+    fareProducts: itinerary.fare?.legProducts
+      ?.filter(lp => lp?.legIndices?.includes(i))
+      .flatMap(lp => lp.products)
   }));
 }
 
@@ -569,17 +569,17 @@ export function getLegCost(
   leg: Leg,
   category: string,
   container: string
-): { cost: Money | undefined; usesTransfer?: boolean } {
-  if (!leg.fareProducts) return { cost: undefined };
+): { price: Money | undefined; usesTransfer?: boolean } {
+  if (!leg.fareProducts) return { price: undefined };
   const relevantFareProducts = leg.fareProducts.filter(
     fp => fp.category.name === category && fp.container.name === container
   );
   const totalCost = relevantFareProducts.find(fp => fp.name === "rideCost")
-    .amount;
+    ?.amount;
   const usesTransfer = !!relevantFareProducts.find(
     fp => fp.name === "transfer"
   );
-  return { cost: totalCost, usesTransfer };
+  return { price: totalCost, usesTransfer };
 }
 
 export function getItineraryCost(
@@ -589,11 +589,11 @@ export function getItineraryCost(
 ): Money {
   return legs
     .filter(leg => !!leg.fareProducts)
-    .map(leg => getLegCost(leg, category, container).cost)
+    .map(leg => getLegCost(leg, category, container).price)
     .reduce<Money>(
       (prev, cur) => ({
-        cents: prev.cents + cur.cents,
-        currency: prev.currency ?? cur.currency
+        cents: prev.cents + cur?.cents || 0,
+        currency: prev.currency ?? cur?.currency
       }),
       { cents: 0, currency: null }
     );

--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -556,6 +556,11 @@ export function getDisplayedStopId(placeOrStop: Place | Stop): string {
   return stopCode || stopId?.split(":")[1] || stopId;
 }
 
+/**
+ * Adds the fare product info to each leg in an itinerary, from the itinerary's fare property
+ * @param itinerary Itinerary with legProducts in fare object
+ * @returns Itinerary with legs that have fare products attached to them
+ */
 export function getLegsWithFares(itinerary: Itinerary): Leg[] {
   return itinerary.legs.map((leg, i) => ({
     ...leg,
@@ -565,6 +570,13 @@ export function getLegsWithFares(itinerary: Itinerary): Leg[] {
   }));
 }
 
+/**
+ * Extracts useful data from the fare products on a leg, such as the leg cost and transfer info.
+ * @param leg Leg with fare products (must have used getLegsWithFares)
+ * @param category Rider category
+ * @param container Fare container (cash, electronic)
+ * @returns Object containing price as well as the transfer discount amount, if a transfer was used.
+ */
 export function getLegCost(
   leg: Leg,
   category: string,
@@ -586,6 +598,13 @@ export function getLegCost(
   };
 }
 
+/**
+ * Returns the total itinerary cost for a given set of legs.
+ * @param legs Itinerary legs with fare products (must have used getLegsWithFares)
+ * @param category Rider category (youth, regular, senior)
+ * @param container Fare container (cash, electronic)
+ * @returns Money object for the total itinerary cost.
+ */
 export function getItineraryCost(
   legs: Leg[],
   category: string,

--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -569,17 +569,21 @@ export function getLegCost(
   leg: Leg,
   category: string,
   container: string
-): { price: Money | undefined; usesTransfer?: boolean } {
+): { price: Money | undefined; transferAmount?: number } {
   if (!leg.fareProducts) return { price: undefined };
   const relevantFareProducts = leg.fareProducts.filter(
     fp => fp.category.name === category && fp.container.name === container
   );
   const totalCost = relevantFareProducts.find(fp => fp.name === "rideCost")
     ?.amount;
-  const usesTransfer = !!relevantFareProducts.find(
+  const transferFareProduct = relevantFareProducts.find(
     fp => fp.name === "transfer"
   );
-  return { price: totalCost, usesTransfer };
+
+  return {
+    price: totalCost,
+    transferAmount: transferFareProduct?.amount?.cents || undefined
+  };
 }
 
 export function getItineraryCost(

--- a/packages/core-utils/tsconfig.json
+++ b/packages/core-utils/tsconfig.json
@@ -4,6 +4,7 @@
     "composite": true,
     "outDir": "./lib",
     "rootDir": "./src",
+    "lib": ["es2019", "dom"],
     "skipLibCheck": true
   },
   "include": ["src/**/*"]

--- a/packages/itinerary-body/src/__mocks__/itineraries/otp2-with-fareproducts.json
+++ b/packages/itinerary-body/src/__mocks__/itineraries/otp2-with-fareproducts.json
@@ -1,0 +1,1131 @@
+{
+  "duration": 3583,
+  "startTime": 1674505485000,
+  "endTime": 1674509068000,
+  "walkTime": 930,
+  "transitTime": 2340,
+  "waitingTime": 313,
+  "walkDistance": 1157.33,
+  "walkLimitExceeded": false,
+  "generalizedCost": 5616,
+  "elevationLost": 0,
+  "elevationGained": 0,
+  "transfers": 1,
+  "fare": {
+    "fare": {
+      "senior": {
+        "cents": 225,
+        "currency": {
+          "currency": "USD",
+          "defaultFractionDigits": 2,
+          "currencyCode": "USD",
+          "symbol": "$"
+        }
+      },
+      "electronicSpecial": {
+        "cents": 150,
+        "currency": {
+          "currency": "USD",
+          "defaultFractionDigits": 2,
+          "currencyCode": "USD",
+          "symbol": "$"
+        }
+      },
+      "electronicSenior": {
+        "cents": 125,
+        "currency": {
+          "currency": "USD",
+          "defaultFractionDigits": 2,
+          "currencyCode": "USD",
+          "symbol": "$"
+        }
+      },
+      "electronicYouth": {
+        "cents": 0,
+        "currency": {
+          "currency": "USD",
+          "defaultFractionDigits": 2,
+          "currencyCode": "USD",
+          "symbol": "$"
+        }
+      },
+      "electronicRegular": {
+        "cents": 250,
+        "currency": {
+          "currency": "USD",
+          "defaultFractionDigits": 2,
+          "currencyCode": "USD",
+          "symbol": "$"
+        }
+      },
+      "youth": {
+        "cents": 0,
+        "currency": {
+          "currency": "USD",
+          "defaultFractionDigits": 2,
+          "currencyCode": "USD",
+          "symbol": "$"
+        }
+      },
+      "regular": {
+        "cents": 250,
+        "currency": {
+          "currency": "USD",
+          "defaultFractionDigits": 2,
+          "currencyCode": "USD",
+          "symbol": "$"
+        }
+      }
+    },
+    "details": {
+      "senior": [],
+      "electronicSpecial": [],
+      "electronicSenior": [],
+      "electronicYouth": [],
+      "electronicRegular": [],
+      "youth": [],
+      "regular": []
+    },
+    "legProducts": [
+      {
+        "legIndices": [1],
+        "products": [
+          {
+            "id": "orcaFares:farePayment",
+            "name": "rideCost",
+            "amount": {
+              "cents": 0,
+              "currency": {
+                "currency": "USD",
+                "defaultFractionDigits": 2,
+                "currencyCode": "USD",
+                "symbol": "$"
+              }
+            },
+            "container": {
+              "id": "orcaFares",
+              "name": "electronic"
+            },
+            "category": {
+              "id": "orcaFares",
+              "name": "youth"
+            }
+          },
+          {
+            "id": "orcaFares:farePayment",
+            "name": "rideCost",
+            "amount": {
+              "cents": 125,
+              "currency": {
+                "currency": "USD",
+                "defaultFractionDigits": 2,
+                "currencyCode": "USD",
+                "symbol": "$"
+              }
+            },
+            "container": {
+              "id": "orcaFares",
+              "name": "cash"
+            },
+            "category": {
+              "id": "orcaFares",
+              "name": "senior"
+            }
+          },
+          {
+            "id": "orcaFares:farePayment",
+            "name": "rideCost",
+            "amount": {
+              "cents": 0,
+              "currency": {
+                "currency": "USD",
+                "defaultFractionDigits": 2,
+                "currencyCode": "USD",
+                "symbol": "$"
+              }
+            },
+            "container": {
+              "id": "orcaFares",
+              "name": "cash"
+            },
+            "category": {
+              "id": "orcaFares",
+              "name": "youth"
+            }
+          },
+          {
+            "id": "orcaFares:farePayment",
+            "name": "rideCost",
+            "amount": {
+              "cents": 125,
+              "currency": {
+                "currency": "USD",
+                "defaultFractionDigits": 2,
+                "currencyCode": "USD",
+                "symbol": "$"
+              }
+            },
+            "container": {
+              "id": "orcaFares",
+              "name": "electronic"
+            },
+            "category": {
+              "id": "orcaFares",
+              "name": "special"
+            }
+          },
+          {
+            "id": "orcaFares:farePayment",
+            "name": "rideCost",
+            "amount": {
+              "cents": 125,
+              "currency": {
+                "currency": "USD",
+                "defaultFractionDigits": 2,
+                "currencyCode": "USD",
+                "symbol": "$"
+              }
+            },
+            "container": {
+              "id": "orcaFares",
+              "name": "electronic"
+            },
+            "category": {
+              "id": "orcaFares",
+              "name": "senior"
+            }
+          },
+          {
+            "id": "orcaFares:farePayment",
+            "name": "rideCost",
+            "amount": {
+              "cents": 250,
+              "currency": {
+                "currency": "USD",
+                "defaultFractionDigits": 2,
+                "currencyCode": "USD",
+                "symbol": "$"
+              }
+            },
+            "container": {
+              "id": "orcaFares",
+              "name": "electronic"
+            },
+            "category": {
+              "id": "orcaFares",
+              "name": "regular"
+            }
+          },
+          {
+            "id": "orcaFares:farePayment",
+            "name": "rideCost",
+            "amount": {
+              "cents": 250,
+              "currency": {
+                "currency": "USD",
+                "defaultFractionDigits": 2,
+                "currencyCode": "USD",
+                "symbol": "$"
+              }
+            },
+            "container": {
+              "id": "orcaFares",
+              "name": "cash"
+            },
+            "category": {
+              "id": "orcaFares",
+              "name": "regular"
+            }
+          }
+        ]
+      },
+      {
+        "legIndices": [3],
+        "products": [
+          {
+            "id": "orcaFares:farePayment",
+            "name": "rideCost",
+            "amount": {
+              "cents": 0,
+              "currency": {
+                "currency": "USD",
+                "defaultFractionDigits": 2,
+                "currencyCode": "USD",
+                "symbol": "$"
+              }
+            },
+            "container": {
+              "id": "orcaFares",
+              "name": "electronic"
+            },
+            "category": {
+              "id": "orcaFares",
+              "name": "youth"
+            }
+          },
+          {
+            "id": "orcaFares:farePayment",
+            "name": "rideCost",
+            "amount": {
+              "cents": 100,
+              "currency": {
+                "currency": "USD",
+                "defaultFractionDigits": 2,
+                "currencyCode": "USD",
+                "symbol": "$"
+              }
+            },
+            "container": {
+              "id": "orcaFares",
+              "name": "cash"
+            },
+            "category": {
+              "id": "orcaFares",
+              "name": "senior"
+            }
+          },
+          {
+            "id": "orcaFares:farePayment",
+            "name": "rideCost",
+            "amount": {
+              "cents": 0,
+              "currency": {
+                "currency": "USD",
+                "defaultFractionDigits": 2,
+                "currencyCode": "USD",
+                "symbol": "$"
+              }
+            },
+            "container": {
+              "id": "orcaFares",
+              "name": "cash"
+            },
+            "category": {
+              "id": "orcaFares",
+              "name": "youth"
+            }
+          },
+          {
+            "id": "orcaFares:farePayment",
+            "name": "rideCost",
+            "amount": {
+              "cents": 25,
+              "currency": {
+                "currency": "USD",
+                "defaultFractionDigits": 2,
+                "currencyCode": "USD",
+                "symbol": "$"
+              }
+            },
+            "container": {
+              "id": "orcaFares",
+              "name": "electronic"
+            },
+            "category": {
+              "id": "orcaFares",
+              "name": "special"
+            }
+          },
+          {
+            "id": "orcaFares:farePayment",
+            "name": "transfer",
+            "amount": {
+              "cents": 125,
+              "currency": {
+                "currency": "USD",
+                "defaultFractionDigits": 2,
+                "currencyCode": "USD",
+                "symbol": "$"
+              }
+            },
+            "container": {
+              "id": "orcaFares",
+              "name": "electronic"
+            },
+            "category": {
+              "id": "orcaFares",
+              "name": "special"
+            }
+          },
+          {
+            "id": "orcaFares:farePayment",
+            "name": "rideCost",
+            "amount": {
+              "cents": 0,
+              "currency": {
+                "currency": "USD",
+                "defaultFractionDigits": 2,
+                "currencyCode": "USD",
+                "symbol": "$"
+              }
+            },
+            "container": {
+              "id": "orcaFares",
+              "name": "electronic"
+            },
+            "category": {
+              "id": "orcaFares",
+              "name": "senior"
+            }
+          },
+          {
+            "id": "orcaFares:farePayment",
+            "name": "transfer",
+            "amount": {
+              "cents": 125,
+              "currency": {
+                "currency": "USD",
+                "defaultFractionDigits": 2,
+                "currencyCode": "USD",
+                "symbol": "$"
+              }
+            },
+            "container": {
+              "id": "orcaFares",
+              "name": "electronic"
+            },
+            "category": {
+              "id": "orcaFares",
+              "name": "senior"
+            }
+          },
+          {
+            "id": "orcaFares:farePayment",
+            "name": "rideCost",
+            "amount": {
+              "cents": 0,
+              "currency": {
+                "currency": "USD",
+                "defaultFractionDigits": 2,
+                "currencyCode": "USD",
+                "symbol": "$"
+              }
+            },
+            "container": {
+              "id": "orcaFares",
+              "name": "electronic"
+            },
+            "category": {
+              "id": "orcaFares",
+              "name": "regular"
+            }
+          },
+          {
+            "id": "orcaFares:farePayment",
+            "name": "rideCost",
+            "amount": {
+              "cents": 0,
+              "currency": {
+                "currency": "USD",
+                "defaultFractionDigits": 2,
+                "currencyCode": "USD",
+                "symbol": "$"
+              }
+            },
+            "container": {
+              "id": "orcaFares",
+              "name": "cash"
+            },
+            "category": {
+              "id": "orcaFares",
+              "name": "regular"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "legs": [
+    {
+      "startTime": 1674505485000,
+      "endTime": 1674506100000,
+      "departureDelay": 0,
+      "arrivalDelay": 0,
+      "realTime": false,
+      "distance": 802.9,
+      "generalizedCost": 1204,
+      "pathway": false,
+      "mode": "WALK",
+      "transitLeg": false,
+      "route": "",
+      "agencyTimeZoneOffset": -28800000,
+      "interlineWithPreviousLeg": false,
+      "from": {
+        "name": "47.83549, -122.31293",
+        "lon": -122.3129313,
+        "lat": 47.8354853,
+        "departure": 1674505485000,
+        "vertexType": "NORMAL"
+      },
+      "to": {
+        "name": "Hwy 99 & 180th St SW",
+        "stopId": "CommTrans:1521",
+        "stopCode": "1521",
+        "lon": -122.303382,
+        "lat": 47.834973,
+        "arrival": 1674506100000,
+        "departure": 1674506100000,
+        "vertexType": "TRANSIT"
+      },
+      "legGeometry": {
+        "points": "u{}bHxfpiV?q@@eE?wG?_D?Y@o@?kCBqF?{D@qI?qA?c@?qA?i@?IZWB?d@ZBAPa@b@^EL",
+        "length": 23
+      },
+      "steps": [
+        {
+          "distance": 717.88,
+          "relativeDirection": "DEPART",
+          "streetName": "180th Street Southwest",
+          "absoluteDirection": "EAST",
+          "stayOn": false,
+          "area": false,
+          "bogusName": false,
+          "lon": -122.3129292,
+          "lat": 47.8356351,
+          "elevation": "",
+          "walkingBike": false
+        },
+        {
+          "distance": 62.21,
+          "relativeDirection": "RIGHT",
+          "streetName": "service road",
+          "absoluteDirection": "SOUTHEAST",
+          "stayOn": false,
+          "area": false,
+          "bogusName": true,
+          "lon": -122.3033119,
+          "lat": 47.8355803,
+          "elevation": "",
+          "walkingBike": false
+        },
+        {
+          "distance": 22.81,
+          "relativeDirection": "RIGHT",
+          "streetName": "Highway 99",
+          "absoluteDirection": "SOUTHWEST",
+          "stayOn": false,
+          "area": false,
+          "bogusName": false,
+          "lon": -122.3031554,
+          "lat": 47.8351213,
+          "elevation": "",
+          "walkingBike": false
+        }
+      ],
+      "rentedBike": false,
+      "walkingBike": false,
+      "duration": 615
+    },
+    {
+      "startTime": 1674506100000,
+      "endTime": 1674507660000,
+      "departureDelay": 0,
+      "arrivalDelay": 0,
+      "realTime": false,
+      "distance": 7813.43,
+      "generalizedCost": 2160,
+      "pathway": false,
+      "mode": "BUS",
+      "transitLeg": true,
+      "route": "Mariner P&R - Aurora Village",
+      "agencyName": "Community Transit",
+      "agencyUrl": "http://www.communitytransit.org/",
+      "agencyTimeZoneOffset": -28800000,
+      "routeColor": "0070c0",
+      "routeType": 3,
+      "routeId": "CommTrans:101",
+      "routeTextColor": "ffffff",
+      "interlineWithPreviousLeg": false,
+      "tripBlockId": "MCOB-DO:123:0:Weekday:1:22SEP:41028:12345",
+      "headsign": "Aurora Village",
+      "agencyId": "CommTrans:29",
+      "tripId": "CommTrans:10499096__MCOB-DO:123:0:Weekday:1:22SEP:41028:12345",
+      "serviceDate": "2023-01-23",
+      "from": {
+        "name": "Hwy 99 & 180th St SW",
+        "stopId": "CommTrans:1521",
+        "stopCode": "1521",
+        "lon": -122.303382,
+        "lat": 47.834973,
+        "arrival": 1674506100000,
+        "departure": 1674506100000,
+        "stopIndex": 16,
+        "stopSequence": 17,
+        "vertexType": "TRANSIT"
+      },
+      "to": {
+        "name": "Aurora Village Transit Center",
+        "stopId": "CommTrans:2877",
+        "stopCode": "2877",
+        "lon": -122.34277,
+        "lat": 47.77435,
+        "arrival": 1674507660000,
+        "departure": 1674507660000,
+        "stopIndex": 30,
+        "stopSequence": 31,
+        "vertexType": "TRANSIT"
+      },
+      "intermediateStops": [
+        {
+          "name": "Hwy 99 & 188th St SW",
+          "stopId": "CommTrans:1502",
+          "stopCode": "1502",
+          "lon": -122.309711,
+          "lat": 47.827669,
+          "arrival": 1674506220000,
+          "departure": 1674506220000,
+          "stopIndex": 17,
+          "stopSequence": 18,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Hwy 99 & 60th Ave W",
+          "stopId": "CommTrans:1495",
+          "stopCode": "1495",
+          "lon": -122.312185,
+          "lat": 47.824801,
+          "arrival": 1674506280000,
+          "departure": 1674506280000,
+          "stopIndex": 18,
+          "stopSequence": 19,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Hwy 99 & 196th St SW",
+          "stopId": "CommTrans:1503",
+          "stopCode": "1503",
+          "lon": -122.31592,
+          "lat": 47.820482,
+          "arrival": 1674506340000,
+          "departure": 1674506340000,
+          "stopIndex": 19,
+          "stopSequence": 20,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Hwy 99 & 200th St SW",
+          "stopId": "CommTrans:1504",
+          "stopCode": "1504",
+          "lon": -122.318702,
+          "lat": 47.81725,
+          "arrival": 1674506340000,
+          "departure": 1674506340000,
+          "stopIndex": 20,
+          "stopSequence": 21,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Hwy 99 & 202nd St SW",
+          "stopId": "CommTrans:1505",
+          "stopCode": "1505",
+          "lon": -122.320426,
+          "lat": 47.815264,
+          "arrival": 1674506400000,
+          "departure": 1674506400000,
+          "stopIndex": 21,
+          "stopSequence": 22,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Hwy 99 & 208th St SW",
+          "stopId": "CommTrans:1506",
+          "stopCode": "1506",
+          "lon": -122.324693,
+          "lat": 47.809703,
+          "arrival": 1674506520000,
+          "departure": 1674506520000,
+          "stopIndex": 22,
+          "stopSequence": 23,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Hwy 99 & 212th St SW",
+          "stopId": "CommTrans:1507",
+          "stopCode": "1507",
+          "lon": -122.327809,
+          "lat": 47.805379,
+          "arrival": 1674506580000,
+          "departure": 1674506580000,
+          "stopIndex": 23,
+          "stopSequence": 24,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Hwy 99 & 216th St SW",
+          "stopId": "CommTrans:1508",
+          "stopCode": "1508",
+          "lon": -122.329866,
+          "lat": 47.802523,
+          "arrival": 1674506640000,
+          "departure": 1674506640000,
+          "stopIndex": 24,
+          "stopSequence": 25,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Hwy 99 & 220th St SW",
+          "stopId": "CommTrans:1509",
+          "stopCode": "1509",
+          "lon": -122.332468,
+          "lat": 47.798918,
+          "arrival": 1674506700000,
+          "departure": 1674506700000,
+          "stopIndex": 25,
+          "stopSequence": 26,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Hwy 99 & 224th St SW",
+          "stopId": "CommTrans:1510",
+          "stopCode": "1510",
+          "lon": -122.334893,
+          "lat": 47.795549,
+          "arrival": 1674506820000,
+          "departure": 1674506820000,
+          "stopIndex": 26,
+          "stopSequence": 27,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Hwy 99 & 230th St SW",
+          "stopId": "CommTrans:1511",
+          "stopCode": "1511",
+          "lon": -122.338743,
+          "lat": 47.790207,
+          "arrival": 1674507000000,
+          "departure": 1674507000000,
+          "stopIndex": 27,
+          "stopSequence": 28,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Hwy 99 & 238th St SW",
+          "stopId": "CommTrans:1517",
+          "stopCode": "1517",
+          "lon": -122.343432,
+          "lat": 47.783697,
+          "arrival": 1674507240000,
+          "departure": 1674507240000,
+          "stopIndex": 28,
+          "stopSequence": 29,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Hwy 99 & N 205th St",
+          "stopId": "CommTrans:2089",
+          "stopCode": "2089",
+          "lon": -122.346379,
+          "lat": 47.777264,
+          "arrival": 1674507420000,
+          "departure": 1674507420000,
+          "stopIndex": 29,
+          "stopSequence": 30,
+          "vertexType": "TRANSIT"
+        }
+      ],
+      "legGeometry": {
+        "points": "ew}bHfjniVj@d@JHLJPNTRb@^h@b@XThA~@n@h@j@d@l@f@VTd@^v@n@RPZVNLVRZVLJrAfAd@`@z@r@^Zf@`@LJbAz@dCrBj@d@ZV~ApA`BtATP\\X??NLNJ^ZPNb@\\HFRPl@f@NL`@^NLn@f@`@\\RPf@`@jA`Ad@^t@l@@@??t@n@JHRP^ZZVHFNLNLb@\\PNJHTRPLd@^TPd@^VRPNVTXTd@^n@h@^Zb@^fA|@bAz@pAdABB??HFh@b@dA|@TPHFXT|@t@ZVPNl@f@f@`@LJ`@Zl@h@n@h@t@l@\\Vn@h@??|@t@b@^f@`@VTNLNJnAbArAhATRNL??LJHF\\XLJf@`@LJTRzAnAf@^RNNJNJ`@ZLHh@`@JHRLf@\\LHdAp@PLf@Zr@d@PJv@f@HFb@XXRrAz@`@Vv@f@\\TXRLHLHLHFD??B@n@b@LHJHb@Xp@b@NJfAp@HF\\TRLl@^\\TTN\\Td@XXPv@f@xA`Aj@^PJn@b@p@b@TN`@V??zA`ADBLHb@ZTNHFl@^HFVNXP\\T^Th@\\\\TfAt@x@h@HFHF??VNNHTNZRj@^d@ZjAv@bAn@bAn@FDxBvAt@d@bAn@JFNJNHh@^??l@^hAt@t@d@NJ^T`@VTNXPn@b@r@f@LHHF|@j@ZTv@f@vA|@JF??BBVNZRd@Zb@XTNXPf@\\TLb@XdAr@zA`ARLj@`@PLh@\\VNf@\\hAt@RLTLTNTNLHLHRLPLTNdAp@h@\\pAx@??FDb@XLHZR~@l@^V`BdANJd@Z`An@VNZR^V\\TZRjBjAfAr@d@Z`GxD^VXPNJh@Zt@d@z@j@b@XJHDB??fAr@`Al@VPTNZRTNPLHFJHNJNLPLLJ\\VLJt@l@b@\\RP`@Z\\VXRXPd@VPJTJRHPFZJVHXHVFPDRD`@FXB\\@X@^?T?hAEz@GdAILATA??f@Cb@ANAjACr@Cr@AX?R?P?VAX?l@?T?f@?T?|AAH?BqBAg@?{A?m@?c@?iB?u@?yCe@??K",
+        "length": 368
+      },
+      "steps": [],
+      "routeShortName": "101",
+      "routeLongName": "Mariner P&R - Aurora Village",
+      "duration": 1560
+    },
+    {
+      "startTime": 1674507660000,
+      "endTime": 1674507707000,
+      "departureDelay": 0,
+      "arrivalDelay": 0,
+      "realTime": false,
+      "distance": 38.11,
+      "generalizedCost": 67,
+      "pathway": false,
+      "mode": "WALK",
+      "transitLeg": false,
+      "route": "",
+      "agencyTimeZoneOffset": -28800000,
+      "interlineWithPreviousLeg": false,
+      "from": {
+        "name": "Aurora Village Transit Center",
+        "stopId": "CommTrans:2877",
+        "stopCode": "2877",
+        "lon": -122.34277,
+        "lat": 47.77435,
+        "arrival": 1674507660000,
+        "departure": 1674507660000,
+        "vertexType": "TRANSIT"
+      },
+      "to": {
+        "name": "Aurora Village Transit Center - Bay 10",
+        "stopId": "kcm:16100",
+        "stopCode": "16100",
+        "lon": -122.342407,
+        "lat": 47.7742424,
+        "arrival": 1674507707000,
+        "departure": 1674508020000,
+        "zoneId": "18",
+        "vertexType": "TRANSIT"
+      },
+      "legGeometry": {
+        "points": "u|qbHhaviV??R??]@C?A@C?C?ACI?O@?",
+        "length": 12
+      },
+      "steps": [
+        {
+          "distance": 10.22,
+          "relativeDirection": "DEPART",
+          "streetName": "service road",
+          "absoluteDirection": "SOUTH",
+          "stayOn": false,
+          "area": false,
+          "bogusName": true,
+          "lon": -122.3427609,
+          "lat": 47.77435,
+          "elevation": "",
+          "walkingBike": false
+        },
+        {
+          "distance": 11.17,
+          "relativeDirection": "LEFT",
+          "streetName": "path",
+          "absoluteDirection": "EAST",
+          "stayOn": true,
+          "area": false,
+          "bogusName": true,
+          "lon": -122.3427605,
+          "lat": 47.7742581,
+          "elevation": "",
+          "walkingBike": false
+        },
+        {
+          "distance": 16.73,
+          "relativeDirection": "RIGHT",
+          "streetName": "open area",
+          "absoluteDirection": "SOUTHEAST",
+          "stayOn": true,
+          "area": true,
+          "bogusName": true,
+          "lon": -122.3426111,
+          "lat": 47.7742565,
+          "elevation": "",
+          "walkingBike": false
+        }
+      ],
+      "rentedBike": false,
+      "walkingBike": false,
+      "duration": 47
+    },
+    {
+      "startTime": 1674508020000,
+      "endTime": 1674508800000,
+      "departureDelay": 0,
+      "arrivalDelay": 0,
+      "realTime": false,
+      "distance": 4792.95,
+      "generalizedCost": 1693,
+      "pathway": false,
+      "mode": "BUS",
+      "transitLeg": true,
+      "agencyName": "Metro Transit",
+      "agencyUrl": "http://metro.kingcounty.gov",
+      "agencyTimeZoneOffset": -28800000,
+      "routeType": 3,
+      "routeId": "kcm:102615",
+      "interlineWithPreviousLeg": false,
+      "tripShortName": "LOCAL",
+      "tripBlockId": "6649263",
+      "headsign": "Downtown Seattle",
+      "agencyId": "kcm:1",
+      "tripId": "kcm:585679422",
+      "serviceDate": "2023-01-23",
+      "from": {
+        "name": "Aurora Village Transit Center - Bay 10",
+        "stopId": "kcm:16100",
+        "stopCode": "16100",
+        "lon": -122.342407,
+        "lat": 47.7742424,
+        "arrival": 1674507707000,
+        "departure": 1674508020000,
+        "zoneId": "18",
+        "stopIndex": 0,
+        "stopSequence": 1,
+        "vertexType": "TRANSIT"
+      },
+      "to": {
+        "name": "Aurora Ave N & N 145th St",
+        "stopId": "kcm:6950",
+        "stopCode": "6950",
+        "lon": -122.345268,
+        "lat": 47.7335701,
+        "arrival": 1674508800000,
+        "departure": 1674508800000,
+        "zoneId": "20",
+        "stopIndex": 11,
+        "stopSequence": 84,
+        "vertexType": "TRANSIT"
+      },
+      "intermediateStops": [
+        {
+          "name": "Aurora Ave N & N 200th St",
+          "stopId": "kcm:75700",
+          "stopCode": "75700",
+          "lon": -122.346207,
+          "lat": 47.7737427,
+          "arrival": 1674508073000,
+          "departure": 1674508073000,
+          "zoneId": "18",
+          "stopIndex": 1,
+          "stopSequence": 6,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Aurora Ave N & N 192nd St",
+          "stopId": "kcm:75730",
+          "stopCode": "75730",
+          "lon": -122.3461,
+          "lat": 47.7672043,
+          "arrival": 1674508191000,
+          "departure": 1674508191000,
+          "zoneId": "18",
+          "stopIndex": 2,
+          "stopSequence": 13,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Aurora Ave N & N 185th St",
+          "stopId": "kcm:75740",
+          "stopCode": "75740",
+          "lon": -122.346184,
+          "lat": 47.7628479,
+          "arrival": 1674508270000,
+          "departure": 1674508270000,
+          "zoneId": "18",
+          "stopIndex": 3,
+          "stopSequence": 22,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Aurora Ave N & N 180th St",
+          "stopId": "kcm:75750",
+          "stopCode": "75750",
+          "lon": -122.346237,
+          "lat": 47.7594452,
+          "arrival": 1674508331000,
+          "departure": 1674508331000,
+          "zoneId": "18",
+          "stopIndex": 4,
+          "stopSequence": 32,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Aurora Ave N & N 175th St",
+          "stopId": "kcm:75760",
+          "stopCode": "75760",
+          "lon": -122.345856,
+          "lat": 47.7552986,
+          "arrival": 1674508407000,
+          "departure": 1674508407000,
+          "zoneId": "18",
+          "stopIndex": 5,
+          "stopSequence": 40,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Aurora Ave N & N 170th St",
+          "stopId": "kcm:75770",
+          "stopCode": "75770",
+          "lon": -122.345741,
+          "lat": 47.7520294,
+          "arrival": 1674508466000,
+          "departure": 1674508466000,
+          "zoneId": "18",
+          "stopIndex": 6,
+          "stopSequence": 48,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Aurora Ave N & N 165th St",
+          "stopId": "kcm:75780",
+          "stopCode": "75780",
+          "lon": -122.345688,
+          "lat": 47.7483559,
+          "arrival": 1674508532000,
+          "departure": 1674508532000,
+          "zoneId": "18",
+          "stopIndex": 7,
+          "stopSequence": 56,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Aurora Ave N & N 160th St",
+          "stopId": "kcm:75790",
+          "stopCode": "75790",
+          "lon": -122.34565,
+          "lat": 47.7446899,
+          "arrival": 1674508599000,
+          "departure": 1674508599000,
+          "zoneId": "18",
+          "stopIndex": 8,
+          "stopSequence": 66,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Aurora Ave N & N 155th St",
+          "stopId": "kcm:75800",
+          "stopCode": "75800",
+          "lon": -122.345497,
+          "lat": 47.7408867,
+          "arrival": 1674508668000,
+          "departure": 1674508668000,
+          "zoneId": "18",
+          "stopIndex": 9,
+          "stopSequence": 73,
+          "vertexType": "TRANSIT"
+        },
+        {
+          "name": "Aurora Ave N & N 152nd St",
+          "stopId": "kcm:75810",
+          "stopCode": "75810",
+          "lon": -122.345428,
+          "lat": 47.7386818,
+          "arrival": 1674508707000,
+          "departure": 1674508707000,
+          "zoneId": "18",
+          "stopIndex": 10,
+          "stopSequence": 75,
+          "vertexType": "TRANSIT"
+        }
+      ],
+      "legGeometry": {
+        "points": "q{qbH`_viV?`AB~R?b@\\Cr@???dB?rBE~@A`HA|IElGArBC??f@?`DBpA?fB?pA@r@BhDBdB@lA???~@BbDDr@?|BBxAB|@?v@?PCb@?HA??v@AtAIjBInBGn@AvAGhES~BM??TA`AE`AA`B?hACbDCfB?|@C??v@AxDCnAAhA?bB?pA?xAA`AA??l@?n@?r@?|@CxAAj@?pB@vA?vB?dAA??|CEv@?fAE`CIhA?~CEnBC??~JIt@A??vBEz@AZCrAApAEfBEvFCvDCrBA",
+        "length": 94
+      },
+      "steps": [],
+      "routeShortName": "E Line",
+      "duration": 780
+    },
+    {
+      "startTime": 1674508800000,
+      "endTime": 1674509068000,
+      "departureDelay": 0,
+      "arrivalDelay": 0,
+      "realTime": false,
+      "distance": 316.32,
+      "generalizedCost": 490,
+      "pathway": false,
+      "mode": "WALK",
+      "transitLeg": false,
+      "route": "",
+      "agencyTimeZoneOffset": -28800000,
+      "interlineWithPreviousLeg": false,
+      "from": {
+        "name": "Aurora Ave N & N 145th St",
+        "stopId": "kcm:6950",
+        "stopCode": "6950",
+        "lon": -122.345268,
+        "lat": 47.7335701,
+        "arrival": 1674508800000,
+        "departure": 1674508800000,
+        "zoneId": "20",
+        "vertexType": "TRANSIT"
+      },
+      "to": {
+        "name": "1318 North 145th Street, Seattle, WA, USA",
+        "lon": -122.3420287,
+        "lat": 47.7342206,
+        "arrival": 1674509068000,
+        "vertexType": "NORMAL"
+      },
+      "legGeometry": {
+        "points": "y}ibH|pviV@Be@?I??Q]?O?Q??c@?W?qB?aA?kA@e@AiEQ??Q@K?o@",
+        "length": 19
+      },
+      "steps": [
+        {
+          "distance": 26.16,
+          "relativeDirection": "DEPART",
+          "streetName": "sidewalk",
+          "absoluteDirection": "NORTH",
+          "stayOn": false,
+          "area": false,
+          "bogusName": true,
+          "lon": -122.3452855,
+          "lat": 47.73357,
+          "elevation": "",
+          "walkingBike": false
+        },
+        {
+          "distance": 7.06,
+          "relativeDirection": "RIGHT",
+          "streetName": "service road",
+          "absoluteDirection": "EAST",
+          "stayOn": true,
+          "area": false,
+          "bogusName": true,
+          "lon": -122.3452885,
+          "lat": 47.7338053,
+          "elevation": "",
+          "walkingBike": false
+        },
+        {
+          "distance": 35.59,
+          "relativeDirection": "LEFT",
+          "streetName": "Aurora Avenue North",
+          "absoluteDirection": "NORTH",
+          "stayOn": false,
+          "area": false,
+          "bogusName": false,
+          "lon": -122.3451941,
+          "lat": 47.7338066,
+          "elevation": "",
+          "walkingBike": false
+        },
+        {
+          "distance": 207.88,
+          "relativeDirection": "RIGHT",
+          "streetName": "North 145th Street",
+          "absoluteDirection": "EAST",
+          "stayOn": false,
+          "area": false,
+          "bogusName": false,
+          "lon": -122.3451971,
+          "lat": 47.7341266,
+          "elevation": "",
+          "walkingBike": false
+        },
+        {
+          "distance": 10.3,
+          "relativeDirection": "LEFT",
+          "streetName": "Stone Avenue North",
+          "absoluteDirection": "NORTH",
+          "stayOn": false,
+          "area": false,
+          "bogusName": false,
+          "lon": -122.3424174,
+          "lat": 47.7341208,
+          "elevation": "",
+          "walkingBike": false
+        },
+        {
+          "distance": 29.32,
+          "relativeDirection": "RIGHT",
+          "streetName": "path",
+          "absoluteDirection": "EAST",
+          "stayOn": false,
+          "area": false,
+          "bogusName": true,
+          "lon": -122.3424186,
+          "lat": 47.7342134,
+          "elevation": "",
+          "walkingBike": false
+        }
+      ],
+      "rentedBike": false,
+      "walkingBike": false,
+      "duration": 268
+    }
+  ],
+  "tooSloped": false,
+  "arrivedAtDestinationWithRentedBicycle": false
+}

--- a/packages/trip-details/i18n/en-US.yml
+++ b/packages/trip-details/i18n/en-US.yml
@@ -39,4 +39,4 @@ otpUi:
       electronic: "Electronic"
       cash: "Cash"
       special: "Special"
-    transferDiscountExplanation: Transfer discount of {transferAmount} is applied.
+    transferDiscountExplanation: Transfer discount of {transferAmount} is applied

--- a/packages/trip-details/i18n/en-US.yml
+++ b/packages/trip-details/i18n/en-US.yml
@@ -37,3 +37,4 @@ otpUi:
       electronic: "Electronic"
       cash: "Cash"
       special: "Special"
+    transferDiscountExplanation: Transfer discount of {transferAmount} is applied.

--- a/packages/trip-details/src/TripDetails.story.tsx
+++ b/packages/trip-details/src/TripDetails.story.tsx
@@ -353,9 +353,7 @@ export const FareLegTableStory = (): ReactElement => {
   return (
     <FareLegTable
       layout={fareByLegLayout}
-      legs={walkInterlinedTransitItinerary.legs}
-      transitFareDetails={walkInterlinedTransitItinerary.fare?.details}
-      transitFares={walkInterlinedTransitItinerary.fare?.fare}
+      itinerary={walkInterlinedTransitItinerary}
     />
   );
 };

--- a/packages/trip-details/src/TripDetails.story.tsx
+++ b/packages/trip-details/src/TripDetails.story.tsx
@@ -40,6 +40,7 @@ const walkTransitWalkTransitWalkItinerary = require("@opentripplanner/itinerary-
 const fareComponentsItinerary = require("@opentripplanner/itinerary-body/src/__mocks__/itineraries/fare-components.json");
 const flexItinerary = require("@opentripplanner/itinerary-body/src/__mocks__/itineraries/flex-itinerary.json");
 const otp2ScooterItinerary = require("@opentripplanner/itinerary-body/src/__mocks__/itineraries/otp2-scooter.json");
+const otp2FareProducts = require("@opentripplanner/itinerary-body/src/__mocks__/itineraries/otp2-with-fareproducts.json");
 
 const flattenedEnglishMessages = flatten(customEnglishMessages);
 const flattenedFrenchMessages = flatten(customFrenchMessages);
@@ -56,6 +57,58 @@ const StyledTripDetails = styled(TripDetails)`
   }
 `;
 
+const otp2FareByLegLayout: FareTableLayout[] = [
+  {
+    header: "regular" as FareTableText,
+    cols: [
+      {
+        header: "cash" as FareTableText,
+        riderCategory: "regular",
+        fareContainer: "cash"
+      },
+      {
+        header: "electronic" as FareTableText,
+        riderCategory: "regular",
+        fareContainer: "electronic"
+      },
+      {
+        header: "special" as FareTableText,
+        riderCategory: "special",
+        fareContainer: "electronic"
+      }
+    ]
+  },
+  {
+    header: "youth" as FareTableText,
+    cols: [
+      {
+        header: "cash" as FareTableText,
+        riderCategory: "youth",
+        fareContainer: "cash"
+      },
+      {
+        header: "electronic" as FareTableText,
+        riderCategory: "youth",
+        fareContainer: "electronic"
+      }
+    ]
+  },
+  {
+    header: "senior" as FareTableText,
+    cols: [
+      {
+        header: "cash" as FareTableText,
+        riderCategory: "senior",
+        fareContainer: "cash"
+      },
+      {
+        header: "electronic" as FareTableText,
+        riderCategory: "senior",
+        fareContainer: "electronic"
+      }
+    ]
+  }
+];
 const fareByLegLayout: FareTableLayout[] = [
   {
     header: "regular" as FareTableText,
@@ -355,5 +408,11 @@ export const FareLegTableStory = (): ReactElement => {
       layout={fareByLegLayout}
       itinerary={walkInterlinedTransitItinerary}
     />
+  );
+};
+
+export const FareLegTableStoryLegProducts = (): ReactElement => {
+  return (
+    <FareLegTable layout={otp2FareByLegLayout} itinerary={otp2FareProducts} />
   );
 };

--- a/packages/trip-details/src/fare-table.tsx
+++ b/packages/trip-details/src/fare-table.tsx
@@ -96,16 +96,9 @@ const FareTypeTable = ({
             {boldText(getFormattedTextForConfigKey(header))}
           </th>
           {colsToRender.map(col => {
-            let fare;
-            if (!hasLegProducts) {
-              fare = fareTotals[col.key];
-            } else {
-              fare = getItineraryCost(
-                legs,
-                col.riderCategory,
-                col.fareContainer
-              );
-            }
+            const fare = hasLegProducts
+              ? getItineraryCost(legs, col.riderCategory, col.fareContainer)
+              : fareTotals[col.key];
             return (
               <th key={col.key || `${col.fareContainer}-${col.riderCategory}`}>
                 {boldText(getFormattedTextForConfigKey(col.header))}
@@ -122,17 +115,15 @@ const FareTypeTable = ({
           <tr key={index}>
             <td className="no-zebra">{leg.routeShortName}</td>
             {colsToRender.map(col => {
-              let fare;
-              if (!hasLegProducts) {
-                fare = leg.fares[col.key];
-              } else {
-                fare = getLegCost(leg, col.riderCategory, col.fareContainer);
-              }
+              const fare = hasLegProducts
+                ? getLegCost(leg, col.riderCategory, col.fareContainer)
+                : leg.fares[col.key];
+
               return (
                 <td
                   key={col.key}
                   title={
-                    fare.transferAmount &&
+                    "transferAmount" in fare &&
                     intl.formatMessage(
                       {
                         defaultMessage:
@@ -156,7 +147,8 @@ const FareTypeTable = ({
                     )
                   }
                 >
-                  {(fare?.isTransfer || fare.transferAmount) && (
+                  {(("isTransfer" in fare && fare?.isTransfer) ||
+                    "transferAmount" in fare) && (
                     <>
                       <TransferIcon size={16} />{" "}
                     </>

--- a/packages/trip-details/src/fare-table.tsx
+++ b/packages/trip-details/src/fare-table.tsx
@@ -69,7 +69,12 @@ const FareTypeTable = ({
   legs,
   hasLegProducts
 }: FareTypeTableProps): JSX.Element => {
-  const colsToRender = cols.filter(col => fareTotals[col.key]);
+  const colsToRender = cols.filter(col =>
+    hasLegProducts
+      ? getItineraryCost(legs, col.riderCategory, col.fareContainer)
+      : fareTotals[col.key]
+  );
+
   if (colsToRender.length) {
     return (
       <Table>
@@ -79,7 +84,7 @@ const FareTypeTable = ({
           </th>
           {colsToRender.map(col => {
             let fare;
-            if (hasLegProducts) {
+            if (!hasLegProducts) {
               fare = fareTotals[col.key];
             } else {
               fare = getItineraryCost(
@@ -89,7 +94,7 @@ const FareTypeTable = ({
               );
             }
             return (
-              <th key={col.key}>
+              <th key={col.key || `${col.fareContainer}-${col.riderCategory}`}>
                 {boldText(getFormattedTextForConfigKey(col.header))}
                 <br />
                 {renderFare(
@@ -158,7 +163,7 @@ const FareLegDetails = ({
       .filter(leg => leg.transitLeg);
   } else {
     // OTP2 Logic
-    legsWithFares = getLegsWithFares(itinerary);
+    legsWithFares = getLegsWithFares(itinerary).filter(leg => leg.transitLeg);
   }
 
   return (

--- a/packages/trip-details/src/fare-table.tsx
+++ b/packages/trip-details/src/fare-table.tsx
@@ -156,12 +156,14 @@ const FareTypeTable = ({
                     )
                   }
                 >
+                  {(fare?.isTransfer || fare.transferAmount) && (
+                    <>
+                      <TransferIcon size={16} />{" "}
+                    </>
+                  )}
                   {renderFare(
                     fare?.price?.currency?.currencyCode,
                     (fare?.price?.cents || 0) / 100
-                  )}
-                  {(fare?.isTransfer || fare.transferAmount) && (
-                    <TransferIcon size={16} />
                   )}
                 </td>
               );

--- a/packages/trip-details/src/index.tsx
+++ b/packages/trip-details/src/index.tsx
@@ -131,7 +131,6 @@ export function TripDetails({
   const fareResult = coreUtils.itinerary.calculateTncFares(itinerary);
   const { currencyCode, maxTNCFare, minTNCFare } = fareResult;
   const transitFares = itinerary?.fare?.fare;
-  const fareDetails = itinerary.fare?.details;
 
   let companies = "";
   itinerary.legs.forEach(leg => {
@@ -174,12 +173,7 @@ export function TripDetails({
           </summary>
           {fareDetailsLayout ? (
             // Show full ƒare details by leg
-            <FareLegTable
-              layout={fareDetailsLayout}
-              legs={itinerary.legs}
-              transitFareDetails={fareDetails}
-              transitFares={transitFares}
-            />
+            <FareLegTable layout={fareDetailsLayout} itinerary={itinerary} />
           ) : (
             // Just show the fares for each payment type
             fareKeys.map(fareKey => {

--- a/packages/trip-details/src/types.ts
+++ b/packages/trip-details/src/types.ts
@@ -1,6 +1,6 @@
 // Prettier does not recognize the import type syntax.
 // eslint-disable-next-line prettier/prettier
-import type { FareDetails, Money, Itinerary, Leg, Fare, } from "@opentripplanner/types";
+import type {  Money, Itinerary, Fare, } from "@opentripplanner/types";
 import type { ReactElement } from "react";
 
 export interface CaloriesDetailsProps {
@@ -31,7 +31,9 @@ export enum FareTableText {
 export interface FareTableLayout {
   cols: {
     header: FareTableText;
-    key: string;
+    key?: string;
+    riderCategory?: string;
+    fareContainer?: string;
   }[];
   header: FareTableText;
 }
@@ -47,9 +49,7 @@ export interface FareDetailsProps {
 
 export interface FareLegTableProps {
   layout?: FareTableLayout[];
-  legs?: Leg[];
-  transitFareDetails?: FareDetails;
-  transitFares?: TransitFareData;
+  itinerary: Itinerary;
 }
 
 export interface TransitFareProps {

--- a/packages/trip-details/src/utils.tsx
+++ b/packages/trip-details/src/utils.tsx
@@ -1,5 +1,16 @@
 import React, { ReactElement } from "react";
-import { FormattedNumber } from "react-intl";
+import { FormattedMessage, FormattedNumber } from "react-intl";
+import { flatten } from "flat";
+import { FareTableText } from "./types";
+
+// Load the default messages.
+import defaultEnglishMessages from "../i18n/en-US.yml";
+
+// HACK: We should flatten the messages loaded above because
+// the YAML loaders behave differently between webpack and our version of jest:
+// - the yaml loader for webpack returns a nested object,
+// - the yaml loader for jest returns messages with flattened ids.
+const defaultMessages: Record<string, string> = flatten(defaultEnglishMessages);
 
 /**
  * Format text bold (used with FormattedMessage).
@@ -28,3 +39,63 @@ export function renderFare(currencyCode: string, fare: number): ReactElement {
     />
   );
 }
+
+export const getFormattedTextForConfigKey = (textKey: FareTableText) => {
+  switch (textKey) {
+    case FareTableText.cash:
+      return (
+        <FormattedMessage
+          defaultMessage={
+            defaultMessages["otpUi.TripDetails.fareDetailsHeaders.cash"]
+          }
+          id="otpUi.TripDetails.fareDetailsHeaders.cash"
+        />
+      );
+    case FareTableText.electronic:
+      return (
+        <FormattedMessage
+          defaultMessage={
+            defaultMessages["otpUi.TripDetails.fareDetailsHeaders.electronic"]
+          }
+          id="otpUi.TripDetails.fareDetailsHeaders.electronic"
+        />
+      );
+    case FareTableText.youth:
+      return (
+        <FormattedMessage
+          defaultMessage={
+            defaultMessages["otpUi.TripDetails.fareDetailsHeaders.youth"]
+          }
+          id="otpUi.TripDetails.fareDetailsHeaders.youth"
+        />
+      );
+    case FareTableText.senior:
+      return (
+        <FormattedMessage
+          defaultMessage={
+            defaultMessages["otpUi.TripDetails.fareDetailsHeaders.senior"]
+          }
+          id="otpUi.TripDetails.fareDetailsHeaders.senior"
+        />
+      );
+    case FareTableText.special:
+      return (
+        <FormattedMessage
+          defaultMessage={
+            defaultMessages["otpUi.TripDetails.fareDetailsHeaders.special"]
+          }
+          id="otpUi.TripDetails.fareDetailsHeaders.special"
+        />
+      );
+    case FareTableText.regular:
+    default:
+      return (
+        <FormattedMessage
+          defaultMessage={
+            defaultMessages["otpUi.TripDetails.fareDetailsHeaders.regular"]
+          }
+          id="otpUi.TripDetails.fareDetailsHeaders.regular"
+        />
+      );
+  }
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -718,6 +718,6 @@ export type FareProduct = {
 };
 
 export type LegProduct = {
-  legIndicies: Array<number>;
+  legIndices: Array<number>;
   products: Array<FareProduct>;
 };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -333,6 +333,11 @@ export type Leg = {
   tripBlockId?: string;
   tripId?: string;
   walkingBike?: boolean;
+  /**
+   * Below this are extra properties added in OTP-RR
+   * They are not returned in the API response
+   */
+  fareProducts?: Array<FareProduct>;
 };
 
 /**
@@ -374,6 +379,7 @@ export type FareDetails = Record<string, FareDetail[]>;
 export type Fare = {
   details?: FareDetails;
   fare?: Record<string, Money>;
+  legProducts?: Array<LegProduct>;
 };
 
 /**
@@ -696,3 +702,22 @@ export type GradationMap = Record<
   number,
   { color: string; icon?: ReactElement; text?: string }
 >;
+
+export type FareProduct = {
+  amount: Money;
+  id: string;
+  name: string;
+  category: {
+    id: string;
+    name: string;
+  };
+  container: {
+    id: string;
+    name: string;
+  };
+};
+
+export type LegProduct = {
+  legIndicies: Array<number>;
+  products: Array<FareProduct>;
+};


### PR DESCRIPTION
This PR adds support for the new fare by leg structure in OTP2. 
The fundamental thing to understand here is that each fare product used for a leg is stored under legProducts, along with the index of the leg it's associated with. An example itinerary was added to itinerary-body package for the story as well as to show an example of how it looks for review. 
This will be a lot more flexible in the future, and one way I took advantage of the new data is by adding a tooltip to the table cell explaining the transfer discount applied to a given fare. 

I tried to keep it so that in the future it will be easy to remove the OTP1 code. There is only one user of the OTP1 fare by leg, so once they upgrade, we can remove the code for that. 