### PR TITLE
Repair A11y `itinerary-body` Regressions

### DIFF
--- a/packages/itinerary-body/src/ItineraryBody/place-row.tsx
+++ b/packages/itinerary-body/src/ItineraryBody/place-row.tsx
@@ -54,7 +54,7 @@ export default function PlaceRow({
   // on the stop viewer in this case, which they may want to do in order to
   // check the real-time arrival information for the next leg of their journey.
   const interline = !!(!isDestination && leg.interlineWithPreviousLeg);
-  const hideBorder = interline || !legIndex;
+  // const hideBorder = interline || !legIndex;
   const place = isDestination ? { ...leg.to } : { ...leg.from };
   // OTP2 marks both bikes and scooters as BIKESHARE in the vertextype
   // To get the right label, we need to fix scooters to be "VEHICLERENTAL"
@@ -98,7 +98,6 @@ export default function PlaceRow({
           <PlaceName config={config} interline={interline} place={place} />
         </S.PlaceName>
       </S.PlaceHeader>
-
       <S.TimeColumn>
         {/* Custom rendering of the departure/arrival time of the specified leg. */}
         <TimeColumnContent isDestination={isDestination} leg={leg} />
@@ -172,8 +171,9 @@ export default function PlaceRow({
             />
           ))}
       </S.PlaceDetails>
+      {/* This prop is a string for some reason... */}
       {showMapButtonColumn && (
-        <S.MapButtonColumn hideBorder={hideBorder.toString()}>
+        <S.MapButtonColumn hideBorder="true">
           <S.MapButton
             aria-label={viewOnMapMessage}
             onClick={() => frameLeg({ isDestination, leg, legIndex, place })}

--- a/packages/itinerary-body/src/TransitLegBody/index.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/index.tsx
@@ -285,7 +285,7 @@ class TransitLegBody extends Component<Props, State> {
               </S.CallAheadWarning>
             )}
             {/* Alerts toggle */}
-            {!shouldOnlyShowAlertsExpanded && (
+            {alerts?.length > 0 && (
               <S.TransitAlertToggle onClick={this.onToggleAlertsClick}>
                 <AlertToggleIcon />{" "}
                 <FormattedMessage

--- a/packages/itinerary-body/src/otp-react-redux/itinerary-body.ts
+++ b/packages/itinerary-body/src/otp-react-redux/itinerary-body.ts
@@ -49,7 +49,6 @@ const StyledItineraryBody = styled(ItineraryBody)`
     font-size: 18px;
     font-weight: 500;
     line-height: 20px;
-    padding-left: 4px;
   }
 
   ${ItineraryBodyClasses.PlaceName} {

--- a/packages/itinerary-body/src/otp-react-redux/itinerary-body.ts
+++ b/packages/itinerary-body/src/otp-react-redux/itinerary-body.ts
@@ -69,7 +69,7 @@ const StyledItineraryBody = styled(ItineraryBody)`
     display: table-cell;
     font-size: 14px;
     padding-right: 4px;
-    padding-top: 1px;
+    padding-top: 2px;
     text-align: right;
     vertical-align: top;
     width: 60px;

--- a/packages/itinerary-body/src/styled.tsx
+++ b/packages/itinerary-body/src/styled.tsx
@@ -474,6 +474,7 @@ export const PlaceName = styled.span`
   white-space: nowrap;
   text-overflow: ellipsis;
   flex: 1 1 auto;
+  padding: 3px 0 10px 0;
 `;
 
 export const PlaceSubheader = styled.div`

--- a/packages/itinerary-body/src/styled.tsx
+++ b/packages/itinerary-body/src/styled.tsx
@@ -269,7 +269,7 @@ export const ItineraryBody = styled.ol`
 export const LegBody = styled.div`
   color: #676767;
   font-size: 13px;
-  padding: 12px 0 12px 4px;
+  padding-bottom: 12px;
 `;
 
 export const LegClickable = styled.div``;
@@ -442,6 +442,7 @@ export const MapButton = styled(LinkButton)`
 
 export const MapButtonColumn = styled(LightBorderDiv)`
   flex: 0 0 25px;
+  grid-column: -1;
 `;
 
 export const MapIcon = styled(Map).attrs(props => ({


### PR DESCRIPTION
The a11y updates to the itinerary body caused some regressions around styling, collapsing alerts, and the non otp-rr styling. This PR repairs all of this. Please let me know if I've missed anything!