### PR TITLE
Replace Calories with Minutes Active in Trip Details

### DIFF
--- a/packages/itinerary-body/package.json
+++ b/packages/itinerary-body/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentripplanner/itinerary-body",
-  "version": "4.1.14",
+  "version": "4.1.15",
   "description": "A component for displaying an itinerary body of a trip planning result",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/packages/trip-details/__mocks__/custom-english-messages.yml
+++ b/packages/trip-details/__mocks__/custom-english-messages.yml
@@ -1,14 +1,14 @@
-# Example used to overwrite a subset of the messages from /i18n/en-US.yml.
 otpUi:
   TripDetails:
-    caloriesDescription: "Walking <strong>{walkMinutes}</strong> minute(s) and biking <strong>{bikeMinutes}</strong> minute(s) will consume {calories} Calories."
-    departure: "<strong>Leave</strong> at <strong>{departureDate, time, short}</strong> on <strong>{departureDate, date, long}</strong>"
-    title: "Custom Trip Details Title"
-    tncFare: "Pay <strong>{minTNCFare}-{maxTNCFare}</strong> to {companies}"
+    departure: >-
+      <strong>Leave</strong> at <strong>{departureDate, time, short}</strong> on
+      <strong>{departureDate, date, long}</strong>
     fareDetailsHeaders:
-      regular: "Regular"
-      youth: "Youth"
-      senior: "Senior"
-      cash: "Cash"
-      electronic: "ORCA"
-      special: "LIFT"
+      cash: Cash
+      electronic: ORCA
+      regular: Regular
+      senior: Senior
+      special: LIFT
+      youth: Youth
+    title: Custom Trip Details Title
+    tncFare: Pay <strong>{minTNCFare}-{maxTNCFare}</strong> to {companies}

--- a/packages/trip-details/i18n/en-US.yml
+++ b/packages/trip-details/i18n/en-US.yml
@@ -16,7 +16,9 @@ otpUi:
       special: Special
       youth: Youth
     hideDetail: Hide details
-    minutesActive: "Time Spent Active: {minutes, plural, one {# minute} other {# minutes}}"
+    minutesActive: >-
+      Time Spent Active:  <strong> {minutes, plural, one {# minute} other {#
+      minutes}}</strong>
     showDetail: Show details
     timeActiveDescription: >
       By taking this trip, you'll spend <strong>{walkMinutes, plural, one {#

--- a/packages/trip-details/i18n/en-US.yml
+++ b/packages/trip-details/i18n/en-US.yml
@@ -17,7 +17,7 @@ otpUi:
       youth: Youth
     hideDetail: Hide details
     minutesActive: >-
-      Time Spent Active:  <strong> {minutes, plural, one {# minute} other {#
+      Time Spent Active: <strong>{minutes, plural, one {# minute} other {#
       minutes}}</strong>
     showDetail: Show details
     timeActiveDescription: >

--- a/packages/trip-details/i18n/en-US.yml
+++ b/packages/trip-details/i18n/en-US.yml
@@ -1,12 +1,5 @@
 otpUi:
   TripDetails:
-    calories: "Calories Burned: <strong>{calories, number, ::.}</strong>"
-    caloriesDescription: >
-      Calories burned is based on <strong>{walkMinutes, plural, one {# minute}
-      other {# minutes}}</strong> spent walking and <strong>{bikeMinutes,
-      plural, one {# minute} other {# minutes}}</strong> spent biking during
-      this trip. Adapted from <dietaryLink>Dietary Guidelines for Americans
-      2005, page 16, Table 4</dietaryLink>.
     co2: "CO₂ Emitted: <strong>{co2}</strong>"
     co2description: >-
       CO₂ intensity is calculated by multiplying the distance of each leg of a
@@ -23,7 +16,12 @@ otpUi:
       special: Special
       youth: Youth
     hideDetail: Hide details
+    minutesActive: "Time Spent Active: {minutes, plural, one {# minute} other {# minutes}}"
     showDetail: Show details
+    timeActiveDescription: >
+      By taking this trip, you'll spend <strong>{walkMinutes, plural, one {#
+      minute} other {# minutes}}</strong> walking and <strong>{bikeMinutes,
+      plural, one {# minute} other {# minutes}}</strong> biking.
     title: Trip Details
     tncFare: "{companies} Fare: <strong>{minTNCFare} - {maxTNCFare}</strong>"
     transferDiscountExplanation: Transfer discount of {transferAmount} is applied

--- a/packages/trip-details/i18n/es.yml
+++ b/packages/trip-details/i18n/es.yml
@@ -1,12 +1,5 @@
 otpUi:
   TripDetails:
-    calories: "Calorías quemadas: <strong>{calories, number, ::.}</strong>"
-    caloriesDescription: >
-      Las calorías quemadas se basan en <strong>{walkMinutes, plural, one {#
-      minuto} other {# minutos}}</strong> de caminata y <strong>{bikeMinutes,
-      plural, one {# minuto} other {# minutos}}</strong> en bicicleta durante
-      este viaje. Adaptado del <dietaryLink>Dietary Guidelines for Americans
-      2005, page 16, Table 4</dietaryLink>.
     co2: "CO₂ emitido: <strong>{co2}</strong>"
     co2description: >-
       La intensidad de CO₂ se calcula multiplicando la distancia de cada tramo

--- a/packages/trip-details/i18n/fr.yml
+++ b/packages/trip-details/i18n/fr.yml
@@ -1,13 +1,5 @@
 otpUi:
   TripDetails:
-    calories: "Calories dépensées : <strong>{calories, number, ::.}</strong>"
-    caloriesDescription: >
-      La dépense calorique est calculée sur la base de {walkMinutes, plural, one
-      {<strong># minute</strong> effectuée} other {<strong># minutes</strong>
-      effectuées}} à pied et {bikeMinutes, plural, one {<strong>#
-      minute</strong> effectuée} other {<strong># minutes</strong> effectuées}}
-      en vélo sur ce trajet. (d'après <dietaryLink>Dietary Guidelines for
-      Americans 2005, page 16, Table 4</dietaryLink>)
     co2: "CO₂ émis : <strong>{co2}</strong>"
     co2description: >-
       L'intensité carbone est calculée en multipliant la distance de chaque
@@ -24,7 +16,12 @@ otpUi:
       special: Spécial
       youth: Jeunes
     hideDetail: Masquer les détails
+    minutesActive: "Activité physique: {minutes, plural, one {# minute} other {# minutes}}"
     showDetail: Afficher les détails
+    timeActiveDescription: >
+      En faisant ce voyage, vous passerez <strong>{walkMinutes, plural, one {#
+      minute} other {# minutes}}</strong> à pied et <strong>{bikeMinutes,
+      plural, one {# minute} other {# minutes}}</strong> à vélo.
     title: Détails du trajet
     tncFare: "Tarif {companies} : <strong>{minTNCFare} - {maxTNCFare}</strong>"
     transferDiscountExplanation: Cette correspondance vous donne une réduction de {transferAmount}

--- a/packages/trip-details/i18n/ko.yml
+++ b/packages/trip-details/i18n/ko.yml
@@ -1,11 +1,5 @@
 otpUi:
   TripDetails:
-    calories: "소모 칼로리: <strong>{calories, number, ::.}</strong>"
-    caloriesDescription: >
-      소모된 칼로리는 이 트립에서 <strong>{walkMinutes}분 동안 </strong>걷고<strong>
-      <strong>{bikeMinutes}분</strong> 동안 자전거를 탄 것을 기준으로 합니다.
-      <dietaryLink>Dietary Guidelines for Americans 2005, 16 페이지, 표
-      4</dietaryLink> 적용.
     co2: "CO₂ 배출: <strong>{co2}</strong>"
     co2description: >-
       CO₂ 강도는 각 모드의 CO₂ 강도를 트립에서 각 다리가 걸은 거리를 곱하여 계산됩니다. 각 모드의 CO₂ 강도는 <link>이

--- a/packages/trip-details/i18n/nb_NO.yml
+++ b/packages/trip-details/i18n/nb_NO.yml
@@ -2,4 +2,3 @@ otpUi:
   TripDetails:
     fareDetailsHeaders:
       cash: Kontanter
-    calories: 'Forbrente kalorier: <strong>{calories, number, ::.}</strong>'

--- a/packages/trip-details/i18n/vi.yml
+++ b/packages/trip-details/i18n/vi.yml
@@ -1,11 +1,5 @@
 otpUi:
   TripDetails:
-    calories: "Calo bị đốt cháy: <strong>{calories, number, ::.}</strong>"
-    caloriesDescription: >
-      Lượng calo bị đốt cháy dựa trên <strong>{walkMinutes} phút</strong> đi bộ
-      và <strong>{bikeMinutes} phút</strong> dành cho chuyến đi xe đạp trong
-      chuyến đi này. Phỏng theo <dietaryLink>Dietary Guidelines for Americans
-      2005, trang 16, hình ảnh 4</dietaryLink>.
     co2: "CO₂ thải ra: <strong>{co2}</strong>"
     co2description: >-
       Nồng độ CO₂ được tính bằng cách nhân khoảng cách của mỗi chặng của một

--- a/packages/trip-details/i18n/zh_Hans.yml
+++ b/packages/trip-details/i18n/zh_Hans.yml
@@ -1,10 +1,5 @@
 otpUi:
   TripDetails:
-    calories: "卡路里消耗: <strong>{calories, number, ::.}</strong>"
-    caloriesDescription: >
-      燃烧的卡路里是根据这次旅行中的 <strong>{walkMinutes}分钟</strong> 步行和
-      <strong>{bikeMinutes}分钟</strong> 骑自行车计算的. 改编自< <dietaryLink>Dietary
-      Guidelines for Americans 2005, 页16, 图片4</dietaryLink>.
     co2: "排放的二氧化碳: <strong>{co2}</strong>"
     co2description: CO₂ 强度的计算方法是将行程的每条腿的距离乘以每种模式的 CO₂ 强度。 每种模式的二氧化碳强度来自<link>此电子表格</link>。
     departure: >-

--- a/packages/trip-details/src/TripDetails.story.tsx
+++ b/packages/trip-details/src/TripDetails.story.tsx
@@ -13,7 +13,7 @@ import styled from "styled-components";
 import TripDetails, { FareLegTable } from ".";
 import * as TripDetailsClasses from "./styled";
 import {
-  CaloriesDetailsProps,
+  TimeActiveDetailsProps,
   DepartureDetailsProps,
   FareDetailsProps,
   FareTableLayout,
@@ -210,15 +210,10 @@ const CustomDepartureDetails = ({
   </>
 );
 
-const CustomCaloriesDetails = ({
-  bikeSeconds,
-  calories,
-  walkSeconds
-}: CaloriesDetailsProps): ReactElement => (
-  <>
-    Custom message about {calories} calories burned,
-    {walkSeconds} seconds and {bikeSeconds} seconds.
-  </>
+const CustomTimeActiveDetails = ({
+  minutesActive
+}: TimeActiveDetailsProps): ReactElement => (
+  <>Custom message about {minutesActive} active minutes.</>
 );
 
 /**
@@ -232,7 +227,7 @@ function createTripDetailsTemplate(
 ): ComponentStory<typeof TripDetails> {
   const TripDetailsTemplate = (
     {
-      CaloriesDetails,
+      TimeActiveDetails,
       DepartureDetails,
       FareDetails,
       fareDetailsLayout,
@@ -249,7 +244,7 @@ function createTripDetailsTemplate(
       : {};
     return (
       <Component
-        CaloriesDetails={CaloriesDetails}
+        TimeActiveDetails={TimeActiveDetails}
         DepartureDetails={DepartureDetails}
         FareDetails={FareDetails}
         fareDetailsLayout={fareDetailsLayout}
@@ -377,7 +372,7 @@ export const TncTransitItinerary = makeStory(
 
 export const TncTransitItineraryWithCustomMessages = makeStory(
   {
-    CaloriesDetails: CustomCaloriesDetails,
+    TimeActiveDetails: CustomTimeActiveDetails,
     defaultFareKey: "electronicRegular",
     DepartureDetails: CustomDepartureDetails,
     itinerary: tncTransitTncItinerary

--- a/packages/trip-details/src/index.tsx
+++ b/packages/trip-details/src/index.tsx
@@ -203,7 +203,7 @@ export function TripDetails({
 
   // Compute total time spent active.
 
-  // TODO: seperate into two reducers
+  // TODO: separate into two reducers
   let walkDurationSeconds = 0;
   let bikeDurationSeconds = 0;
   itinerary.legs.forEach(leg => {

--- a/packages/trip-details/src/index.tsx
+++ b/packages/trip-details/src/index.tsx
@@ -14,7 +14,7 @@ import FareLegTable from "./fare-table";
 import { boldText, renderFare } from "./utils";
 
 import {
-  CaloriesDetailsProps,
+  TimeActiveDetailsProps,
   TransitFareProps,
   TripDetailsProps
 } from "./types";
@@ -28,21 +28,6 @@ import defaultEnglishMessages from "../i18n/en-US.yml";
 // - the yaml loader for jest returns messages with flattened ids.
 const defaultMessages: Record<string, string> = flatten(defaultEnglishMessages);
 
-/**
- * Helper function to specify the link to dietary table.
- */
-function dietaryLink(contents: ReactElement): ReactElement {
-  return (
-    <a
-      href="https://health.gov/dietaryguidelines/dga2005/document/html/chapter3.htm#table4"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      {contents}
-    </a>
-  );
-}
-
 function CO2DescriptionLink(contents: ReactElement): ReactElement {
   return (
     <a
@@ -54,27 +39,25 @@ function CO2DescriptionLink(contents: ReactElement): ReactElement {
     </a>
   );
 }
-
 /**
- * Default rendering if no component is provided for the CaloriesDetails
+ * Default rendering if no component is provided for the TimeActiveDetails
  * slot in the TripDetails component.
  */
-function DefaultCaloriesDetails({
-  bikeSeconds,
-  calories,
-  walkSeconds
-}: CaloriesDetailsProps): ReactElement {
+function DefaultTimeActiveDetails({
+  bikeDuration,
+  walkDuration
+}: TimeActiveDetailsProps): ReactElement {
   return (
     <FormattedMessage
-      defaultMessage={defaultMessages["otpUi.TripDetails.caloriesDescription"]}
-      description="Text describing how the calories relate to the walking and biking duration of a trip."
-      id="otpUi.TripDetails.caloriesDescription"
+      defaultMessage={
+        defaultMessages["otpUi.TripDetails.timeActiveDescription"]
+      }
+      description="Text describing the walking and biking durations of a trip."
+      id="otpUi.TripDetails.timeActiveDescription"
       values={{
-        bikeMinutes: Math.round(bikeSeconds / 60),
-        calories: Math.round(calories),
-        dietaryLink,
+        bikeMinutes: bikeDuration,
         strong: boldText,
-        walkMinutes: Math.round(walkSeconds / 60)
+        walkMinutes: walkDuration
       }}
     />
   );
@@ -111,19 +94,19 @@ const TransitFare = ({
 };
 
 /**
- * Renders trip details such as departure instructions, fare amount, and calories spent.
+ * Renders trip details such as departure instructions, fare amount, and minutes active.
  */
 export function TripDetails({
-  CaloriesDetails = DefaultCaloriesDetails,
   className = "",
+  co2Config,
   defaultFareKey = "regular",
-  displayCalories = true,
   DepartureDetails = null,
+  displayTimeActive = true,
   FareDetails = null,
   fareDetailsLayout,
   fareKeyNameMap = {},
   itinerary,
-  co2Config
+  TimeActiveDetails = DefaultTimeActiveDetails
 }: TripDetailsProps): ReactElement {
   // process the transit fare
   const fareResult = coreUtils.itinerary.calculateTncFares(itinerary);
@@ -218,12 +201,17 @@ export function TripDetails({
 
   const departureDate = new Date(itinerary.startTime);
 
-  // Compute calories burned.
-  const {
-    bikeDuration,
-    caloriesBurned,
-    walkDuration
-  } = coreUtils.itinerary.calculatePhysicalActivity(itinerary);
+  // Compute total time spent active.
+
+  let walkDurationSeconds = 0;
+  let bikeDurationSeconds = 0;
+  itinerary.legs.forEach(leg => {
+    if (leg.mode.startsWith("WALK")) walkDurationSeconds += leg.duration;
+    if (leg.mode.startsWith("BICYCLE")) bikeDurationSeconds += leg.duration;
+  });
+  const bikeDuration = Math.round(bikeDurationSeconds / 60);
+  const walkDuration = Math.round(walkDurationSeconds / 60);
+  const minutesActive = bikeDuration + walkDuration;
 
   // Calculate CO₂ if it's not provided by the itinerary
   const co2 =
@@ -297,28 +285,26 @@ export function TripDetails({
             summary={fare}
           />
         )}
-        {displayCalories && caloriesBurned > 0 && (
+        {displayTimeActive && minutesActive > 0 && (
           <TripDetail
             icon={<Heartbeat size={17} />}
             summary={
-              <S.CaloriesSummary>
-                <FormattedMessage
-                  defaultMessage={defaultMessages["otpUi.TripDetails.calories"]}
-                  description="Text showing the number of calories for the walking and biking legs of a trip."
-                  id="otpUi.TripDetails.calories"
-                  values={{
-                    calories: caloriesBurned,
-                    strong: boldText
-                  }}
-                />
-              </S.CaloriesSummary>
+              <FormattedMessage
+                defaultMessage={
+                  defaultMessages["otpUi.TripDetails.minutesActive"]
+                }
+                description="Text showing the number of minutes spent walking or biking throughout trip."
+                id="otpUi.TripDetails.minutesActive"
+                values={{
+                  minutes: minutesActive
+                }}
+              />
             }
             description={
-              CaloriesDetails && (
-                <CaloriesDetails
-                  bikeSeconds={bikeDuration}
-                  calories={caloriesBurned}
-                  walkSeconds={walkDuration}
+              TimeActiveDetails && (
+                <TimeActiveDetails
+                  bikeDuration={bikeDuration}
+                  walkDuration={walkDuration}
                 />
               )
             }

--- a/packages/trip-details/src/index.tsx
+++ b/packages/trip-details/src/index.tsx
@@ -203,6 +203,7 @@ export function TripDetails({
 
   // Compute total time spent active.
 
+  // TODO: seperate into two reducers
   let walkDurationSeconds = 0;
   let bikeDurationSeconds = 0;
   itinerary.legs.forEach(leg => {
@@ -296,7 +297,8 @@ export function TripDetails({
                 description="Text showing the number of minutes spent walking or biking throughout trip."
                 id="otpUi.TripDetails.minutesActive"
                 values={{
-                  minutes: minutesActive
+                  minutes: minutesActive,
+                  strong: boldText
                 }}
               />
             }

--- a/packages/trip-details/src/index.tsx
+++ b/packages/trip-details/src/index.tsx
@@ -44,8 +44,8 @@ function CO2DescriptionLink(contents: ReactElement): ReactElement {
  * slot in the TripDetails component.
  */
 function DefaultTimeActiveDetails({
-  bikeDuration,
-  walkDuration
+  bikeMinutes,
+  walkMinutes
 }: TimeActiveDetailsProps): ReactElement {
   return (
     <FormattedMessage
@@ -55,9 +55,9 @@ function DefaultTimeActiveDetails({
       description="Text describing the walking and biking durations of a trip."
       id="otpUi.TripDetails.timeActiveDescription"
       values={{
-        bikeMinutes: bikeDuration,
+        bikeMinutes,
         strong: boldText,
-        walkMinutes: walkDuration
+        walkMinutes
       }}
     />
   );
@@ -209,9 +209,9 @@ export function TripDetails({
     if (leg.mode.startsWith("WALK")) walkDurationSeconds += leg.duration;
     if (leg.mode.startsWith("BICYCLE")) bikeDurationSeconds += leg.duration;
   });
-  const bikeDuration = Math.round(bikeDurationSeconds / 60);
-  const walkDuration = Math.round(walkDurationSeconds / 60);
-  const minutesActive = bikeDuration + walkDuration;
+  const bikeMinutes = Math.round(bikeDurationSeconds / 60);
+  const walkMinutes = Math.round(walkDurationSeconds / 60);
+  const minutesActive = bikeMinutes + walkMinutes;
 
   // Calculate CO₂ if it's not provided by the itinerary
   const co2 =
@@ -303,8 +303,8 @@ export function TripDetails({
             description={
               TimeActiveDetails && (
                 <TimeActiveDetails
-                  bikeDuration={bikeDuration}
-                  walkDuration={walkDuration}
+                  bikeMinutes={bikeMinutes}
+                  walkMinutes={walkMinutes}
                 />
               )
             }

--- a/packages/trip-details/src/styled.ts
+++ b/packages/trip-details/src/styled.ts
@@ -17,10 +17,6 @@ const BaseButton = styled.button`
   white-space: nowrap;
 `;
 
-export const CaloriesDescription = styled.span``;
-
-export const CaloriesSummary = styled.span``;
-
 export const CO2Description = styled.span``;
 
 export const CO2Summary = styled.span``;

--- a/packages/trip-details/src/styled.ts
+++ b/packages/trip-details/src/styled.ts
@@ -94,4 +94,5 @@ export const TripDetailSummary = styled.div`
   padding-top: 2px;
   display: flex;
   align-items: baseline;
+  white-space: pre;
 `;

--- a/packages/trip-details/src/types.ts
+++ b/packages/trip-details/src/types.ts
@@ -4,9 +4,9 @@ import type { MassUnitOption, Fare, Itinerary, Money } from "@opentripplanner/ty
 import type { ReactElement } from "react";
 
 export interface TimeActiveDetailsProps {
-  bikeDuration: number;
+  bikeMinutes: number;
   minutesActive?: number;
-  walkDuration: number;
+  walkMinutes: number;
 }
 
 export interface CO2ConfigType {

--- a/packages/trip-details/src/types.ts
+++ b/packages/trip-details/src/types.ts
@@ -3,10 +3,10 @@
 import type { MassUnitOption, Fare, Itinerary, Money } from "@opentripplanner/types";
 import type { ReactElement } from "react";
 
-export interface CaloriesDetailsProps {
-  bikeSeconds: number;
-  calories: number;
-  walkSeconds: number;
+export interface TimeActiveDetailsProps {
+  bikeDuration: number;
+  minutesActive?: number;
+  walkDuration: number;
 }
 
 export interface CO2ConfigType {
@@ -63,13 +63,13 @@ export interface TransitFareProps {
 
 export interface TripDetailsProps {
   /**
-   * Slot for a custom component to render the expandable section for calories.
-   */
-  CaloriesDetails?: React.ElementType<CaloriesDetailsProps>;
-  /**
    * Used for additional styling with styled components for example.
    */
   className?: string;
+    /**
+   * Object containing the CO₂ config.
+   */
+  co2Config?: CO2ConfigType;
   /**
    * Determines which transit fare should be displayed by default, should there be multiple transit fare types.
    */
@@ -80,9 +80,9 @@ export interface TripDetailsProps {
   DepartureDetails?: React.ElementType<DepartureDetailsProps>;
   /**
    * If this is set to true, a row will be added to the trip details displaying how
-   * many calories were burned on the active legs of the trip.
+   * many minutes in total the user will spend walking or biking.
    */
-  displayCalories?: boolean;
+  displayTimeActive?: boolean;
   /**
    * Slot for a custom component to render the expandable section for fares.
    */
@@ -101,8 +101,8 @@ export interface TripDetailsProps {
    * Itinerary that the user has selected to view, contains multiple legs.
    */
   itinerary: Itinerary;
-  /**
-   * Object containing the CO₂ config.
+    /**
+   * Slot for a custom component to render the expandable section for time active.
    */
-  co2Config?: CO2ConfigType;
+  TimeActiveDetails?: React.ElementType<TimeActiveDetailsProps>;
 }


### PR DESCRIPTION
Removes calorie counts and repurposes all methods with "Time Active" which combines time spent biking and walking to reflect the total number of minutes spent active in the trip duration.

BREAKING CHANGE: Calories removed and replaced by minutes active

![image](https://user-images.githubusercontent.com/115499534/236063654-a89b07bf-dc0a-48f0-9f5d-3bb64a43499c.png)
