### PR TITLE
Avoid Trip Details Crash on Missing Fare Info

### DIFF
--- a/packages/itinerary-body/src/__mocks__/itineraries/bike-transit-bike.json
+++ b/packages/itinerary-body/src/__mocks__/itineraries/bike-transit-bike.json
@@ -18,8 +18,7 @@
           "currency": "USD",
           "defaultFractionDigits": 2,
           "currencyCode": "USD"
-        },
-        "cents": 250
+        }
       }
     },
     "details": {

--- a/packages/itinerary-body/src/__mocks__/itineraries/park-and-ride.json
+++ b/packages/itinerary-body/src/__mocks__/itineraries/park-and-ride.json
@@ -15,9 +15,7 @@
       "regular": {
         "currency": {
           "symbol": "$",
-          "currency": "USD",
-          "defaultFractionDigits": 2,
-          "currencyCode": "USD"
+          "defaultFractionDigits": 2
         },
         "cents": 250
       }

--- a/packages/trip-details/i18n/en-US.yml
+++ b/packages/trip-details/i18n/en-US.yml
@@ -29,4 +29,5 @@ otpUi:
     transferDiscountExplanation: Transfer discount of {transferAmount} is applied
     transitFare: Transit Fare
     transitFareEntry: "{name}: <strong>{value}</strong>"
+    transitFareUnknown: No fare info
     tripIncludesFlex: This trip includes flexible routes. {extraMessage}

--- a/packages/trip-details/i18n/es.yml
+++ b/packages/trip-details/i18n/es.yml
@@ -29,4 +29,5 @@ otpUi:
     transferDiscountExplanation: Se aplica un descuento de transferencia de {transferAmount}
     transitFare: Tarifa de tránsito
     transitFareEntry: "{name} : <strong>{value}</strong>"
+    transitFareUnknown: No hay información sobre las tarifas
     tripIncludesFlex: Este viaje incluye rutas flexibles. {extraMessage}

--- a/packages/trip-details/i18n/fr.yml
+++ b/packages/trip-details/i18n/fr.yml
@@ -30,4 +30,5 @@ otpUi:
     transferDiscountExplanation: Cette correspondance vous donne une réduction de {transferAmount}
     transitFare: Tarif en transports
     transitFareEntry: "{name} : <strong>{value}</strong>"
+    transitFareUnknown: Tarif inconnu
     tripIncludesFlex: Ce trajet comprend un service à la demande (Flex). {extraMessage}

--- a/packages/trip-details/i18n/ko.yml
+++ b/packages/trip-details/i18n/ko.yml
@@ -27,4 +27,5 @@ otpUi:
     transferDiscountExplanation: 환승 할인 {transferAmount} 적용
     transitFare: 대중 교통 운임
     transitFareEntry: "{name} : <strong>{value}</strong>"
+    transitFareUnknown: 운임 정보 없음
     tripIncludesFlex: 이 트립에는 가변 경로가 포함되어 있습니다. {extraMessage}

--- a/packages/trip-details/i18n/vi.yml
+++ b/packages/trip-details/i18n/vi.yml
@@ -28,4 +28,5 @@ otpUi:
     transferDiscountExplanation: Giảm giá chuyển khoản {transferAmount} được áp dụng
     transitFare: Giá vé xe công cộng
     transitFareEntry: "{name}: <strong>{value}</strong>"
+    transitFareUnknown: Không có thông tin giá vé
     tripIncludesFlex: Chuyến đi này bao gồm các tuyến đường linh hoạt. {extraMessage}

--- a/packages/trip-details/i18n/zh_Hans.yml
+++ b/packages/trip-details/i18n/zh_Hans.yml
@@ -24,4 +24,5 @@ otpUi:
     transferDiscountExplanation: 应用了 {transferAmount} 的转让折扣
     transitFare: 公共交通费
     transitFareEntry: "{name}: <strong>{value}</strong>"
+    transitFareUnknown: 没有票价信息
     tripIncludesFlex: 这个行程包括灵活的路线. {extraMessage}

--- a/packages/trip-details/src/index.tsx
+++ b/packages/trip-details/src/index.tsx
@@ -92,7 +92,7 @@ const TransitFare = ({
   const currentFare = transitFares[fareKey];
 
   // TODO: Is this needed? Every implementation of TransitFare does a check for currentFare's existence, although not the cents field
-  if (!currentFare?.cents) {
+  if (typeof currentFare?.cents !== "number") {
     return (
       <FormattedMessage
         defaultMessage={defaultMessages["otpUi.TripDetails.transitFareUnknown"]}
@@ -180,29 +180,26 @@ export function TripDetails({
               transitFares={transitFares}
             />
           </summary>
-          {fareDetailsLayout
-            ? // Show full ƒare details by leg
-              transitFares?.[defaultFare] && (
-                <FareLegTable
-                  layout={fareDetailsLayout}
-                  itinerary={itinerary}
+          {fareDetailsLayout ? (
+            // Show full ƒare details by leg
+            <FareLegTable layout={fareDetailsLayout} itinerary={itinerary} />
+          ) : (
+            // Just show the fares for each payment type
+            fareKeys.map(fareKey => {
+              // Don't show the default fare twice!
+              if (fareKey === defaultFare) {
+                return null;
+              }
+              return (
+                <TransitFare
+                  fareKey={fareKey}
+                  fareKeyNameMap={fareKeyNameMap}
+                  key={fareKey}
+                  transitFares={transitFares}
                 />
-              )
-            : // Just show the fares for each payment type
-              fareKeys.map(fareKey => {
-                // Don't show the default fare twice!
-                if (fareKey === defaultFare) {
-                  return null;
-                }
-                return (
-                  <TransitFare
-                    fareKey={fareKey}
-                    key={fareKey}
-                    fareKeyNameMap={fareKeyNameMap}
-                    transitFares={transitFares}
-                  />
-                );
-              })}
+              );
+            })
+          )}
         </TransitFareWrapper>
         {minTNCFare !== 0 && (
           <S.TNCFare>

--- a/packages/trip-details/src/index.tsx
+++ b/packages/trip-details/src/index.tsx
@@ -91,6 +91,16 @@ const TransitFare = ({
 }: TransitFareProps): ReactElement => {
   const currentFare = transitFares[fareKey];
 
+  if (!currentFare?.cents) {
+    return (
+      <FormattedMessage
+        defaultMessage={defaultMessages["otpUi.TripDetails.transitFareUnknown"]}
+        description="Text showing that no fare information is present."
+        id="otpUi.TripDetails.transitFareUnknown"
+      />
+    );
+  }
+
   return (
     <span>
       <FormattedMessage
@@ -101,7 +111,7 @@ const TransitFare = ({
           name: fareKeyNameMap[fareKey] || fareNameFallback || fareKey,
           strong: boldText,
           value: renderFare(
-            currentFare.currency.currencyCode,
+            currentFare?.currency?.currencyCode || "USD",
             currentFare.cents / 100
           )
         }}
@@ -150,7 +160,7 @@ export function TripDetails({
     const TransitFareWrapper =
       transitFares && fareKeys.length > 1 ? S.TransitFare : S.TransitFareSingle;
 
-    fare = (
+    fare = transitFares?.[defaultFare] && (
       <S.Fare>
         <TransitFareWrapper>
           <summary style={{ display: fareKeys.length > 1 ? "list-item" : "" }}>
@@ -169,26 +179,29 @@ export function TripDetails({
               transitFares={transitFares}
             />
           </summary>
-          {fareDetailsLayout ? (
-            // Show full ƒare details by leg
-            <FareLegTable layout={fareDetailsLayout} itinerary={itinerary} />
-          ) : (
-            // Just show the fares for each payment type
-            fareKeys.map(fareKey => {
-              // Don't show the default fare twice!
-              if (fareKey === defaultFare) {
-                return null;
-              }
-              return (
-                <TransitFare
-                  fareKey={fareKey}
-                  key={fareKey}
-                  fareKeyNameMap={fareKeyNameMap}
-                  transitFares={transitFares}
+          {fareDetailsLayout
+            ? // Show full ƒare details by leg
+              transitFares?.[defaultFare] && (
+                <FareLegTable
+                  layout={fareDetailsLayout}
+                  itinerary={itinerary}
                 />
-              );
-            })
-          )}
+              )
+            : // Just show the fares for each payment type
+              fareKeys.map(fareKey => {
+                // Don't show the default fare twice!
+                if (fareKey === defaultFare) {
+                  return null;
+                }
+                return (
+                  <TransitFare
+                    fareKey={fareKey}
+                    key={fareKey}
+                    fareKeyNameMap={fareKeyNameMap}
+                    transitFares={transitFares}
+                  />
+                );
+              })}
         </TransitFareWrapper>
         {minTNCFare !== 0 && (
           <S.TNCFare>

--- a/packages/trip-details/src/index.tsx
+++ b/packages/trip-details/src/index.tsx
@@ -91,6 +91,7 @@ const TransitFare = ({
 }: TransitFareProps): ReactElement => {
   const currentFare = transitFares[fareKey];
 
+  // TODO: Is this needed? Every implementation of TransitFare does a check for currentFare's existence, although not the cents field
   if (!currentFare?.cents) {
     return (
       <FormattedMessage


### PR DESCRIPTION
Previous crash could happen if currency was missing, `cents` was missing, or if the entire fare object was missing. This PR allows for all those cases to occur.