### PR TITLE
More lenient transit leg detection

### DIFF
--- a/packages/itinerary-body/src/otp-react-redux/line-column-content.tsx
+++ b/packages/itinerary-body/src/otp-react-redux/line-column-content.tsx
@@ -90,7 +90,7 @@ const IconStacker = styled.span`
 
 const legLineBackgroundColor = ({ leg, routeColor }: LegLineProps): string => {
   const { mode } = leg;
-  return coreUtils.itinerary.isTransit(mode)
+  return leg.transitLeg || coreUtils.itinerary.isTransit(mode)
     ? routeColor
       ? `#${routeColor}`
       : "#000088"

--- a/packages/transitive-overlay/src/util.ts
+++ b/packages/transitive-overlay/src/util.ts
@@ -300,7 +300,7 @@ export function itineraryToTransitive(
       });
     }
 
-    if (isTransit(leg.mode)) {
+    if (leg.transitLeg || isTransit(leg.mode)) {
       // Flex routes sometimes have the same from and to IDs, but
       // these stops still need to be rendered separately!
       if (leg.from.stopId === leg.to.stopId) {


### PR DESCRIPTION
Sometimes we may want to use a non-gtfs mode type. However, this mode may still be a transit mode! This PR adds support for accepting this non-standard mode as a transit mode.