### PR TITLE
fix(otp-tile-overlay): support enabling layers by default

### DIFF
--- a/packages/otp2-tile-overlay/src/index.tsx
+++ b/packages/otp2-tile-overlay/src/index.tsx
@@ -55,6 +55,7 @@ const OTP2TileLayerWithPopup = ({
    * Determines which layer of the OTP2 tile data to display. Also determines icon color.
    */
   type: string
+  visible?: boolean
 }): JSX.Element => {
   const { current: map } = useMap()
 
@@ -167,7 +168,7 @@ const OTP2TileLayerWithPopup = ({
  * @returns               Array of <Source> and <OTP2TileLayerWithPopup> components
  */
 const generateOTP2TileLayers = (
-  layers: { name?: string; network?: string; type: string }[],
+  layers: { name?: string; network?: string; type: string, initiallyVisible?: boolean }[],
   endpoint: string,
   setLocation?: (location: MapLocationActionArg) => void,
   setViewedStop?: ({ stopId }: { stopId: string }) => void,
@@ -184,7 +185,7 @@ const generateOTP2TileLayers = (
       url={`${endpoint}/${layers.map((l) => l.type).join(",")}/tilejson.json`}
     />,
     ...layers.map((layer) => {
-      const { name, network, type } = layer
+      const { name, network, type, initiallyVisible } = layer
 
       const id = `${type}${network ? `-${network}` : ""}`
       return (
@@ -197,6 +198,7 @@ const generateOTP2TileLayers = (
           setLocation={setLocation}
           setViewedStop={setViewedStop}
           type={type}
+          visible={initiallyVisible}
         />
       )
     })


### PR DESCRIPTION
The overlays had support for displaying themselves by default. With the new otp2 tile layer we lost this functionality! This PR resolves this, allowing any OTP2 tile layer to be set to be initially visible