### PR TITLE
Spell CO₂ using the Unicode subscript

### DIFF
--- a/packages/trip-details/i18n/en-US.yml
+++ b/packages/trip-details/i18n/en-US.yml
@@ -7,11 +7,11 @@ otpUi:
       plural, one {# minute} other {# minutes}}</strong> spent biking during
       this trip. Adapted from <dietaryLink>Dietary Guidelines for Americans
       2005, page 16, Table 4</dietaryLink>.
-    co2: "CO<sub>2</sub> Emitted: <strong>{co2}</strong>"
+    co2: "CO₂ Emitted: <strong>{co2}</strong>"
     co2description: >-
-      CO<sub>2</sub> intensity is calculated by multiplying the distance of each
-      leg of a trip by the CO<sub>2</sub> intensity of each mode. CO<sub>2</sub>
-      intensity of each mode is derived from <link>this spreadsheet</link>.
+      CO₂ intensity is calculated by multiplying the distance of each leg of a
+      trip by the CO₂ intensity of each mode. CO₂ intensity of each mode is
+      derived from <link>this spreadsheet</link>.
     departure: >-
       Depart <strong>{departureDate, date, long}</strong> at
       <strong>{departureDate, time, short}</strong>

--- a/packages/trip-details/i18n/es.yml
+++ b/packages/trip-details/i18n/es.yml
@@ -1,30 +1,32 @@
 otpUi:
   TripDetails:
     calories: "Calorías quemadas: <strong>{calories, number, ::.}</strong>"
-    caloriesDescription: "Las calorías quemadas se basan en <strong>{walkMinutes,\
-      \ plural, one {# minuto} other {# minutos}}</strong> de caminata y <strong>{bikeMinutes,\
-      \ plural, one {# minuto} other {# minutos}}</strong> en bicicleta durante este\
-      \ viaje. Adaptado del <dietaryLink>Dietary Guidelines for Americans 2005, page\
-      \ 16, Table 4</dietaryLink>.\n"
-    co2: "CO<sub>2</sub> emitido: <strong>{co2}</strong>"
-    departure: Salida <strong>{departureDate, date, long}</strong> a las <strong>{departureDate,
-      time, short}</strong>
+    caloriesDescription: >
+      Las calorías quemadas se basan en <strong>{walkMinutes, plural, one {#
+      minuto} other {# minutos}}</strong> de caminata y <strong>{bikeMinutes,
+      plural, one {# minuto} other {# minutos}}</strong> en bicicleta durante
+      este viaje. Adaptado del <dietaryLink>Dietary Guidelines for Americans
+      2005, page 16, Table 4</dietaryLink>.
+    co2: "CO₂ emitido: <strong>{co2}</strong>"
+    co2description: >-
+      La intensidad de CO₂ se calcula multiplicando la distancia de cada tramo
+      de un viaje por la intensidad de CO₂ de cada modo. La intensidad de CO₂ de
+      cada modo se deriva de esta <link>hoja de cálculo</link>.
+    departure: >-
+      Salida <strong>{departureDate, date, long}</strong> a las
+      <strong>{departureDate, time, short}</strong>
     fareDetailsHeaders:
       cash: Efectivo
+      electronic: Electrónico
       regular: Adulto
       senior: Major edad
       special: Especial
       youth: Juventud
-      electronic: Electrónico
+    hideDetail: Ocultar detalles
+    showDetail: Mostrar detalles
     title: Detalles del viaje
     tncFare: "{companies} Tarifa: <strong>{minTNCFare} - {maxTNCFare}</strong>"
+    transferDiscountExplanation: Se aplica un descuento de transferencia de {transferAmount}
     transitFare: Tarifa de tránsito
     transitFareEntry: "{name} : <strong>{value}</strong>"
     tripIncludesFlex: Este viaje incluye rutas flexibles. {extraMessage}
-    co2description: La intensidad de CO<sub>2 </sub> se calcula multiplicando la distancia
-      de cada tramo de un viaje por la intensidad de CO<sub>2</sub> de cada modo.
-      La intensidad de CO<sub>2 </sub> de cada modo se deriva de esta <link>hoja de
-      cálculo</link>.
-    hideDetail: Ocultar detalles
-    showDetail: Mostrar detalles
-    transferDiscountExplanation: Se aplica un descuento de transferencia de {transferAmount}

--- a/packages/trip-details/i18n/fr.yml
+++ b/packages/trip-details/i18n/fr.yml
@@ -8,12 +8,11 @@ otpUi:
       minute</strong> effectuée} other {<strong># minutes</strong> effectuées}}
       en vélo sur ce trajet. (d'après <dietaryLink>Dietary Guidelines for
       Americans 2005, page 16, Table 4</dietaryLink>)
-    co2: "CO<sub>2</sub> émis : <strong>{co2}</strong>"
+    co2: "CO₂ émis : <strong>{co2}</strong>"
     co2description: >-
       L'intensité carbone est calculée en multipliant la distance de chaque
-      portion d'un trajet par l'intensité en CO<sub>2</sub> du mode utilisé.
-      L'intensité en CO<sub>2</sub> de chaque mode est obtenue d'après <link>ce
-      tableau</link>.
+      portion d'un trajet par l'intensité en CO₂ du mode utilisé. L'intensité en
+      CO₂ de chaque mode est obtenue d'après <link>ce tableau</link>.
     departure: >-
       Départ le <strong>{departureDate, date, long}</strong> à
       <strong>{departureDate, time, short}</strong>
@@ -24,12 +23,11 @@ otpUi:
       senior: Séniors
       special: Spécial
       youth: Jeunes
+    hideDetail: Masquer les détails
+    showDetail: Afficher les détails
     title: Détails du trajet
     tncFare: "Tarif {companies} : <strong>{minTNCFare} - {maxTNCFare}</strong>"
+    transferDiscountExplanation: Cette correspondance vous donne une réduction de {transferAmount}
     transitFare: Tarif en transports
     transitFareEntry: "{name} : <strong>{value}</strong>"
     tripIncludesFlex: Ce trajet comprend un service à la demande (Flex). {extraMessage}
-    showDetail: Afficher les détails
-    hideDetail: Masquer les détails
-    transferDiscountExplanation: Cette correspondance vous donne une réduction de
-      {transferAmount}

--- a/packages/trip-details/i18n/ko.yml
+++ b/packages/trip-details/i18n/ko.yml
@@ -1,26 +1,30 @@
 otpUi:
   TripDetails:
     calories: "소모 칼로리: <strong>{calories, number, ::.}</strong>"
+    caloriesDescription: >
+      소모된 칼로리는 이 트립에서 <strong>{walkMinutes}분 동안 </strong>걷고<strong>
+      <strong>{bikeMinutes}분</strong> 동안 자전거를 탄 것을 기준으로 합니다.
+      <dietaryLink>Dietary Guidelines for Americans 2005, 16 페이지, 표
+      4</dietaryLink> 적용.
+    co2: "CO₂ 배출: <strong>{co2}</strong>"
+    co2description: >-
+      CO₂ 강도는 각 모드의 CO₂ 강도를 트립에서 각 다리가 걸은 거리를 곱하여 계산됩니다. 각 모드의 CO₂ 강도는 <link>이
+      스프레드시트</link>에 기반합니다.
+    departure: >-
+      <strong>{departureDate, time, short}</strong>에 <strong>{departureDate,
+      date, long}</strong> 출발
     fareDetailsHeaders:
       cash: 현금
-      special: 특별
-      regular: 성인
-      youth: 청소년
-      senior: 경로
       electronic: 전자
-    departure: <strong>{departureDate, time, short}</strong>에 <strong>{departureDate,
-      date, long}</strong> 출발
-    title: 트립 상세정보
-    tncFare: "{companies} 운임: <strong>{minTNCFare} - {maxTNCFare}</strong>"
-    transitFare: 대중 교통 운임
-    transitFareEntry: "{name} : <strong>{value}</strong>"
-    caloriesDescription: "소모된 칼로리는 이 트립에서 <strong>{walkMinutes}분 동안 </strong>걷고<strong>\
-      \ <strong>{bikeMinutes}분</strong> 동안 자전거를 탄 것을 기준으로 합니다. <dietaryLink>Dietary\
-      \ Guidelines for Americans 2005, 16 페이지, 표 4</dietaryLink> 적용.\n"
-    co2: "CO<sub>2</sub> 배출: <strong>{co2}</strong>"
-    co2description: CO<sub>2</sub> 강도는 각 모드의 CO<sub>2</sub> 강도를 트립에서 각 다리가 걸은 거리를
-      곱하여 계산됩니다. 각 모드의 CO<sub>2</sub> 강도는 <link>이 스프레드시트</link>에 기반합니다.
-    tripIncludesFlex: 이 트립에는 가변 경로가 포함되어 있습니다. {extraMessage}
+      regular: 성인
+      senior: 경로
+      special: 특별
+      youth: 청소년
     hideDetail: 세부정보 숨기기
     showDetail: 세부정보 표시
+    title: 트립 상세정보
+    tncFare: "{companies} 운임: <strong>{minTNCFare} - {maxTNCFare}</strong>"
     transferDiscountExplanation: 환승 할인 {transferAmount} 적용
+    transitFare: 대중 교통 운임
+    transitFareEntry: "{name} : <strong>{value}</strong>"
+    tripIncludesFlex: 이 트립에는 가변 경로가 포함되어 있습니다. {extraMessage}

--- a/packages/trip-details/i18n/vi.yml
+++ b/packages/trip-details/i18n/vi.yml
@@ -1,28 +1,31 @@
 otpUi:
   TripDetails:
     calories: "Calo bị đốt cháy: <strong>{calories, number, ::.}</strong>"
-    departure: Khởi hành <strong>{departureDate, date, long}</strong> lúc <strong>{departureDate,
-      time, short}</strong>
+    caloriesDescription: >
+      Lượng calo bị đốt cháy dựa trên <strong>{walkMinutes} phút</strong> đi bộ
+      và <strong>{bikeMinutes} phút</strong> dành cho chuyến đi xe đạp trong
+      chuyến đi này. Phỏng theo <dietaryLink>Dietary Guidelines for Americans
+      2005, trang 16, hình ảnh 4</dietaryLink>.
+    co2: "CO₂ thải ra: <strong>{co2}</strong>"
+    co2description: >-
+      Nồng độ CO₂ được tính bằng cách nhân khoảng cách của mỗi chặng của một
+      chuyến đi với nồng độ CO₂ của mỗi phương tiện. Nồng độ CO₂ của mỗi phương
+      tiện được lấy từ <link>bảng tính này</link>.
+    departure: >-
+      Khởi hành <strong>{departureDate, date, long}</strong> lúc
+      <strong>{departureDate, time, short}</strong>
+    fareDetailsHeaders:
+      cash: Tiền mặt
+      electronic: Điện tử
+      regular: Người lớn
+      senior: Người lớn tuổi
+      special: Đặc biệt
+      youth: Thiếu niên
+    hideDetail: Ẩn chi tiết
+    showDetail: Hiển thị chi tiết
     title: Chi tiết chuyến đi
     tncFare: "{companies} Giá vé: <strong>{minTNCFare} - {maxTNCFare}</strong>"
+    transferDiscountExplanation: Giảm giá chuyển khoản {transferAmount} được áp dụng
     transitFare: Giá vé xe công cộng
     transitFareEntry: "{name}: <strong>{value}</strong>"
-    caloriesDescription: "Lượng calo bị đốt cháy dựa trên <strong>{walkMinutes} phút</strong>\
-      \ đi bộ và <strong>{bikeMinutes} phút</strong> dành cho chuyến đi xe đạp trong\
-      \ chuyến đi này. Phỏng theo <dietaryLink>Dietary Guidelines for Americans 2005,\
-      \ trang 16, hình ảnh 4</dietaryLink>.\n"
-    co2: "CO<sub>2</sub> thải ra: <strong>{co2}</strong>"
-    co2description: Nồng độ CO<sub>2</sub> được tính bằng cách nhân khoảng cách của
-      mỗi chặng của một chuyến đi với nồng độ CO<sub>2</sub> của mỗi phương tiện.
-      Nồng độ CO<sub>2</sub> của mỗi phương tiện được lấy từ <link>bảng tính này</link>.
     tripIncludesFlex: Chuyến đi này bao gồm các tuyến đường linh hoạt. {extraMessage}
-    fareDetailsHeaders:
-      regular: Người lớn
-      youth: Thiếu niên
-      senior: Người lớn tuổi
-      electronic: Điện tử
-      cash: Tiền mặt
-      special: Đặc biệt
-    hideDetail: Ẩn chi tiết
-    transferDiscountExplanation: Giảm giá chuyển khoản {transferAmount} được áp dụng
-    showDetail: Hiển thị chi tiết

--- a/packages/trip-details/i18n/zh_Hans.yml
+++ b/packages/trip-details/i18n/zh_Hans.yml
@@ -1,24 +1,27 @@
 otpUi:
   TripDetails:
-    tncFare: "{companies} 票价: <strong>{minTNCFare} - {maxTNCFare}</strong>"
-    transitFare: 公共交通费
-    tripIncludesFlex: 这个行程包括灵活的路线. {extraMessage}
-    fareDetailsHeaders:
-      regular: 成人
-      youth: 青年
-      senior: 长者
-      electronic: 电子的
-      cash: 现金
-      special: 特别的
     calories: "卡路里消耗: <strong>{calories, number, ::.}</strong>"
-    departure: <strong>{departureDate, date, long}</strong> <strong>{departureDate,
-      time, short}</strong> 出发
-    title: 行程详情
-    transitFareEntry: "{name}: <strong>{value}</strong>"
+    caloriesDescription: >
+      燃烧的卡路里是根据这次旅行中的 <strong>{walkMinutes}分钟</strong> 步行和
+      <strong>{bikeMinutes}分钟</strong> 骑自行车计算的. 改编自< <dietaryLink>Dietary
+      Guidelines for Americans 2005, 页16, 图片4</dietaryLink>.
     co2: "排放的二氧化碳: <strong>{co2}</strong>"
-    co2description: CO<sub>2</sub> 强度的计算方法是将行程的每条腿的距离乘以每种模式的 CO<sub>2</sub> 强度。 每种模式的二氧化碳强度来自<link>此电子表格</link>。
-    caloriesDescription: "燃烧的卡路里是根据这次旅行中的 <strong>{walkMinutes}分钟</strong> 步行和 <strong>{bikeMinutes}分钟</strong>\
-      \ 骑自行车计算的. 改编自< <dietaryLink>Dietary Guidelines for Americans 2005, 页16, 图片4</dietaryLink>.\n"
+    co2description: CO₂ 强度的计算方法是将行程的每条腿的距离乘以每种模式的 CO₂ 强度。 每种模式的二氧化碳强度来自<link>此电子表格</link>。
+    departure: >-
+      <strong>{departureDate, date, long}</strong> <strong>{departureDate, time,
+      short}</strong> 出发
+    fareDetailsHeaders:
+      cash: 现金
+      electronic: 电子的
+      regular: 成人
+      senior: 长者
+      special: 特别的
+      youth: 青年
     hideDetail: 隐藏细节
     showDetail: 显示详细资料
+    title: 行程详情
+    tncFare: "{companies} 票价: <strong>{minTNCFare} - {maxTNCFare}</strong>"
     transferDiscountExplanation: 应用了 {transferAmount} 的转让折扣
+    transitFare: 公共交通费
+    transitFareEntry: "{name}: <strong>{value}</strong>"
+    tripIncludesFlex: 这个行程包括灵活的路线. {extraMessage}

--- a/packages/trip-details/src/index.tsx
+++ b/packages/trip-details/src/index.tsx
@@ -28,8 +28,6 @@ import defaultEnglishMessages from "../i18n/en-US.yml";
 // - the yaml loader for jest returns messages with flattened ids.
 const defaultMessages: Record<string, string> = flatten(defaultEnglishMessages);
 
-const subText = contents => <sub>{contents}</sub>;
-
 /**
  * Helper function to specify the link to dietary table.
  */
@@ -345,8 +343,7 @@ export function TripDetails({
                         unitDisplay="narrow"
                       />
                     ),
-                    strong: boldText,
-                    sub: subText
+                    strong: boldText
                   }}
                 />
               </S.CO2Summary>
@@ -358,7 +355,6 @@ export function TripDetails({
                 }
                 values={{
                   link: CO2DescriptionLink,
-                  sub: subText,
                   totalDistance
                 }}
                 description="Text explaining how the CO2 emissions is calculated."

--- a/packages/trip-details/src/index.tsx
+++ b/packages/trip-details/src/index.tsx
@@ -225,7 +225,7 @@ export function TripDetails({
     walkDuration
   } = coreUtils.itinerary.calculatePhysicalActivity(itinerary);
 
-  // Calculate CO2 if it's not provided by the itinerary
+  // Calculate CO₂ if it's not provided by the itinerary
   const co2 =
     itinerary.co2 ||
     (co2Config?.enabled &&
@@ -331,7 +331,7 @@ export function TripDetails({
               <S.CO2Summary>
                 <FormattedMessage
                   defaultMessage={defaultMessages["otpUi.TripDetails.co2"]}
-                  description="Text showing the quantity of CO2 emitted by this trip."
+                  description="Text showing the quantity of CO₂ emitted by this trip."
                   id="otpUi.TripDetails.co2"
                   values={{
                     co2: (
@@ -353,12 +353,12 @@ export function TripDetails({
                 defaultMessage={
                   defaultMessages["otpUi.TripDetails.co2description"]
                 }
+                description="Text explaining how the CO₂ emissions are calculated."
+                id="otpUi.TripDetails.co2description"
                 values={{
                   link: CO2DescriptionLink,
                   totalDistance
                 }}
-                description="Text explaining how the CO2 emissions is calculated."
-                id="otpUi.TripDetails.co2description"
               />
             }
           />

--- a/packages/trip-details/src/types.ts
+++ b/packages/trip-details/src/types.ts
@@ -102,7 +102,7 @@ export interface TripDetailsProps {
    */
   itinerary: Itinerary;
   /**
-   * Object containing the CO2 config.
+   * Object containing the CO₂ config.
    */
   co2Config?: CO2ConfigType;
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -775,6 +775,6 @@ export type LegProduct = {
 };
 
 /**
- * Options for units of mass (used in CO2 calculation config)
+ * Options for units of mass (used in CO₂ calculation config)
  */
 export type MassUnitOption = "ounce" | "kilogram" | "pound" | "gram";


### PR DESCRIPTION
This PR corrects the spelling of CO₂ to use the Unicode subscript.