### PR TITLE
fix(location-field): Add aria-activedescendant attribute

### DIFF
--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -28,6 +28,8 @@ import {
 import * as S from "./styled";
 import { generateLabel, getCombinedLabel } from "./utils";
 
+const optionIdPrefix = "otpui-locf-option-";
+
 // FIXME have a better key generator for options
 let optionKey = 0;
 
@@ -442,6 +444,7 @@ const LocationField = ({
         classes={classNames.join(" ")}
         color={layerColorMap[layer]}
         icon={operatorIcon || <GeocodedOptionIconComponent feature={feature} />}
+        id={`${optionIdPrefix}${itemIndex}`}
         isActive={itemIndex === activeIndex}
         key={optionKey++}
         onClick={locationSelected}
@@ -566,6 +569,7 @@ const LocationField = ({
         // Create and return the option menu item
         const option = (
           <TransitStopOption
+            id={`${optionIdPrefix}${itemIndex}`}
             isActive={itemIndex === activeIndex}
             key={optionKey++}
             onClick={locationSelected}
@@ -610,6 +614,7 @@ const LocationField = ({
         const option = (
           <Option
             icon={sessionOptionIcon}
+            id={`${optionIdPrefix}${itemIndex}`}
             isActive={itemIndex === activeIndex}
             key={optionKey++}
             onClick={locationSelected}
@@ -656,6 +661,7 @@ const LocationField = ({
         const option = (
           <Option
             icon={<UserLocationIconComponent userLocation={userLocation} />}
+            id={`${optionIdPrefix}${itemIndex}`}
             isActive={itemIndex === activeIndex}
             key={optionKey++}
             onClick={locationSelected}
@@ -708,6 +714,7 @@ const LocationField = ({
       <Option
         disabled={positionUnavailable}
         icon={optionIcon}
+        id={`${optionIdPrefix}${itemIndex}`}
         isActive={itemIndex === activeIndex}
         key={optionKey++}
         onClick={locationSelected}
@@ -745,6 +752,7 @@ const LocationField = ({
       : defaultPlaceholder;
   const textControl = (
     <S.Input
+      aria-activedescendant={activeIndex !== null ? `${optionIdPrefix}${activeIndex}` : null}
       aria-autocomplete="list"
       aria-controls={listBoxId}
       aria-expanded={menuVisible}

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -28,7 +28,15 @@ import {
 import * as S from "./styled";
 import { generateLabel, getCombinedLabel } from "./utils";
 
-const optionIdPrefix = "otpui-locf-option-";
+const optionIdPrefix = "otpui-locf-option";
+
+/**
+ * Formats the option id based on its given index position.
+ * This assumes only one location dropdown is shown at a time.
+ */
+function getOptionId(index: number): string {
+  return `${optionIdPrefix}-${index}`
+}
 
 // FIXME have a better key generator for options
 let optionKey = 0;
@@ -444,7 +452,7 @@ const LocationField = ({
         classes={classNames.join(" ")}
         color={layerColorMap[layer]}
         icon={operatorIcon || <GeocodedOptionIconComponent feature={feature} />}
-        id={`${optionIdPrefix}${itemIndex}`}
+        id={getOptionId(itemIndex)}
         isActive={itemIndex === activeIndex}
         key={optionKey++}
         onClick={locationSelected}
@@ -569,7 +577,7 @@ const LocationField = ({
         // Create and return the option menu item
         const option = (
           <TransitStopOption
-            id={`${optionIdPrefix}${itemIndex}`}
+            id={getOptionId(itemIndex)}
             isActive={itemIndex === activeIndex}
             key={optionKey++}
             onClick={locationSelected}
@@ -614,7 +622,7 @@ const LocationField = ({
         const option = (
           <Option
             icon={sessionOptionIcon}
-            id={`${optionIdPrefix}${itemIndex}`}
+            id={getOptionId(itemIndex)}
             isActive={itemIndex === activeIndex}
             key={optionKey++}
             onClick={locationSelected}
@@ -661,7 +669,7 @@ const LocationField = ({
         const option = (
           <Option
             icon={<UserLocationIconComponent userLocation={userLocation} />}
-            id={`${optionIdPrefix}${itemIndex}`}
+            id={getOptionId(itemIndex)}
             isActive={itemIndex === activeIndex}
             key={optionKey++}
             onClick={locationSelected}
@@ -714,7 +722,7 @@ const LocationField = ({
       <Option
         disabled={positionUnavailable}
         icon={optionIcon}
-        id={`${optionIdPrefix}${itemIndex}`}
+        id={getOptionId(itemIndex)}
         isActive={itemIndex === activeIndex}
         key={optionKey++}
         onClick={locationSelected}
@@ -752,7 +760,7 @@ const LocationField = ({
       : defaultPlaceholder;
   const textControl = (
     <S.Input
-      aria-activedescendant={activeIndex !== null ? `${optionIdPrefix}${activeIndex}` : null}
+      aria-activedescendant={activeIndex !== null ? getOptionId(activeIndex) : null}
       aria-autocomplete="list"
       aria-controls={listBoxId}
       aria-expanded={menuVisible}

--- a/packages/location-field/src/options.tsx
+++ b/packages/location-field/src/options.tsx
@@ -35,6 +35,7 @@ export function Option({
   color = null,
   disabled = false,
   icon = null,
+  id,
   isActive = false,
   onClick,
   subTitle = null,
@@ -44,13 +45,14 @@ export function Option({
   color?: string;
   disabled?: boolean;
   icon?: React.ReactNode;
+  id?: string;
   isActive?: boolean;
   onClick?: () => void;
   subTitle?: React.ReactNode;
   title?: React.ReactNode;
 }): React.ReactElement {
   return (
-    <S.MenuItem onClick={onClick} active={isActive} disabled={disabled}>
+    <S.MenuItem active={isActive} disabled={disabled} id={id} onClick={onClick}>
       {coreUtils.ui.isIE() ? (
         // In internet explorer 11, some really weird stuff is happening where it
         // is not possible to click the text of the title, but if you click just
@@ -79,18 +81,20 @@ export function Option({
 }
 
 export function TransitStopOption({
+  id,
   isActive = false,
   onClick,
   stop,
   stopOptionIcon
 }: {
+  id?: string;
   isActive?: boolean;
   onClick: () => void;
   stop: Stop;
   stopOptionIcon: React.ReactNode;
 }): React.ReactElement {
   return (
-    <S.MenuItem onClick={onClick} active={isActive}>
+    <S.MenuItem id={id} onClick={onClick} active={isActive}>
       <S.StopIconAndDistanceContainer>
         {stopOptionIcon}
         <S.StopDistance>

--- a/packages/location-field/src/styled.tsx
+++ b/packages/location-field/src/styled.tsx
@@ -191,6 +191,7 @@ export const MenuItem = ({
   disabled = false,
   fgColor = null,
   header = false,
+  id,
   level = 1,
   onClick = null,
   role = undefined
@@ -202,6 +203,7 @@ export const MenuItem = ({
   disabled?: boolean;
   fgColor?: string;
   header?: boolean;
+  id?: string;
   level?: number;
   onClick?: () => void;
   role?: string;
@@ -230,6 +232,7 @@ export const MenuItem = ({
     >
       <MenuItemA
         active={active}
+        id={id}
         onClick={handleClick}
         role="option"
         tabIndex={-1}


### PR DESCRIPTION
This PR improves a11y to the `LocationField` component, so that screen readers can indicate the active item when the user uses the up/down arrows to browse the list of suggested locations. This is done by using the `aria-activedescendant` attribute to the input field.