### PR TITLE
Fix types and remove caret if bearing null

### DIFF
--- a/packages/transit-vehicle-overlay/src/WithCaret.tsx
+++ b/packages/transit-vehicle-overlay/src/WithCaret.tsx
@@ -57,7 +57,7 @@ export default function withCaret(
   }: IconContainerProps): JSX.Element => (
     <Component className={className} style={style} vehicle={vehicle}>
       {children}
-      <SizedCaret rotate={vehicle.heading} />
+      {vehicle.heading && <SizedCaret rotate={vehicle.heading} />}
     </Component>
   );
 

--- a/packages/transit-vehicle-overlay/src/index.story.tsx
+++ b/packages/transit-vehicle-overlay/src/index.story.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { ClassicModeIcon, TriMetModeIcon } from "@opentripplanner/icons";
-
 import vehicleData from "../__mocks__/seattle.json";
 import { withMap } from "../../../.storybook/base-map-wrapper";
 
@@ -15,6 +14,7 @@ import TransitVehicleOverlay, {
 
 const SEATTLE: [number, number] = [47.6, -122.3];
 
+// TODO: TransitVehicle[] type doesn't match with vehicles object
 const vehicles: TransitVehicle[] = vehicleData.vehiclePositions;
 
 const CircleWithInnerCaret = withCaret(Circle, { position: "inner" });
@@ -54,7 +54,7 @@ export const OuterCaretWithCustomSize = () => (
 
 export const RouteColorBackground = () => (
   <TransitVehicleOverlay
-    IconContainer={withRouteColorBackground(DefaultIconContainer)}
+    IconContainer={withRouteColorBackground(DefaultIconContainer, null)}
     ModeIcon={TriMetModeIcon}
     vehicles={vehicles}
   />
@@ -73,8 +73,8 @@ export const RouteColorBackgroundWithTransparencyOnHover = () => (
 
 export const RouteColorBackgroundWithInnerCaret = () => (
   <TransitVehicleOverlay
-    IconContainer={withRouteColorBackground(CircleWithInnerCaret)}
-    iconPaddding={4}
+    IconContainer={withRouteColorBackground(CircleWithInnerCaret, null)}
+    iconPadding={4}
     ModeIcon={TriMetModeIcon}
     vehicles={vehicles}
   />

--- a/packages/transit-vehicle-overlay/src/index.tsx
+++ b/packages/transit-vehicle-overlay/src/index.tsx
@@ -1,6 +1,6 @@
 import { MarkerWithPopup } from "@opentripplanner/base-map";
 import { TransitVehicle } from "@opentripplanner/types";
-import React, { FC, ReactNode } from "react";
+import React, { FC } from "react";
 
 import withCaret from "./WithCaret";
 import {
@@ -74,7 +74,7 @@ const TransitVehicleOverlay = ({
   TooltipSlot = VehicleTooltip,
   VehicleIcon = DefaultVehicleIcon,
   vehicles
-}: Props): ReactNode => {
+}: Props): JSX.Element | null => {
   const validVehicles = vehicles?.filter(
     vehicle => !!vehicle?.lat && !!vehicle?.lon
   );
@@ -90,25 +90,29 @@ const TransitVehicleOverlay = ({
     iconPixels
   );
 
-  return validVehicles?.map(vehicle => (
-    <MarkerWithPopup
-      key={vehicle.vehicleId}
-      // @ts-expect-error the prop override doesn't require all props to be present
-      popupProps={{ offset: [-iconPixels / 2 - iconPadding, 0] }}
-      position={[vehicle.lat, vehicle.lon]}
-      tooltipContents={
-        vehicle.routeShortName && <TooltipSlot vehicle={vehicle} />
-      }
-    >
-      <StyledContainer vehicle={vehicle}>
-        <VehicleIcon
-          defaultMode={defaultMode}
-          ModeIcon={ModeIcon}
-          vehicle={vehicle}
-        />
-      </StyledContainer>
-    </MarkerWithPopup>
-  ));
+  return (
+    <>
+      {validVehicles?.map(vehicle => (
+        <MarkerWithPopup
+          key={vehicle.vehicleId}
+          // @ts-expect-error the prop override doesn't require all props to be present
+          popupProps={{ offset: [-iconPixels / 2 - iconPadding, 0] }}
+          position={[vehicle.lat, vehicle.lon]}
+          tooltipContents={
+            vehicle.routeShortName && <TooltipSlot vehicle={vehicle} />
+          }
+        >
+          <StyledContainer vehicle={vehicle}>
+            <VehicleIcon
+              defaultMode={defaultMode}
+              ModeIcon={ModeIcon}
+              vehicle={vehicle}
+            />
+          </StyledContainer>
+        </MarkerWithPopup>
+      ))}
+    </>
+  );
 };
 
 export default TransitVehicleOverlay;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2845,15 +2845,10 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
-"@opentripplanner/geocoder@1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/geocoder/-/geocoder-1.3.4.tgz#94f1b4085ab3005ef6c8960ab5f75387db29a123"
-  integrity sha512-Dqzkt5wRjTbgzUg79H5ZSHHI/OG58+jeQJaPUMkBzyx759hUiHKuj5X7VwDtF3LI9mfR7SUyxOtu4QQtNvyGmQ==
-  dependencies:
-    "@conveyal/geocoder-arcgis-geojson" "^0.0.3"
-    "@conveyal/lonlat" "^1.4.1"
-    isomorphic-mapzen-search "^1.6.1"
-    lodash.memoize "^4.1.2"
+"@opentripplanner/types@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/types/-/types-4.0.6.tgz#abd802c4ac8b9a9c83bc189e9bdc4bbc4bef78fc"
+  integrity sha512-2NyUrIH0jdTrZrzKFOVD4Vnc8Nf2iYFfQZ2Bg/mwmCXlPuew7eKqfY2krtyotsYcQU1+BmO/+oZre/tzW3SgQQ==
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.1":
   version "0.5.4"


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Some feeds do not include vehicle bearing, making transit overlay carets default to pointing upwards. This PR removes the caret if vehicle.heading is null. Let me know if you think there's a better way to go about this; I had to break up the original function a bit. The `waterloo` instance is a good example of a feed without bearings (shown below).

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
| Before | After |
|--------|-------|
| ![Pasted Graphic 63](https://user-images.githubusercontent.com/62163307/222554533-45c59805-70bd-472d-996a-639669b863d4.png) | ![Pasted Graphic 60](https://user-images.githubusercontent.com/62163307/222554453-e3bb0673-4d85-4f2e-bf08-a2e35d163923.png) |