### PR TITLE
fix(route-viewer-overlay): fix crash on incomplete flex data

### DIFF
--- a/packages/route-viewer-overlay/__mocks__/mock-flex-route.json
+++ b/packages/route-viewer-overlay/__mocks__/mock-flex-route.json
@@ -18,10 +18,7 @@
     {
       "id": "UGF0dGVybjpDb2JiLWZsZXg6cG8wcDowOjAx",
       "name": "Zone 3 to Zone 3 - Downtown Austell (Cobb-flex:urnz)",
-      "geometry": {
-        "points": "kfsmEjojcOa@eBRKfBfHR|ALjB@pEhF`ElFrEhPpN|B|AtBbAfA`@fCf@|@JfGd@vEl@jB\\rWdGrC`@tF`@vOTrD^|B`@~C|@xIhDvChA|\\rNjBt@`Bj@lIzBxAf@jDrArBh@|@R`CR|BBnAAx@EdDYtAAtAHhCb@LARKHMDWAy@Gi@[y@_@c@]Su@Mk@Ae@B]Ft@nEpG|]fGb^`@jC^|CTxCTvFZzI???DLdArAvGXGjBq@FV",
-        "length": 71
-      },
+      "geometry": {},
       "stops": [
         {
           "code": null,

--- a/packages/route-viewer-overlay/src/index.tsx
+++ b/packages/route-viewer-overlay/src/index.tsx
@@ -6,6 +6,7 @@ import React, { useEffect } from "react";
 
 import polyline from "@mapbox/polyline";
 import pointInPolygon from "point-in-polygon";
+import { objectExistsAndPopulated } from "./util";
 
 type RouteData = {
   color?: string;
@@ -136,7 +137,7 @@ const RouteViewerOverlay = (props: Props): JSX.Element => {
       });
     });
 
-    if (bounds && current) {
+    if (objectExistsAndPopulated(bounds) && current) {
       // Try to fit the map to route bounds immediately. If other overlays are still populating contents
       // and/or the map skips/aborts fitting for any reason, try fitting bounds again after a short delay.
       const fitBounds = () => util.fitMapBounds(current, bounds);
@@ -160,7 +161,7 @@ const RouteViewerOverlay = (props: Props): JSX.Element => {
     ? `#${routeData.color}`
     : path?.color || "#00bfff";
   const segments = patterns
-    .filter(pattern => !!pattern?.geometry)
+    .filter(pattern => objectExistsAndPopulated(pattern?.geometry))
     .map(pattern => {
       const pts = polyline.decode(pattern.geometry.points);
       const clippedPts = clipToPatternStops

--- a/packages/route-viewer-overlay/src/util.ts
+++ b/packages/route-viewer-overlay/src/util.ts
@@ -1,0 +1,7 @@
+/**
+ * Method to test if an object not only exists but contains entries
+ */
+// eslint-disable-next-line import/prefer-default-export
+export const objectExistsAndPopulated = (o: Record<any, unknown>): boolean => {
+  return !!o && Object.keys(o).length > 0;
+};


### PR DESCRIPTION
There was a previous bug where the overlay would attempt to center the map on non-existent data. This PR resolves this issue.