### PR TITLE
Itinerary Body: correct stop viewer font size

### DIFF
--- a/packages/itinerary-body/src/styled.tsx
+++ b/packages/itinerary-body/src/styled.tsx
@@ -466,6 +466,7 @@ export const PlaceName = styled.span`
 
 export const PlaceSubheader = styled.div`
   color: #807373;
+  font-size: 13px;
   font-weight: 300;
   padding-left: 4px;
   padding-top: 1px;


### PR DESCRIPTION
There was a regression with the a11y work that has made the stop viewer link far too large. This PR corrects this.