### PR TITLE
Map layer button fixes

### DIFF
--- a/packages/base-map/src/index.tsx
+++ b/packages/base-map/src/index.tsx
@@ -71,6 +71,9 @@ const BaseMap = ({
     zoom: initZoom
   });
 
+  // Firefox and Safari on iOS: hover is not triggered when the user touches the layer selector
+  // (unlike Firefox or Chromium on Android), so we have to detect touch and trigger hover ourselves.
+  const [fakeMobileHover, setFakeHover] = useState(false);
   const [longPressTimer, setLongPressTimer] = useState(null);
 
   useEffect(() => {
@@ -133,6 +136,7 @@ const BaseMap = ({
         clearLongPressTimer();
       }}
       onTouchStart={e => {
+        setFakeHover(false);
         // Start detecting long presses on screens when there is only one touch point.
         // If the user is pinching the map or does other multi-touch actions, cancel long-press detection.
         const touchPointCount = e.points.length;
@@ -151,8 +155,18 @@ const BaseMap = ({
         (!!baseLayer &&
           typeof baseLayer === "object" &&
           baseLayer.length > 1)) && (
-        <Styled.LayerSelector className="filter-group" id="filter-group">
-          <ul className="maplibregl-ctrl-group layers-list">
+        <Styled.LayerSelector
+          className="filter-group"
+          id="filter-group"
+          onBlur={() => setFakeHover(false)}
+          onFocus={() => setFakeHover(true)}
+          onTouchEnd={() => setFakeHover(true)}
+        >
+          <ul
+            className={`maplibregl-ctrl-group layers-list ${
+              fakeMobileHover ? "fake-mobile-hover" : ""
+            }`}
+          >
             {!!baseLayer &&
               typeof baseLayer === "object" &&
               baseLayer.map((layer: string, index: number) => {

--- a/packages/base-map/src/index.tsx
+++ b/packages/base-map/src/index.tsx
@@ -71,9 +71,6 @@ const BaseMap = ({
     zoom: initZoom
   });
 
-  // On mobile hover is unavailable, so we use this variable to use a two tap process
-  // to simulate a hover
-  const [fakeMobileHover, setFakeHover] = useState(false);
   const [longPressTimer, setLongPressTimer] = useState(null);
 
   useEffect(() => {
@@ -136,7 +133,6 @@ const BaseMap = ({
         clearLongPressTimer();
       }}
       onTouchStart={e => {
-        setFakeHover(false);
         // Start detecting long presses on screens when there is only one touch point.
         // If the user is pinching the map or does other multi-touch actions, cancel long-press detection.
         const touchPointCount = e.points.length;
@@ -155,16 +151,8 @@ const BaseMap = ({
         (!!baseLayer &&
           typeof baseLayer === "object" &&
           baseLayer.length > 1)) && (
-        <Styled.LayerSelector
-          className="filter-group"
-          id="filter-group"
-          onBlur={() => setFakeHover(false)}
-          onFocus={() => setFakeHover(true)}
-          onTouchEnd={() => setFakeHover(true)}
-        >
-          <ul
-            className={`layers-list ${fakeMobileHover && "fake-mobile-hover"}`}
-          >
+        <Styled.LayerSelector className="filter-group" id="filter-group">
+          <ul className="maplibregl-ctrl-group layers-list">
             {!!baseLayer &&
               typeof baseLayer === "object" &&
               baseLayer.map((layer: string, index: number) => {

--- a/packages/base-map/src/styled.ts
+++ b/packages/base-map/src/styled.ts
@@ -99,6 +99,7 @@ export const LayerSelector = styled.aside`
 
     &:hover,
     &.fake-mobile-hover {
+      box-shadow: 0px -1px 15px -3px rgba(0, 0, 0, 0.1);
       label {
         height: unset;
         overflow: unset;

--- a/packages/base-map/src/styled.ts
+++ b/packages/base-map/src/styled.ts
@@ -73,6 +73,7 @@ export const LayerSelector = styled.aside`
   }
 
   .layers-list {
+    background: rgba(255, 255, 255, 0.95);
     list-style-type: none;
     padding: 1em;
     position: absolute;
@@ -96,8 +97,8 @@ export const LayerSelector = styled.aside`
       cursor: pointer;
     }
 
-    /* :hover state is set on mouse over and on click on touch screens. */
-    &:hover {
+    &:hover,
+    &.fake-mobile-hover {
       label {
         height: unset;
         overflow: unset;

--- a/packages/base-map/src/styled.ts
+++ b/packages/base-map/src/styled.ts
@@ -55,7 +55,7 @@ export const LeafletStyleMarker = styled.div<LeafletStyleMarkerProps>`
 export const LayerSelector = styled.aside`
   display: flex;
   justify-content: end;
-  margin: 1em;
+  margin: 10px;
   position: relative;
   right: 0;
   top: 0;
@@ -73,15 +73,11 @@ export const LayerSelector = styled.aside`
   }
 
   .layers-list {
-    background: rgba(255, 255, 255, 0.95);
-    border-radius: 0.5em;
-    box-shadow: 0px -1px 15px -3px rgba(0, 0, 0, 0.1);
-    display: flex;
-    flex-direction: column;
     list-style-type: none;
     padding: 1em;
     position: absolute;
     right: 0;
+    z-index: 1000;
 
     label {
       display: block;
@@ -100,13 +96,17 @@ export const LayerSelector = styled.aside`
       cursor: pointer;
     }
 
-    &:hover,
-    &.fake-mobile-hover {
+    /* :hover state is set on mouse over and on click on touch screens. */
+    &:hover {
       label {
-        display: block;
         height: unset;
         overflow: unset;
         width: unset;
+      }
+      li:first-child {
+        /* Prevent most accidental toggling of the first selectable layer on touch screens.
+           Toggling is still possible if you touch the left-most area of the globe "button". */
+        margin-right: 2em;
       }
       &::after {
         display: none;


### PR DESCRIPTION
This PR proposes the following fixes to the map layer selector:
- Same style and right margin as the zoom controls.
- Expanded layer selector contents appears above the zoom controls.
- Avoid most accidental activations of the first layer when opening the layer selector using touchscreens.