### PR TITLE
Add OTP Geocoder

### DIFF
--- a/packages/geocoder/src/apis/otp/index.ts
+++ b/packages/geocoder/src/apis/otp/index.ts
@@ -1,6 +1,6 @@
 
 // eslint-disable-next-line prettier/prettier
-import type { AutocompleteQuery  } from "../../geocoders/types"
+import type { AutocompleteQuery } from "../../geocoders/types"
 
 type FetchArgs = {
   url: string
@@ -14,10 +14,10 @@ type OTPGeocoderResponse = {
     description: string,
     id: string
   }[]
-}
+} | undefined
 
 
-function run({  query, url }: FetchArgs): Promise<OTPGeocoderResponse> {
+function run({ query, url }: FetchArgs): Promise<OTPGeocoderResponse> {
   // TODO: Support corners/osm nodes?
   return fetch(`${url}/geocode?corners=false&query=${query}`)
     .then(res => res.text())
@@ -29,9 +29,9 @@ function run({  query, url }: FetchArgs): Promise<OTPGeocoderResponse> {
  * OTP Geocoder
  *
  * @param  {Object} $0
- * @param  {string} $0.url                    The OTP instance, ending with /default/
- * @param  {string} $0.text                       query
- * @return {Promise}                              A Promise that'll get resolved with the autocomplete result
+ * @param  {string} $0.url  The OTP instance, ending with /default/
+ * @param  {string} $0.text query
+ * @return {Promise}        A Promise that'll get resolved with the autocomplete result
  */
 async function autocomplete({
   url,
@@ -47,5 +47,5 @@ function search(): Promise<unknown> { console.warn("Not implemented"); return nu
 function reverse(): Promise<unknown> { console.warn("Not implemented"); return null }
 
 
-export { autocomplete, reverse, search,  };
+export { autocomplete, reverse, search };
 export type { OTPGeocoderResponse }

--- a/packages/geocoder/src/apis/otp/index.ts
+++ b/packages/geocoder/src/apis/otp/index.ts
@@ -1,0 +1,47 @@
+
+// eslint-disable-next-line prettier/prettier
+import type { AutocompleteQuery  } from "../../geocoders/types"
+
+type FetchArgs = {
+  url: string
+  query: string
+}
+
+type OTPGeocoderResponse = { results:{
+  lat: number,
+  lng: number,
+  description: string,
+  id: string
+}[] }
+
+
+function run({  query, url }: FetchArgs): Promise<OTPGeocoderResponse> {
+  // TODO: Support corners/osm nodes?
+  return fetch(`${url}/geocode?corners=false&query=${query}`).then(res => res.text()).then(res => JSON.parse(`{"results": ${res}}`));
+}
+
+/**
+ * Search for an address using
+ * OTP Geocoder
+ *
+ * @param  {Object} $0
+ * @param  {string} $0.url                    The OTP instance, ending with /default/
+ * @param  {string} $0.text                       query
+ * @return {Promise}                              A Promise that'll get resolved with the autocomplete result
+ */
+async function autocomplete({
+  url,
+  text
+}: AutocompleteQuery): Promise<OTPGeocoderResponse> {
+  return run({
+    query: text,
+    url
+  })
+}
+
+function search(): Promise<unknown> { console.warn("Not implemented"); return null }
+function reverse(): Promise<unknown> { console.warn("Not implemented"); return null }
+
+
+export { autocomplete, reverse, search,  };
+export type { OTPGeocoderResponse }

--- a/packages/geocoder/src/apis/otp/index.ts
+++ b/packages/geocoder/src/apis/otp/index.ts
@@ -7,17 +7,21 @@ type FetchArgs = {
   query: string
 }
 
-type OTPGeocoderResponse = { results:{
-  lat: number,
-  lng: number,
-  description: string,
-  id: string
-}[] }
+type OTPGeocoderResponse = {
+  results: {
+    lat: number,
+    lng: number,
+    description: string,
+    id: string
+  }[]
+}
 
 
 function run({  query, url }: FetchArgs): Promise<OTPGeocoderResponse> {
   // TODO: Support corners/osm nodes?
-  return fetch(`${url}/geocode?corners=false&query=${query}`).then(res => res.text()).then(res => JSON.parse(`{"results": ${res}}`));
+  return fetch(`${url}/geocode?corners=false&query=${query}`)
+    .then(res => res.text())
+    .then(res => JSON.parse(`{"results": ${res}}`));
 }
 
 /**

--- a/packages/geocoder/src/geocoders/otp.ts
+++ b/packages/geocoder/src/geocoders/otp.ts
@@ -1,0 +1,37 @@
+// Prettier does not support typescript annotation
+// eslint-disable-next-line prettier/prettier
+import type { AutocompleteQuery, MultiGeocoderResponse } from "./types";
+
+import Geocoder from "./abstract-geocoder";
+import { OTPGeocoderResponse } from "../apis/otp";
+
+/**
+ * Allows fetching results from OTP instance with the geocoder endpoint enabled
+ */
+export default class OTPGeocoder extends Geocoder {
+  getAutocompleteQuery(query: AutocompleteQuery): AutocompleteQuery {
+    const {
+      baseUrl,
+    } = this.geocoderConfig;
+    return {
+      url: baseUrl,
+      ...query
+    };
+  }
+
+
+  rewriteAutocompleteResponse(response: OTPGeocoderResponse): MultiGeocoderResponse {
+    return {
+        features: response?.results?.map(stop => ({
+            geometry: { type: "Point", coordinates: [stop.lng, stop.lat] },
+            id: stop.id, 
+            // TODO: if non-stops are supported, these need to be detected here and 
+            // this layer property updated accordingly
+            properties: { layer: "stops", source: "otp", name: stop.description, label: stop.description }, 
+            type: "Feature"
+        })),
+      type: "FeatureCollection"
+    };
+  }
+
+}

--- a/packages/geocoder/src/index.story.tsx
+++ b/packages/geocoder/src/index.story.tsx
@@ -28,6 +28,8 @@ const GeocoderTester = ({
   const [enableGeocodeEarth, setEnableGeocodeEarth] = useState(true);
   const [enableHere, setEnableHere] = useState(true);
   const [enablePhoton, setEnablePhoton] = useState(true);
+  const [enableOtp, setEnableOtp] = useState(false);
+  const [otpHost, setOtpHost] = useState("");
   const [
     reverseUseFeatureCollection,
     setReverseUseFeatureCollection
@@ -57,6 +59,12 @@ const GeocoderTester = ({
     type: "PHOTON"
   });
 
+  const otpGeocoder = getGeocoder({
+    baseUrl: otpHost,
+    size: 1,
+    type: "OTP"
+  });
+
   const searchObj: AnyGeocoderQuery = {
     text: searchTerm
   };
@@ -77,15 +85,29 @@ const GeocoderTester = ({
     const photonRes = enablePhoton
       ? await photonGeocoder[endpoint](searchObj)
       : null;
+    const otpRes = enableOtp ? await otpGeocoder[endpoint](searchObj) : null;
     onResults({
       hereRes,
       peliasRes,
-      photonRes
+      photonRes,
+      otpRes
     });
   };
 
   return (
     <div>
+      {endpoint === "autocomplete" && (
+        <div>
+          <label htmlFor="otpHost">
+            OTP Host (ending with{" "}
+            <pre style={{ display: "inline" }}>/router/default</pre>)
+          </label>
+          <input
+            id="otpHost"
+            onChange={e => setOtpHost(e.target.value)}
+          ></input>
+        </div>
+      )}
       {/* Boundary Input */}
       {endpoint !== "reverse" && (
         <div>
@@ -216,6 +238,15 @@ const GeocoderTester = ({
             checked={enablePhoton}
             id="photon"
             onChange={e => setEnablePhoton(e.target.checked)}
+            type="checkbox"
+          />
+        </label>
+        <label htmlFor="otp">
+          OTP:
+          <input
+            checked={enableOtp}
+            id="otp"
+            onChange={e => setEnableOtp(e.target.checked)}
             type="checkbox"
           />
         </label>

--- a/packages/geocoder/src/index.ts
+++ b/packages/geocoder/src/index.ts
@@ -3,12 +3,14 @@ import * as pelias from "isomorphic-mapzen-search";
 import memoize from "lodash.memoize";
 import * as here from "./apis/here";
 import * as photon from "./apis/photon";
+import * as otp from "./apis/otp";
 
 import ArcGISGeocoder from "./geocoders/arcgis";
 import NoApiGeocoder from "./geocoders/noapi";
 import PeliasGeocoder from "./geocoders/pelias";
 import HereGeocoder from "./geocoders/here";
 import PhotonGeocoder from "./geocoders/photon";
+import OTPGeocoder from "./geocoders/otp";
 
 // Prettier does not support typescript annotation
 // eslint-disable-next-line prettier/prettier
@@ -29,6 +31,8 @@ const getGeocoder = memoize((geocoderConfig: GeocoderConfig & { type: string }) 
       return new HereGeocoder(here, geocoderConfig);
     case "PHOTON":
       return new PhotonGeocoder(photon, geocoderConfig);
+    case "OTP":
+      return new OTPGeocoder(otp, geocoderConfig);
     default:
       console.error(`Unknown geocoder type: "${type}". Using NoApiGeocoder.`);
       return new NoApiGeocoder();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2845,23 +2845,6 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
-"@opentripplanner/core-utils@^8.1.1":
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-8.1.1.tgz#434487a09605fd3c241d36993c63e0c2c965e6da"
-  integrity sha512-xQhc6uhdcGZR5HKfQclA4d2YDkUtBcCz+LnFGpXRSlkyJtXHkVs+Z+CsTK/GfNlnhmEoUcyrKN6yGA8xG0/1IA==
-  dependencies:
-    "@mapbox/polyline" "^1.1.0"
-    "@opentripplanner/geocoder" "^1.3.4"
-    "@styled-icons/foundation" "^10.34.0"
-    "@turf/along" "^6.0.1"
-    bowser "^2.7.0"
-    chroma-js "^2.4.2"
-    date-fns "^2.28.0"
-    date-fns-tz "^1.2.2"
-    lodash.clonedeep "^4.5.0"
-    lodash.isequal "^4.5.0"
-    qs "^6.9.1"
-
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.1":
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.4.tgz#df0d0d855fc527db48aac93c218a0bf4ada41f99"


### PR DESCRIPTION
OTP has a geocoder now! https://docs.opentripplanner.org/en/dev-2.x/sandbox/GeocoderAPI/

This PR lets you use it within otp-ui. Only the stops endpoint for now, as it would be a lot more work to get the rest of the layers to work (would have to parse the label strings) and they're not that high quality. ARCGIS provides better results without an API key.