### PR TITLE
fix(itinerary-body): Add distances to access legs

### DIFF
--- a/packages/itinerary-body/src/defaults/access-leg-step.tsx
+++ b/packages/itinerary-body/src/defaults/access-leg-step.tsx
@@ -1,6 +1,7 @@
 import { Step } from "@opentripplanner/types";
 import React, { HTMLAttributes, ReactElement } from "react";
-import { FormattedMessage } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
+import { humanizeDistanceString } from "@opentripplanner/humanize-distance";
 import { defaultMessages } from "../util";
 
 import * as S from "../styled";
@@ -21,6 +22,8 @@ export default function AccessLegStep({
   style
 }: Props): ReactElement {
   const { absoluteDirection, relativeDirection, streetName } = step;
+  const intl = useIntl();
+
   const street = (
     <S.StepStreetName>
       <StreetName rawStreetName={streetName} />
@@ -70,6 +73,12 @@ export default function AccessLegStep({
     // for styled-components support.
     <span className={className} style={style}>
       {stepContent}
+      {/* TODO: Implement metric vs imperial (up until now it's just imperial). */}
+      {step?.distance && (
+        <S.StepLength>
+          {humanizeDistanceString(step.distance, false, intl)}
+        </S.StepLength>
+      )}
     </span>
   );
 }

--- a/packages/itinerary-body/src/styled.tsx
+++ b/packages/itinerary-body/src/styled.tsx
@@ -594,6 +594,12 @@ export const StepStreetName = styled.span`
   font-weight: 500;
 `;
 
+export const StepLength = styled.span`
+  font-weight: 200;
+  opacity: 0.8;
+  padding-left: 1ch;
+`;
+
 export const StopIdSpan = styled.span`
   font-weight: 200;
   font-size: 0.9em;

--- a/packages/itinerary-body/src/styled.tsx
+++ b/packages/itinerary-body/src/styled.tsx
@@ -596,7 +596,8 @@ export const StepStreetName = styled.span`
 
 export const StepLength = styled.span`
   font-weight: 200;
-  opacity: 0.8;
+  /* This is the lowest opacity which still meets AA text color contrast standards */
+  opacity: 0.8975;
   padding-left: 1ch;
 `;
 


### PR DESCRIPTION
Close #571. This PR adds distances to each walking leg step. Styles are configurable in that the styled components can be overridden. If we want explicit prop-based configuration, that can be added.

<img width="379" alt="Screenshot 2023-04-28 at 1 11 27 PM" src="https://user-images.githubusercontent.com/86619099/235210992-8bbf11d1-9294-4763-a532-518dfaf39bbd.png">
