### PR TITLE
Perform yaml-sort on pre-commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Language-specific content is located in YML files under the `i18n` folder of pac
 (e.g. `en-US.yml` for American English, `fr.yml` for generic French, etc.).
 
 Note: Do not add comments to these YML files! Comments are removed by `yaml-sort` during pre-commit.
+Instead, comments for other developers should be placed in the corresponding js/jsx/ts/tsx file.
+Comments for translators should be entered into Weblate (see [Contributing Translations](#contributing-translations))
 
 To use the YML files in your react-intl application:
 
@@ -148,6 +150,6 @@ OTP-UI now uses [Hosted Weblate](https://www.weblate.org) to manage translations
 Translations from the community are welcome and very much appreciated,
 please see instructions at https://hosted.weblate.org/projects/otp-react-redux/.
 Community input from Weblate will appear as pull requests with changes to files in the applicable `i18n` folders for our review.
-(We reserve the right to edit or reject contributions as we see fit.)
+(Contributions may be edited or rejected to remain in line with long-term project goals.)
 
 If changes to a specific language file is needed but not enabled in Weblate, please open an issue or a pull request with the changes needed.

--- a/README.md
+++ b/README.md
@@ -112,8 +112,25 @@ To use the YML files in your react-intl application:
     otpUi.ItineraryBody.travelByMode.bike
   ```
 - Pass the resulting object to the messages prop of `IntlProvider`.
+  See `packages/from-to-location-picker/src/index.story.tsx` for an example of how to initialize localized messages with `IntlProvider`.
 
-See `packages/from-to-location-picker/src/index.story.tsx` for an example of how to initialize localized messages with `IntlProvider`.
+### Using internationalizable content in the code
+
+Use message id **literals** (no variables or other dynamic content) with either
+
+```jsx
+<FormattedMessage id="..." />
+```
+
+or
+
+```js
+intl.formatMessage({ id: ... })
+```
+
+The reason for passing **literals** to `FormattedMessage` and `intl.formatMessage` is that we have a checker script `yarn check:i18n` that is based on the `formatJS` CLI and that detects unused messages in the code and exports translation tables.
+Passing variables or dynamic content will cause the `formatJS` CLI and the checker to ignore the corresponding messages and
+incorrectly claim that a string is unused or missing from a translation file.
 
 ### Contributing translations
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,23 @@ Both `react-intl` and `formatjs` take advantage of native internationalization f
 Language-specific content is located in YML files under the `i18n` folder of packages that have internationalizable content
 (e.g. `en-US.yml` for American English, `fr.yml` for generic French, etc.).
 
+Note: Do not add comments to these YML files! Comments are removed by `yaml-sort` during pre-commit.
+
+To use the YML files in your react-intl application:
+
+- Merge the content of this file into the messages object that has your other localized strings,
+- Flatten the ids, i.e. convert a structure such as
+  ```
+    otpUi > ItineraryBody > travelByMode > bike
+  ```
+  into
+  ```
+    otpUi.ItineraryBody.travelByMode.bike
+  ```
+- Pass the resulting object to the messages prop of `IntlProvider`.
+
+See `packages/from-to-location-picker/src/index.story.tsx` for an example of how to initialize localized messages with `IntlProvider`.
+
 ### Contributing translations
 
 OTP-UI now uses [Hosted Weblate](https://www.weblate.org) to manage translations!
@@ -114,5 +131,6 @@ OTP-UI now uses [Hosted Weblate](https://www.weblate.org) to manage translations
 Translations from the community are welcome and very much appreciated,
 please see instructions at https://hosted.weblate.org/projects/otp-react-redux/.
 Community input from Weblate will appear as pull requests with changes to files in the applicable `i18n` folders for our review.
+(We reserve the right to edit or reject contributions as we see fit.)
 
 If changes to a specific language file is needed but not enabled in Weblate, please open an issue or a pull request with the changes needed.

--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
     ],
     "*.{yml,yaml}": [
       "prettier --write",
-      "yaml-sort --input",
+      "yaml-sort --quotingStyle double --input",
       "git add"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
     "stylelint-processor-styled-components": "^1.8.0",
     "typescript": "^4.2.4",
     "webpack": "^4.33.0",
-    "yaml-loader": "^0.6.0"
+    "yaml-loader": "^0.6.0",
+    "yaml-sort": "^2.0.0"
   },
   "scripts": {
     "a11y-test": "yarn build-storybook && jest --testPathIgnorePatterns packages storybook",
@@ -220,8 +221,13 @@
       "stylelint \"packages/**/!(*.d).{j,t}s{,x}\" --fix",
       "git add"
     ],
-    "*.{json,md,yml}": [
+    "*.{json,md}": [
       "prettier --write",
+      "git add"
+    ],
+    "*.{yml,yaml}": [
+      "prettier --write",
+      "yaml-sort --input",
       "git add"
     ]
   },

--- a/packages/endpoints-overlay/i18n/en-US.yml
+++ b/packages/endpoints-overlay/i18n/en-US.yml
@@ -1,22 +1,9 @@
-# Default messages for the EndpointsOverlay component.
-# To use from a react-intl application:
-# - merge the content of this file into the messages object
-#   that has your other localized strings,
-# - flatten the ids, i.e. convert a structure such as
-#      otpUi > EndpointsOverlay > saveAsHome
-#   into "otpUi.EndpointsOverlay.saveAsHome",
-# - pass the resulting object to the messages prop of IntlProvider.
-
 otpUi:
   EndpointsOverlay:
-    # Note to translator:
-    # This should read, in English, as e.g. "Remove as 'from' location" (quotes not included).
     clearLocation: Remove as {locationType} location
     coordinates: "{lat, number, ::.00000}, {lon, number, ::.00000}"
     forgetHome: Forget home
     forgetWork: Forget work
     saveAsHome: Save as home
     saveAsWork: Save as work
-    # Note to translator:
-    # This should read, in English, as e.g. "Change to 'from' location" (quotes not included).
     swapLocation: Change to {locationType} location

--- a/packages/endpoints-overlay/i18n/fr.yml
+++ b/packages/endpoints-overlay/i18n/fr.yml
@@ -1,20 +1,13 @@
-# Example translations for the EndpointsOVerlay component into French.
 otpUi:
   EndpointsOverlay:
-    # Note to translator:
-    # This should read, in English, as e.g. "Remove as 'from' location" (quotes not included).
-    clearLocation: "Effacer {locationType, select,
-      from {le point de départ}
-      to {la destination}
-      other {{locationType}}}"
+    clearLocation: >-
+      Effacer {locationType, select, from {le point de départ} to {la
+      destination} other {{locationType}}}
     coordinates: "{lat, number, ::.00000}; {lon, number, ::.00000}"
     forgetHome: Oublier le domicile
     forgetWork: Oublier le lieu de travail
     saveAsHome: En faire le domicile
     saveAsWork: En faire le lieu de travail
-    # Note to translator:
-    # This should read, in English, as e.g. "Change to 'from' location" (quotes not included).
-    swapLocation: "En faire {locationType, select,
-      from {le point de départ}
-      to {la destination}
-      other {{locationType}}}"
+    swapLocation: >-
+      En faire {locationType, select, from {le point de départ} to {la
+      destination} other {{locationType}}}

--- a/packages/from-to-location-picker/i18n/en-US.yml
+++ b/packages/from-to-location-picker/i18n/en-US.yml
@@ -1,13 +1,3 @@
-# Default messages for the FromToLocationPicker component.
-# To use from a react-intl application:
-# - merge the content of this file into the messages object
-#   that has your other localized strings,
-# - flatten the ids, i.e. convert a structure such as
-#      otpUi > FromToLocationPicker > from
-#   into "otpUi.FromToLocationPicker.from" (see FromToLocationPicker story for an example),
-# - pass the resulting object to the messages prop of IntlProvider.
-#
-
 otpUi:
   FromToLocationPicker:
     from: From here

--- a/packages/from-to-location-picker/i18n/fr.yml
+++ b/packages/from-to-location-picker/i18n/fr.yml
@@ -1,13 +1,3 @@
-# Default messages for the FromToLocationPicker component.
-# To use from a react-intl application:
-# - merge the content of this file into the messages object
-#   that has your other localized strings,
-# - flatten the ids, i.e. convert a structure such as
-#      otpUi > FromToLocationPicker > from
-#   into "otpUi.FromToLocationPicker.from" (see FromToLocationPicker story for an example),
-# - pass the resulting object to the messages prop of IntlProvider.
-#
-
 otpUi:
   FromToLocationPicker:
     from: Départ

--- a/packages/itinerary-body/i18n/en-US.yml
+++ b/packages/itinerary-body/i18n/en-US.yml
@@ -1,19 +1,9 @@
-# Default messages for the ItineraryBody component and subcomponents.
-# To use from a react-intl application:
-# - merge the content of this file into the messages object
-#   that has your other localized strings,
-# - flatten the ids, i.e. convert a structure such as
-#      otpUi > LocationField > stations
-#   into "otpUi.TripDetails.stations" (see story for an example),
-# - pass the resulting object to the messages prop of IntlProvider.
-
 otpUi:
   AccessLegBody:
     LegDiagramPreview:
       elevationChart: Elevation chart
       noElevationData: No elevation data available.
       toggleElevationChart: Toggle elevation chart
-    mapillaryTooltip: Show street imagery at this location
     RentedVehicleSubheader:
       pickupRental: Pick up {company} {vehicleType} {vehicleName}
       resumeRentalRide: Continue using rental
@@ -24,6 +14,13 @@ otpUi:
         escooter: E-scooter
         vehicle: vehicle
       walkVehicle: Walk vehicle along {place}
+    TncLeg:
+      bookRide: Book Ride
+      bookRideLater: Wait until {timeMillis, time, short} to book
+      estimatedCost: "Estimated cost: {minFare} - {maxFare}"
+      estimatedTravelTime: "Estimated travel time: {duration} (does not account for traffic)"
+      waitForPickup: "Wait{minutes, plural, =0 {} other { # minutes}} for {company} pickup"
+    mapillaryTooltip: Show street imagery at this location
     step:
       circleClockwise: Follow circle clockwise
       circleCounterClockwise: Follow circle counterclockwise
@@ -37,6 +34,8 @@ otpUi:
       uTurnLeft: Left U-turn
       uTurnRight: Right U-turn
     stepDepart: Head {heading} on {street}
+    stepElevator: Take elevator to {street}
+    stepGeneric: "{step} on {street}"
     stepHeading:
       east: east
       north: north
@@ -46,11 +45,8 @@ otpUi:
       southeast: southeast
       southwest: southwest
       west: west
-    stepElevator: Take elevator to {street}
-    stepGeneric: "{step} on {street}"
     summary: "{mode} to {place}"
     summaryAndDistance: "{mode} {distance} to {place}"
-    # The summary modes below only include access mode actions (ride, walk...).
     summaryMode:
       bike: Bicycle
       bikeshare: Bikeshare
@@ -58,12 +54,6 @@ otpUi:
       carHail: Ride
       escooter: Ride
       walk: Walk
-    TncLeg:
-      bookRide: Book Ride
-      bookRideLater: Wait until {timeMillis, time, short} to book
-      estimatedCost: "Estimated cost: {minFare} - {maxFare}"
-      estimatedTravelTime: "Estimated travel time: {duration} (does not account for traffic)"
-      waitForPickup: "Wait{minutes, plural, =0 {} other { # minutes}} for {company} pickup"
     unnamedPath: Unnamed Path
     unnamedRoad: Unnamed Road
     vehicleTitle: "{company} {vehicleType}"
@@ -89,19 +79,19 @@ otpUi:
       walk: by walking
     viewOnMap: View on map
   TransitLegBody:
-    agencyExternalLink: "{agencyName} (External Link)"
     AlertsBody:
       effectiveDate: Effective as of {dateTime, date, long}
       effectiveTimeAndDate: Effective as of {dateTime, time, short}, {day}
       today: Today
       tomorrow: Tomorrow
       yesterday: Yesterday
+    agencyExternalLink: "{agencyName} (External Link)"
     alertsHeader: "{alertCount, plural, =1 {# alert} other {# alerts}}"
-    arriveAt: "Arrive at {place}"
+    arriveAt: Arrive at {place}
     disembarkAt: Disembark at {legDestination}
     expandDetails: (Expand details)
     fare: "Fare: {fare}"
-    fromLocation: "from {location}"
+    fromLocation: from {location}
     legDetails: Leg details
     operatedBy: Service operated by {agencyLink}
     ride: Ride

--- a/packages/itinerary-body/i18n/fr.yml
+++ b/packages/itinerary-body/i18n/fr.yml
@@ -1,19 +1,9 @@
-# Default messages for the ItineraryBody component and subcomponents.
-# To use from a react-intl application:
-# - merge the content of this file into the messages object
-#   that has your other localized strings,
-# - flatten the ids, i.e. convert a structure such as
-#      otpUi > LocationField > stations
-#   into "otpUi.TripDetails.stations" (see story for an example),
-# - pass the resulting object to the messages prop of IntlProvider.
-
 otpUi:
   AccessLegBody:
     LegDiagramPreview:
       elevationChart: Dénivelés
       noElevationData: Aucune information sur les dénivelés.
       toggleElevationChart: Afficher/masquer les dénivelés
-    mapillaryTooltip: Afficher la vue panoramique à cet endroit
     RentedVehicleSubheader:
       pickupRental: Récupérez {vehicleType} {company} {vehicleName}
       resumeRentalRide: Continuez avec le véhicule loué
@@ -24,6 +14,17 @@ otpUi:
         escooter: la trottinette
         vehicle: le véhicule
       walkVehicle: Emmenez à pied le véhicule le long de {place}
+    TncLeg:
+      bookRide: Réserver
+      bookRideLater: Attendez jusqu'à {timeMillis, time, short} avant de réserver
+      estimatedCost: "Coût estimé : {minFare} - {maxFare}"
+      estimatedTravelTime: >-
+        Temps de trajet estimé : {duration} (ne tient pas compte de la
+        circulation)
+      waitForPickup: >-
+        Attendez votre chauffeur {company}{minutes, plural, =0 {} other { #
+        minutes}}
+    mapillaryTooltip: Afficher la vue panoramique à cet endroit
     step:
       circleClockwise: Prenez le rond-point par la gauche
       circleCounterClockwise: Prenez le rond-point par la droite
@@ -37,6 +38,8 @@ otpUi:
       uTurnLeft: Demi-tour par la gauche
       uTurnRight: Demi-tour par la droite
     stepDepart: Dirigez-vous vers {heading} sur {street}
+    stepElevator: Prenez l'ascenseur jusqu'à {street}
+    stepGeneric: "{step} sur {street}"
     stepHeading:
       east: l'est
       north: le nord
@@ -46,18 +49,8 @@ otpUi:
       southeast: le sud-est
       southwest: le sud-ouest
       west: l'ouest
-    # TODO: elevator destinations (e.g. "3rd floor") may need to be localized.
-    stepElevator: Prenez l'ascenseur jusqu'à {street}
-    stepGeneric: "{step} sur {street}"
-    # In the summary below, only include access mode actions (ride, walk...).
-    # Note de traduction: nous utilisons le format
-    #   "Marche/velo/etc - 2,5 miles vers 10th Street" qui peut paraître un peu "robotique".
-    # Une formulation du type "2,5 miles à pied/en voiture/etc" est plus couramment "parlée"
-    # mais donne lieu à des expressions bizarres comme "230 pieds à pied vers 10th Street"
-    # à cause de l'utilisation d'unités impériales.
     summary: "{mode} vers {place}"
     summaryAndDistance: "{mode} - {distance} vers {place}"
-    # The summary modes below only include access mode actions (ride, walk...).
     summaryMode:
       bike: Vélo
       bikeshare: Vélo partagé
@@ -65,16 +58,6 @@ otpUi:
       carHail: Course en voiture
       escooter: Trottinette
       walk: Marche
-    TncLeg:
-      bookRide: Réserver
-      bookRideLater: Attendez jusqu'à {timeMillis, time, short} avant de réserver
-      estimatedCost: "Coût estimé : {minFare} - {maxFare}"
-      estimatedTravelTime:
-        "Temps de trajet estimé : {duration} (ne tient pas compte\
-        \ de la circulation)"
-      waitForPickup:
-        "Attendez votre chauffeur {company}{minutes, plural, =0 {} other\
-        \ { # minutes}}"
     unnamedPath: Chemin sans nom
     unnamedRoad: Route sans nom
     vehicleTitle: "{vehicleType} {company}"
@@ -87,40 +70,36 @@ otpUi:
   ItineraryBody:
     common:
       durationShort: "{hours, plural, =0 {} other {# h }}{minutes} mn"
-    flexAdvanceNotice:
-      " au moins {leadDays, plural, one {# jour} other {# jours}}\
-      \ à l'avance"
+    flexAdvanceNotice: " au moins {leadDays, plural, one {# jour} other {# jours}} à l'avance"
     flexCallAhead: réserver au préalable
     flexCallNumber: réserver au {phoneNumber}
     flexPickupMessage: Pour emprunter cette ligne, vous devez {action}{advanceNotice}.
     stayOnBoard: Restez à bord à {place}
     travelBy: Trajet {mode}
     travelByMode:
+      bike: en vélo
       car: en voiture
       escooter: en trottinette
       walk: à pied
-      bike: en vélo
     viewOnMap: Afficher sur le plan
   TransitLegBody:
-    agencyExternalLink: "{agencyName} (Lien externe)"
     AlertsBody:
       effectiveDate: À partir du {dateTime, date, long}
       effectiveTimeAndDate: À partir de {dateTime, time, short}, {day}
       today: aujourd'hui
       tomorrow: demain
       yesterday: hier
+    agencyExternalLink: "{agencyName} (Lien externe)"
     alertsHeader: "{alertCount, plural, =0 {# alerte} =1 {# alerte} other {# alertes}}"
-    arriveAt: "Arrivée à {place}"
+    arriveAt: Arrivée à {place}
     disembarkAt: Descendez à {legDestination}
     expandDetails: (Plus de détails)
     fare: "Tarif : {fare}"
-    fromLocation: "de {location}"
+    fromLocation: de {location}
     legDetails: Détails de l'étape
     operatedBy: Exploité par {agencyLink}
     ride: Prenez la ligne
-    rideDurationAndStops:
-      "Trajet : {duration}{numStops, plural, =1 {} other { / #\
-      \ arrêts}}"
+    rideDurationAndStops: "Trajet : {duration}{numStops, plural, =1 {} other { / # arrêts}}"
     routeDescription: "{routeName} <toPrefix>vers</toPrefix> {headsign}"
     stopId: Arrêt n°{stopId}
     stopIdBasic: Arrêt n°{stopId}

--- a/packages/location-field/i18n/en-US.yml
+++ b/packages/location-field/i18n/en-US.yml
@@ -1,38 +1,30 @@
-# Default messages for the LocationField component.
-# To use from a react-intl application:
-# - merge the content of this file into the messages object
-#   that has your other localized strings,
-# - flatten the ids, i.e. convert a structure such as
-#      otpUi > LocationField > stations
-#   into "otpUi.TripDetails.stations" (see LocationField story for an example),
-# - pass the resulting object to the messages prop of IntlProvider.
-
 otpUi:
   LocationField:
     beingTypingPrompt: Begin typing to search for locations
     clearLocation: Clear location
-    currentLocationUnavailable: Current location not available{error, select, undefined {} other { ({error})}}
+    currentLocationUnavailable: >-
+      Current location not available{error, select, undefined {} other {
+      ({error})}}
     fetchingLocation: Fetching location…
     fetchingSuggestions: Fetching suggestions…
     geocoderUnreachable: Could not reach geocoder{error, select, undefined {} other { ({error})}}
     homeLocation: Home
     myPlaces: My Places
     nearby: Nearby Stops
-    noResultsFound: >
+    noResultsFound: |
       No results found for {input, select,
         null {your query}
         other {{input}}
       }
-    placeNameWithDetails: "{placeName} ({details})"
-    # Note to translator: This is an implicit plural (as in "Other results").
     other: Other
+    placeNameWithDetails: "{placeName} ({details})"
     recentlySearched: Recently Searched
     resultsFound: >
-      {count, plural, =0 {No results} =1 {# geocoder result} other {# geocoder results}}
-      found for {input, select, null {your query} other {"{input}"}}
-    suggestedLocations: Suggested locations
-    suggestedLocationsLong: Toggle displaying the list of suggested locations
+      {count, plural, =0 {No results} =1 {# geocoder result} other {# geocoder
+      results}} found for {input, select, null {your query} other {"{input}"}}
     stations: Stations
     stops: Stops
+    suggestedLocations: Suggested locations
+    suggestedLocationsLong: Toggle displaying the list of suggested locations
     useCurrentLocation: Use Current Location
     workLocation: Work

--- a/packages/location-field/i18n/fr.yml
+++ b/packages/location-field/i18n/fr.yml
@@ -1,38 +1,30 @@
-# Default messages for the LocationField component.
-# To use from a react-intl application:
-# - merge the content of this file into the messages object
-#   that has your other localized strings,
-# - flatten the ids, i.e. convert a structure such as
-#      otpUi > LocationField > stations
-#   into "otpUi.TripDetails.stations" (see LocationField story for an example),
-# - pass the resulting object to the messages prop of IntlProvider.
-
 otpUi:
   LocationField:
     beingTypingPrompt: Tapez pour rechercher des lieux
     clearLocation: Effacer le lieu
-    currentLocationUnavailable: Position actuelle non disponible{error, select, undefined {} other { ({error})}}
+    currentLocationUnavailable: >-
+      Position actuelle non disponible{error, select, undefined {} other {
+      ({error})}}
     fetchingLocation: Chargement du lieu…
     fetchingSuggestions: Chargement des suggestions…
     geocoderUnreachable: Géocodeur introuvable{error, select, undefined {} other { ({error})}}
     homeLocation: Domicile
     myPlaces: Mes lieux
     nearby: Arrêts à proximité
-    noResultsFound: >
+    noResultsFound: |
       Aucun résultat trouvé pour {input, select,
         null {votre requête}
         other {{input}}
       }
-    placeNameWithDetails: "{placeName} ({details})"
-    # Note to translator: This is an implicit plural (as in "Other results").
     other: Autres
+    placeNameWithDetails: "{placeName} ({details})"
     recentlySearched: Recherches récentes
     resultsFound: >
-      {count, plural, =0 {Aucun résultat} =1 {# résultat} other {# résultats}} du
-      géocodeur pour {input, select, null {votre requête} other {"{input}"}}
+      {count, plural, =0 {Aucun résultat} =1 {# résultat} other {# résultats}}
+      du géocodeur pour {input, select, null {votre requête} other {"{input}"}}
     stations: Stations
     stops: Arrêts
-    useCurrentLocation: Utiliser ma position actuelle
-    workLocation: Lieu de travail
     suggestedLocations: Lieux suggérés
     suggestedLocationsLong: Basculer l'affichage de la liste de lieux suggérés
+    useCurrentLocation: Utiliser ma position actuelle
+    workLocation: Lieu de travail

--- a/packages/map-popup/i18n/en-US.yml
+++ b/packages/map-popup/i18n/en-US.yml
@@ -1,23 +1,9 @@
-# Default messages for the MapPopup component.
-# To use from a react-intl application:
-# - merge the content of this file into the messages object
-#   that has your other localized strings,
-# - flatten the ids, i.e. convert a structure such as
-#      otpUi > MapPopup > stopViewer
-#   into "otpUi.MapPopup.stopViewer" (see TripDetail story for an example),
-# - pass the resulting object to the messages prop of IntlProvider.
-#
-# The meaning of the pseudo <tags> used in the strings below is as follows:
-# - <dietaryLink>: The link to the Dietary Guidelines for Americans will surround the text enclosed by the tag.
-# - <strong>: The enclosed text will be rendered as strong (bold) text (same meaning as in HTML).
-
 otpUi:
   MapPopup:
     availableBikes: "Available bikes: {value}"
     availableDocks: "Available docks: {value}"
     floatingBike: "Free-floating bike: {name}"
-    floatingCar: "{company} {name}" # as in "CarCompany Veh1234a"
+    floatingCar: "{company} {name}"
     floatingEScooter: "E-scooter: {name}"
-
     stopId: "Stop ID: {stopId}"
     stopViewer: Stop Viewer

--- a/packages/map-popup/i18n/fr.yml
+++ b/packages/map-popup/i18n/fr.yml
@@ -3,8 +3,7 @@ otpUi:
     availableBikes: "Vélos disponibles : {value}"
     availableDocks: "Bornes disponibles : {value}"
     floatingBike: "Vélo flottant : {name}"
-    floatingCar: "{company} {name}" # as in "CarCompany Veh1234a"
-    floatingEScooter: "Trottinette {company}"
-
+    floatingCar: "{company} {name}"
+    floatingEScooter: Trottinette {company}
     stopId: Arrêt n°{stopId}
     stopViewer: Info arrêt

--- a/packages/printable-itinerary/i18n/en-US.yml
+++ b/packages/printable-itinerary/i18n/en-US.yml
@@ -1,20 +1,17 @@
-# Default messages for the PrintableItinerary component and subcomponents.
-# To use from a react-intl application:
-# - merge the content of this file into the messages object
-#   that has your other localized strings,
-# - flatten the ids, i.e. convert a structure such as
-#      otpUi > LocationField > stations
-#   into "otpUi.TripDetails.stations" (see story for an example),
-# - pass the resulting object to the messages prop of IntlProvider.
-
 otpUi:
   PrintableItinerary:
-    depart: <strong>Depart</strong> from <strong>{place}</strong>
     TncLeg:
-      estimatedTravelTime: "Estimated travel time: <strong>{duration}</strong> (does not account for traffic)"
+      estimatedTravelTime: >-
+        Estimated travel time: <strong>{duration}</strong> (does not account for
+        traffic)
       estimatedWaitTime: "Estimated wait time for pickup: <strong>{duration}</strong>"
       header: <strong>Take {company}</strong> to <strong>{place}</strong>
     TransitLeg:
-      alight: Get off at <strong>{place}</strong> ({stopId}) at <strong>{time, time, short}</strong>
-      board: Board at <strong>{place}</strong> ({stopId}) at <strong>{time, time, short}</strong>
+      alight: >-
+        Get off at <strong>{place}</strong> ({stopId}) at <strong>{time, time,
+        short}</strong>
+      board: >-
+        Board at <strong>{place}</strong> ({stopId}) at <strong>{time, time,
+        short}</strong>
       continuesAs: Continues as {routeDescription}
+    depart: <strong>Depart</strong> from <strong>{place}</strong>

--- a/packages/printable-itinerary/i18n/fr.yml
+++ b/packages/printable-itinerary/i18n/fr.yml
@@ -1,20 +1,17 @@
-# Default messages for the PrintableItinerary component and subcomponents.
-# To use from a react-intl application:
-# - merge the content of this file into the messages object
-#   that has your other localized strings,
-# - flatten the ids, i.e. convert a structure such as
-#      otpUi > LocationField > stations
-#   into "otpUi.TripDetails.stations" (see story for an example),
-# - pass the resulting object to the messages prop of IntlProvider.
-
 otpUi:
   PrintableItinerary:
-    depart: <strong>Partez</strong> de <strong>{place}</strong>
     TncLeg:
-      estimatedTravelTime: "Temps de trajet estimé : <strong>{duration}</strong> (ne tient pas compte de la circulation)"
+      estimatedTravelTime: >-
+        Temps de trajet estimé : <strong>{duration}</strong> (ne tient pas
+        compte de la circulation)
       estimatedWaitTime: "Temps d'attente estimé : <strong>{duration}</strong>"
       header: <strong>Prenez {company}</strong> vers <strong>{place}</strong>
     TransitLeg:
-      alight: Descendez à <strong>{place}</strong> ({stopId}) à <strong>{time, time, short}</strong>
-      board: Montez à <strong>{place}</strong> ({stopId}) à <strong>{time, time, short}</strong>
+      alight: >-
+        Descendez à <strong>{place}</strong> ({stopId}) à <strong>{time, time,
+        short}</strong>
+      board: >-
+        Montez à <strong>{place}</strong> ({stopId}) à <strong>{time, time,
+        short}</strong>
       continuesAs: Devient {routeDescription}
+    depart: <strong>Partez</strong> de <strong>{place}</strong>

--- a/packages/transit-vehicle-overlay/i18n/en-US.yml
+++ b/packages/transit-vehicle-overlay/i18n/en-US.yml
@@ -1,22 +1,9 @@
-# Default messages for the TransitVehicleOverlay component.
-# To use from a react-intl application:
-# - merge the content of this file into the messages object
-#   that has your other localized strings,
-# - flatten the ids, i.e. convert a structure such as
-#      otpUi > TransitVehicleOverlay > status
-#   into "otpUi.TransitVehicleOverlay.status".
-# - pass the resulting object to the messages prop of IntlProvider.
-#
-
 otpUi:
   TransitVehicleOverlay:
     defaultTooltip: "{route}: {duration} ago"
-    durationWithSeconds: "{hours, plural,
-      =0 {}
-      other {# hr }}{minutes, plural,
-      =0 {{seconds, plural, =0 {# min} other {}}}
-      other {# min}}{seconds, plural,
-      =0 {}
-      other { # sec}}"
+    durationWithSeconds: >-
+      {hours, plural, =0 {} other {# hr }}{minutes, plural, =0 {{seconds,
+      plural, =0 {# min} other {}}} other {# min}}{seconds, plural, =0 {} other
+      { # sec}}
     routeTitle: "{type} {name}"
     transitLine: Line

--- a/packages/transit-vehicle-overlay/i18n/fr.yml
+++ b/packages/transit-vehicle-overlay/i18n/fr.yml
@@ -1,22 +1,9 @@
-# Default messages for the TransitVehicleOverlay component.
-# To use from a react-intl application:
-# - merge the content of this file into the messages object
-#   that has your other localized strings,
-# - flatten the ids, i.e. convert a structure such as
-#      otpUi > TransitVehicleOverlay > status
-#   into "otpUi.TransitVehicleOverlay.status".
-# - pass the resulting object to the messages prop of IntlProvider.
-#
-
 otpUi:
   TransitVehicleOverlay:
     defaultTooltip: "{route} : il y a {duration}"
-    durationWithSeconds: "{hours, plural,
-      =0 {}
-      other {# hr }}{minutes, plural,
-      =0 {{seconds, plural, =0 {# mn} other {}}}
-      other {# mn}}{seconds, plural,
-      =0 {}
-      other { # s}}"
+    durationWithSeconds: >-
+      {hours, plural, =0 {} other {# hr }}{minutes, plural, =0 {{seconds,
+      plural, =0 {# mn} other {}}} other {# mn}}{seconds, plural, =0 {} other {
+      # s}}
     routeTitle: "{type} {name}"
     transitLine: Ligne

--- a/packages/trip-details/i18n/en-US.yml
+++ b/packages/trip-details/i18n/en-US.yml
@@ -1,42 +1,32 @@
-# Default messages for the TripDetails component.
-# To use from a react-intl application:
-# - merge the content of this file into the messages object
-#   that has your other localized strings,
-# - flatten the ids, i.e. convert a structure such as
-#      otpUi > TripDetails > calories
-#   into "otpUi.TripDetails.calories" (see TripDetail story for an example),
-# - pass the resulting object to the messages prop of IntlProvider.
-#
-# The meaning of the pseudo <tags> used in the strings below is as follows:
-# - <dietaryLink>: The link to the Dietary Guidelines for Americans will surround the text enclosed by the tag.
-# - <strong>: The enclosed text will be rendered as strong (bold) text (same meaning as in HTML).
-
 otpUi:
   TripDetails:
     calories: "Calories Burned: <strong>{calories, number, ::.}</strong>"
     caloriesDescription: >
-      Calories burned is based on
-      <strong>{walkMinutes, plural, one {# minute} other {# minutes}}</strong> spent walking and
-      <strong>{bikeMinutes, plural, one {# minute} other {# minutes}}</strong> spent biking during this trip.
-      Adapted from <dietaryLink>Dietary Guidelines for Americans 2005, page 16, Table 4</dietaryLink>.
+      Calories burned is based on <strong>{walkMinutes, plural, one {# minute}
+      other {# minutes}}</strong> spent walking and <strong>{bikeMinutes,
+      plural, one {# minute} other {# minutes}}</strong> spent biking during
+      this trip. Adapted from <dietaryLink>Dietary Guidelines for Americans
+      2005, page 16, Table 4</dietaryLink>.
     co2: "CO<sub>2</sub> Emitted: <strong>{co2}</strong>"
-    co2description:
-      "CO<sub>2</sub> intensity is calculated by multiplying the distance of each leg of a trip by the CO<sub>2</sub> intensity of each mode.
-      CO<sub>2</sub> intensity of each mode is derived from <link>this spreadsheet</link>."
-    departure: Depart <strong>{departureDate, date, long}</strong> at <strong>{departureDate, time, short}</strong>
+    co2description: >-
+      CO<sub>2</sub> intensity is calculated by multiplying the distance of each
+      leg of a trip by the CO<sub>2</sub> intensity of each mode. CO<sub>2</sub>
+      intensity of each mode is derived from <link>this spreadsheet</link>.
+    departure: >-
+      Depart <strong>{departureDate, date, long}</strong> at
+      <strong>{departureDate, time, short}</strong>
+    fareDetailsHeaders:
+      cash: Cash
+      electronic: Electronic
+      regular: Adult
+      senior: Senior
+      special: Special
+      youth: Youth
+    hideDetail: Hide details
+    showDetail: Show details
     title: Trip Details
     tncFare: "{companies} Fare: <strong>{minTNCFare} - {maxTNCFare}</strong>"
+    transferDiscountExplanation: Transfer discount of {transferAmount} is applied
     transitFare: Transit Fare
     transitFareEntry: "{name}: <strong>{value}</strong>"
-    # The {extraMessage} string is included here instead of in the html so that it can be rearranged or surrounded as required in certain languages
     tripIncludesFlex: This trip includes flexible routes. {extraMessage}
-    showDetail: Show details
-    hideDetail: Hide details
-    fareDetailsHeaders:
-      regular: "Adult"
-      youth: "Youth"
-      senior: "Senior"
-      electronic: "Electronic"
-      cash: "Cash"
-      special: "Special"
-    transferDiscountExplanation: Transfer discount of {transferAmount} is applied

--- a/packages/trip-details/i18n/fr.yml
+++ b/packages/trip-details/i18n/fr.yml
@@ -1,26 +1,31 @@
-# Example translations for the TripDetails component into French.
 otpUi:
   TripDetails:
     calories: "Calories dépensées : <strong>{calories, number, ::.}</strong>"
     caloriesDescription: >
-      La dépense calorique est calculée sur la base de
-      {walkMinutes, plural, one {<strong># minute</strong> effectuée} other {<strong># minutes</strong> effectuées}} à pied et
-      {bikeMinutes, plural, one {<strong># minute</strong> effectuée} other {<strong># minutes</strong> effectuées}} en vélo sur ce trajet.
-      (d'après <dietaryLink>Dietary Guidelines for Americans 2005, page 16, Table 4</dietaryLink>)
+      La dépense calorique est calculée sur la base de {walkMinutes, plural, one
+      {<strong># minute</strong> effectuée} other {<strong># minutes</strong>
+      effectuées}} à pied et {bikeMinutes, plural, one {<strong>#
+      minute</strong> effectuée} other {<strong># minutes</strong> effectuées}}
+      en vélo sur ce trajet. (d'après <dietaryLink>Dietary Guidelines for
+      Americans 2005, page 16, Table 4</dietaryLink>)
     co2: "CO<sub>2</sub> émis: <strong>{co2}</strong>"
-    co2description:
-      "L'intensité carbone est calculée en multipliant la distance de chaque portion d'un trajet par l'intensité en CO<sub>2</sub> du mode utilisé.
-      L'intensité en CO<sub>2</sub> de chaque mode est obtenue d'après <link>ce tableau</link>."
-    departure: Départ le <strong>{departureDate, date, long}</strong> à <strong>{departureDate, time, short}</strong>
+    co2description: >-
+      L'intensité carbone est calculée en multipliant la distance de chaque
+      portion d'un trajet par l'intensité en CO<sub>2</sub> du mode utilisé.
+      L'intensité en CO<sub>2</sub> de chaque mode est obtenue d'après <link>ce
+      tableau</link>.
+    departure: >-
+      Départ le <strong>{departureDate, date, long}</strong> à
+      <strong>{departureDate, time, short}</strong>
+    fareDetailsHeaders:
+      cash: Espèces
+      electronic: Électronique
+      regular: Normal
+      senior: Séniors
+      special: Spécial
+      youth: Jeunes
     title: Détails du trajet
     tncFare: "Tarif {companies} : <strong>{minTNCFare} - {maxTNCFare}</strong>"
     transitFare: Tarif en transports
     transitFareEntry: "{name} : <strong>{value}</strong>"
     tripIncludesFlex: Ce trajet comprend un service à la demande (Flex).
-    fareDetailsHeaders:
-      regular: "Normal"
-      youth: "Jeunes"
-      senior: "Séniors"
-      cash: "Espèces"
-      electronic: "Électronique"
-      special: "Spécial"

--- a/packages/trip-form/i18n/en-US.yml
+++ b/packages/trip-form/i18n/en-US.yml
@@ -1,12 +1,3 @@
-# Default messages for components in the trip-form package.
-# To use from a react-intl application:
-# - merge the content of this file into the messages object
-#   that has your other localized strings,
-# - flatten the ids, i.e. convert a structure such as
-#      otpUi > DateTimeSelector > now
-#   into "otpUi.DateTimeSelector.now" (see the DateTimeSelector story for an example),
-# - pass the resulting object to the messages prop of your IntlProvider.
-
 otpUi:
   DateTimeSelector:
     arrive: Arrive by
@@ -15,11 +6,17 @@ otpUi:
     depart: Depart at
     now: Leave now
     time: Time
+  SettingsSelectorPanel:
+    bikeOnly: Bike Only
+    escooterOnly: E-scooter Only
+    takeTransit: Take Transit
+    travelPreferences: Travel Preferences
+    use: Use
+    useCompanies: Use companies
+    walkOnly: Walk Only
   queryParameters:
     bikeSpeed: Bicycle Speed
-    # 1 mile = 100 "centimiles"
-    # There are exceptions in English for 1/10 mile , 1/4 mile, 1/2 mile etc.
-    distanceInMiles: >
+    distanceInMiles: |
       {centimiles, select, 
         10 {1/10 mile}
         25 {1/4 mile}
@@ -36,22 +33,14 @@ otpUi:
     optimizeBikeFriendly: Bike-Friendly Trip
     optimizeBikeSpeed: Speed
     optimizeFor: Optimize for
-    speedInMilesPerHour: "{mph} MPH" # Original units were all caps.
-    walkSpeed: Walk Speed
+    speedInMilesPerHour: "{mph} MPH"
     walkReluctance: Walking Avoidance
     walkReluctanceHigh: More Transit
     walkReluctanceLow: More Walking
+    walkSpeed: Walk Speed
     watts: E-scooter Power
     watts125kidsHoverboard: Kid's hoverboard (6 mph)
     watts1500powerfulEscooter: Powerful E-scooter (24 mph)
     watts250entryLevelEscooter: Entry-level scooter (11 mph)
     watts500robustEscooter: Robust E-scooter (18 mph)
     wheelchair: Prefer Wheelchair Accessible Routes
-  SettingsSelectorPanel:
-    bikeOnly: Bike Only
-    escooterOnly: E-scooter Only
-    takeTransit: Take Transit
-    travelPreferences: Travel Preferences
-    use: Use # as in "Use bus, train, subway".
-    useCompanies: Use companies # as in :"Use companies: Spin, Lime, Bolt"
-    walkOnly: Walk Only

--- a/packages/trip-form/i18n/fr.yml
+++ b/packages/trip-form/i18n/fr.yml
@@ -1,17 +1,16 @@
-# Default messages for components in the trip-form package.
-# To use from a react-intl application:
-# - merge the content of this file into the messages object
-#   that has your other localized strings,
-# - flatten the ids, i.e. convert a structure such as
-#      otpUi > DateTimeSelector > now
-#   into "otpUi.DateTimeSelector.now" (see the DateTimeSelector story for an example),
-# - pass the resulting object to the messages prop of your IntlProvider.
-
 otpUi:
   DateTimeSelector:
     arrive: Arrivée
     depart: Départ
     now: Maintenant
+  SettingsSelectorPanel:
+    bikeOnly: Vélo uniquement
+    escooterOnly: Trottinette uniquement
+    takeTransit: En transports
+    travelPreferences: Préférences de trajet
+    use: Utiliser
+    useCompanies: Prestataires
+    walkOnly: À pied uniquement
   queryParameters:
     bikeSpeed: Vitesse à vélo
     distanceInMiles: "{miles, number, :: unit/mile unit-width-full-name}"
@@ -25,21 +24,13 @@ otpUi:
     optimizeBikeSpeed: plus rapides
     optimizeFor: Privilégier les trajets
     speedInMilesPerHour: "{mph} mi/h"
-    walkSpeed: Vitesse à pied
     walkReluctance: Je préfère
     walkReluctanceHigh: Plus de transports
     walkReluctanceLow: Plus de marche
+    walkSpeed: Vitesse à pied
     watts: Puissance de la trottinette électrique
     watts125kidsHoverboard: Hoverboard pour enfants (10 km/h)
     watts1500powerfulEscooter: Trottinette puissante (40 km/h)
     watts250entryLevelEscooter: Trottinette de base (18 km/h)
     watts500robustEscooter: Trottinette robuste (30 km/h)
     wheelchair: Privilégier l'accès en fauteuil roulant
-  SettingsSelectorPanel:
-    bikeOnly: Vélo uniquement
-    escooterOnly: Trottinette uniquement
-    takeTransit: En transports
-    travelPreferences: Préférences de trajet
-    use: Utiliser # as in "Use bus, train, subway"
-    useCompanies: Prestataires # as in "Use companies: Spin, Lime, Bolt"
-    walkOnly: À pied uniquement

--- a/yarn.lock
+++ b/yarn.lock
@@ -7195,6 +7195,15 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
 clone-deep@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
@@ -12102,7 +12111,7 @@ js-yaml@^3.13.1, js-yaml@^3.9.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^4.1.0:
+js-yaml@^4.0.0, js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
@@ -19478,6 +19487,14 @@ yaml-loader@^0.6.0:
     loader-utils "^1.4.0"
     yaml "^1.8.3"
 
+yaml-sort@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yaml-sort/-/yaml-sort-2.0.0.tgz#2774745794de34384aaec88d42e29a128599c454"
+  integrity sha512-RWANpatfFS+1iPKUX9qqN95GozgZQs7Xl/Mw6pp7UDP9h1lX04o9EScnlheYk2YzHJWp+YiymjFSt4GxGuu65Q==
+  dependencies:
+    js-yaml "^4.0.0"
+    yargs "^17.0.0"
+
 yaml@^1.10.0, yaml@^1.7.2, yaml@^1.8.3:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
@@ -19518,6 +19535,11 @@ yargs-parser@^20.2.2, yargs-parser@^20.2.3, yargs-parser@^20.2.7:
   version "20.2.7"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
   integrity sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
+
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs@^13.3.0:
   version "13.3.2"
@@ -19581,6 +19603,19 @@ yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yargs@^17.0.0:
+  version "17.7.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.1.tgz#34a77645201d1a8fc5213ace787c220eabbd0967"
+  integrity sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yargs@^17.0.1:
   version "17.1.1"


### PR DESCRIPTION
This PR adds `yaml-sort` to automatically sort modified YAML files (using A-Za-z) during the pre-commit stage.
`yaml-sort` will also reformat certain long strings and strip comments, so I have moved instructions to README and translation notes to Weblate ([see here for instance](https://hosted.weblate.org/translate/otp-react-redux/otp-ui-trip-form/en_US/?sort_by=-priority%2Cposition&offset=34)).
