### PR TITLE
fix(core-utils): add more missing fields to graphQL Plan request

### DIFF
--- a/packages/core-utils/src/planQuery.graphql
+++ b/packages/core-utils/src/planQuery.graphql
@@ -46,6 +46,13 @@ query PlanQuery(
       waitingTime
       walkTime
       legs {
+        pickupType
+        dropoffType
+        pickupBookingInfo {
+          earliestBookingTime {
+            daysPrior
+          }
+        }
         rentedBike
         interlineWithPreviousLeg
         departureDelay

--- a/packages/core-utils/src/planQuery.graphql
+++ b/packages/core-utils/src/planQuery.graphql
@@ -105,6 +105,7 @@ query PlanQuery(
           lat
           lon
           name
+          stopIndex
           vertexType
           rentalVehicle {
             network
@@ -125,6 +126,7 @@ query PlanQuery(
           lat
           lon
           name
+          stopIndex
           vertexType
           rentalVehicle {
             network


### PR DESCRIPTION
For now, this PR adds `stopIndex` for trip viewing.