### PR TITLE
I18n message groups

### DIFF
--- a/packages/scripts/src/__tests__/__mocks__/i18n1/en-US.yml
+++ b/packages/scripts/src/__tests__/__mocks__/i18n1/en-US.yml
@@ -3,6 +3,9 @@ otpUi:
     from: From here
     planATrip: "Plan a trip:"
     to: To here
+  OtherComponent:
+    key1Message: Key 1
+    key2Message: Key 2
   TestComponent1:
     unusedText: I am unused.
     unusedTextThatIsIgnored: I am unused and ignored.

--- a/packages/scripts/src/__tests__/__mocks__/i18n1/i18n-exceptions.json
+++ b/packages/scripts/src/__tests__/__mocks__/i18n1/i18n-exceptions.json
@@ -1,3 +1,6 @@
 {
-  "ignoredIds": ["otpUi.TestComponent1.unusedTextThatIsIgnored"]
+  "ignoredIds": ["otpUi.TestComponent1.unusedTextThatIsIgnored"],
+  "groups": {
+    "otpUi.OtherComponent.*Message": ["key1", "key2"]
+  }
 }

--- a/packages/scripts/src/__tests__/collect-i18n-messages.ts
+++ b/packages/scripts/src/__tests__/collect-i18n-messages.ts
@@ -1,0 +1,56 @@
+import { buildTranslationTable } from "../collect-i18n-messages";
+
+import { mocksFolderFromCwd } from "./util";
+
+describe("collect-i18n-messages", () => {
+  describe("buildTranslationTable", () => {
+    it("should build a translation table", async () => {
+      const groups = {
+        "otpUi.OtherComponent.*Message": ["key1", "key2", "extraKey"]
+      };
+      const ymlFiles = {
+        "en-US": [`${mocksFolderFromCwd}/i18n1/en-US.yml`],
+        fr: [`${mocksFolderFromCwd}/i18n1/fr.yml`]
+      };
+      const messagesFromCode = {
+        "otpUi.FromToLocationPicker.from": {},
+        "otpUi.FromToLocationPicker.planATrip": {
+          description: "Prompt for planning a trip"
+        },
+        "otpUi.FromToLocationPicker.to": {},
+        // Extra ones not in the language files for detecting untranslated ids.
+        "otpUi.ExtraId.fromCode": {},
+        "otpUi.ExtraId.fromCodeThatIsIgnored": {}
+      };
+
+      const translationTable = await buildTranslationTable(
+        ymlFiles,
+        messagesFromCode,
+        groups
+      );
+
+      expect(Object.keys(translationTable).length).toBe(8);
+      expect(
+        Object.keys(messagesFromCode).every(id => !!translationTable[id])
+      ).toBe(true);
+      // Basic message from code and in translation files.
+      const planTripMessage =
+        translationTable["otpUi.FromToLocationPicker.planATrip"];
+      expect(planTripMessage.description).toBe("Prompt for planning a trip");
+      expect(planTripMessage["en-US"]).toBe("Plan a trip:");
+      expect(planTripMessage.fr).toBe("Planifier un trajet :");
+
+      // Message declared in groups should be reported too, even if not in translation files.
+      const groupMessage = translationTable["otpUi.OtherComponent.key1Message"];
+      expect(groupMessage.description).toBe(undefined);
+      expect(groupMessage["en-US"]).toBe("Key 1");
+      expect(groupMessage.fr).toBe(undefined);
+
+      const unusedGroupMessage =
+        translationTable["otpUi.OtherComponent.extraKeyMessage"];
+      expect(unusedGroupMessage.description).toBe(undefined);
+      expect(unusedGroupMessage["en-US"]).toBe(undefined);
+      expect(unusedGroupMessage.fr).toBe(undefined);
+    });
+  });
+});

--- a/packages/scripts/src/__tests__/util.ts
+++ b/packages/scripts/src/__tests__/util.ts
@@ -1,4 +1,8 @@
-import { shouldProcessFile, sortSourceAndYmlFiles } from "../util";
+import {
+  expandGroupIds,
+  shouldProcessFile,
+  sortSourceAndYmlFiles
+} from "../util";
 
 const packagesFolder = `${process.cwd()}/packages`;
 export const mocksFolderFromCwd = `${packagesFolder}/scripts/src/__tests__/__mocks__`;
@@ -62,6 +66,22 @@ describe("util", () => {
           "/some/folder/__tests__"
         )
       ).toBe(true);
+    });
+  });
+
+  describe("expandGroupIds", () => {
+    it("should expand group ids", () => {
+      const groups = {
+        "group1.*Message": ["key1", "key2"],
+        "group2.*": ["key3", "key4", "key5"]
+      };
+      const idsFromGroups = expandGroupIds(groups);
+      expect(idsFromGroups.length).toBe(5);
+      expect(idsFromGroups.includes("group1.key1Message")).toBe(true);
+      expect(idsFromGroups.includes("group1.key2Message")).toBe(true);
+      expect(idsFromGroups.includes("group2.key3")).toBe(true);
+      expect(idsFromGroups.includes("group2.key4")).toBe(true);
+      expect(idsFromGroups.includes("group2.key5")).toBe(true);
     });
   });
 });

--- a/packages/scripts/src/__tests__/util.ts
+++ b/packages/scripts/src/__tests__/util.ts
@@ -1,4 +1,5 @@
 import {
+  combineExceptionFiles,
   expandGroupIds,
   shouldProcessFile,
   sortSourceAndYmlFiles
@@ -82,6 +83,30 @@ describe("util", () => {
       expect(idsFromGroups.includes("group2.key3")).toBe(true);
       expect(idsFromGroups.includes("group2.key4")).toBe(true);
       expect(idsFromGroups.includes("group2.key5")).toBe(true);
+    });
+  });
+
+  describe("combineExceptionFiles", () => {
+    it("should combine ignored ids", async () => {
+      const exceptionFiles = [
+        `${mocksFolderFromCwd}/i18n1/i18n-exceptions.json`,
+        `${mocksFolderFromCwd}/i18n2/i18n-exceptions.json`
+      ];
+      const { groups, ignoredIds } = await combineExceptionFiles(
+        exceptionFiles
+      );
+
+      const groupKeys = Object.keys(groups);
+      expect(groupKeys.length).toBe(1);
+      expect(groupKeys[0]).toBe("otpUi.OtherComponent.*Message");
+
+      expect(ignoredIds.size).toBe(2);
+      expect(
+        ignoredIds.has("otpUi.TestComponent1.unusedTextThatIsIgnored")
+      ).toBe(true);
+      expect(
+        ignoredIds.has("otpUi.TestComponent2.unusedTextThatIsIgnored")
+      ).toBe(true);
     });
   });
 });

--- a/packages/scripts/src/__tests__/validate-i18n.ts
+++ b/packages/scripts/src/__tests__/validate-i18n.ts
@@ -34,7 +34,7 @@ describe("validate-i18n", () => {
         "otpUi.ExtraId.fromCodeThatIsIgnored"
       ]);
       const groups = {
-        "otpUi.OtherComponent.*Message": ["key1", "key2"]
+        "otpUi.OtherComponent.*Message": ["key1", "key2", "extraKey"]
       };
       const ymlFiles = [`${mocksFolderFromCwd}/i18n1/en-US.yml`];
       const messageIdsFromCode = [
@@ -53,8 +53,11 @@ describe("validate-i18n", () => {
         groups
       );
 
-      expect(missingIdsForLocale.length).toBe(1);
-      expect(missingIdsForLocale[0]).toBe("otpUi.ExtraId.fromCode");
+      expect(missingIdsForLocale.length).toBe(2);
+      expect(missingIdsForLocale.includes("otpUi.ExtraId.fromCode")).toBe(true);
+      expect(
+        missingIdsForLocale.includes("otpUi.OtherComponent.extraKeyMessage")
+      ).toBe(true);
 
       expect(idsNotInCode.length).toBe(1);
       expect(idsNotInCode[0]).toBe("otpUi.TestComponent1.unusedText");

--- a/packages/scripts/src/__tests__/validate-i18n.ts
+++ b/packages/scripts/src/__tests__/validate-i18n.ts
@@ -1,32 +1,8 @@
-import { checkLocale, combineExceptionFiles } from "../validate-i18n";
+import { checkLocale } from "../validate-i18n";
 
 import { mocksFolderFromCwd } from "./util";
 
 describe("validate-i18n", () => {
-  describe("combineExceptionFiles", () => {
-    it("should combine ignored ids", async () => {
-      const exceptionFiles = [
-        `${mocksFolderFromCwd}/i18n1/i18n-exceptions.json`,
-        `${mocksFolderFromCwd}/i18n2/i18n-exceptions.json`
-      ];
-      const { groups, ignoredIds } = await combineExceptionFiles(
-        exceptionFiles
-      );
-
-      const groupKeys = Object.keys(groups);
-      expect(groupKeys.length).toBe(1);
-      expect(groupKeys[0]).toBe("otpUi.OtherComponent.*Message");
-
-      expect(ignoredIds.size).toBe(2);
-      expect(
-        ignoredIds.has("otpUi.TestComponent1.unusedTextThatIsIgnored")
-      ).toBe(true);
-      expect(
-        ignoredIds.has("otpUi.TestComponent2.unusedTextThatIsIgnored")
-      ).toBe(true);
-    });
-  });
-
   describe("checkLocale", () => {
     it("should detect unused message ids, excluding declared groups", async () => {
       const ignoredIds = new Set([

--- a/packages/scripts/src/__tests__/validate-i18n.ts
+++ b/packages/scripts/src/__tests__/validate-i18n.ts
@@ -33,6 +33,9 @@ describe("validate-i18n", () => {
         "otpUi.TestComponent1.unusedTextThatIsIgnored",
         "otpUi.ExtraId.fromCodeThatIsIgnored"
       ]);
+      const groups = {
+        "otpUi.OtherComponent.*Message": ["key1", "key2"]
+      };
       const ymlFiles = [`${mocksFolderFromCwd}/i18n1/en-US.yml`];
       const messageIdsFromCode = [
         "otpUi.FromToLocationPicker.from",
@@ -46,7 +49,8 @@ describe("validate-i18n", () => {
       const { idsNotInCode, missingIdsForLocale } = await checkLocale(
         ymlFiles,
         messageIdsFromCode,
-        ignoredIds
+        ignoredIds,
+        groups
       );
 
       expect(missingIdsForLocale.length).toBe(1);

--- a/packages/scripts/src/__tests__/validate-i18n.ts
+++ b/packages/scripts/src/__tests__/validate-i18n.ts
@@ -9,7 +9,14 @@ describe("validate-i18n", () => {
         `${mocksFolderFromCwd}/i18n1/i18n-exceptions.json`,
         `${mocksFolderFromCwd}/i18n2/i18n-exceptions.json`
       ];
-      const { ignoredIds } = await combineExceptionFiles(exceptionFiles);
+      const { groups, ignoredIds } = await combineExceptionFiles(
+        exceptionFiles
+      );
+
+      const groupKeys = Object.keys(groups);
+      expect(groupKeys.length).toBe(1);
+      expect(groupKeys[0]).toBe("otpUi.OtherComponent.*Message");
+
       expect(ignoredIds.size).toBe(2);
       expect(
         ignoredIds.has("otpUi.TestComponent1.unusedTextThatIsIgnored")
@@ -21,7 +28,7 @@ describe("validate-i18n", () => {
   });
 
   describe("checkLocale", () => {
-    it("should detect unused message ids", async () => {
+    it("should detect unused message ids, excluding declared groups", async () => {
       const ignoredIds = new Set([
         "otpUi.TestComponent1.unusedTextThatIsIgnored",
         "otpUi.ExtraId.fromCodeThatIsIgnored"

--- a/packages/scripts/src/util.ts
+++ b/packages/scripts/src/util.ts
@@ -115,3 +115,14 @@ export async function sortSourceAndYmlFiles(
 export async function loadYamlFile(filename: string): Promise<any> {
   return load(await fs.readFile(filename));
 }
+
+/**
+ * Convert a groups object into a list of corresponding message ids.
+ */
+export function expandGroupIds(groups: Record<string, string[]>): string[] {
+  return Object.keys(groups).reduce(
+    (result, group) =>
+      result.concat(groups[group].map(key => group.replace("*", key))),
+    []
+  );
+}

--- a/packages/scripts/src/validate-i18n.ts
+++ b/packages/scripts/src/validate-i18n.ts
@@ -1,48 +1,14 @@
 /* eslint-disable no-console */
 import flatten from "flat";
-import { promises as fs } from "fs";
 import { extract } from "@formatjs/cli";
 
 import {
+  combineExceptionFiles,
   expandGroupIds,
   isNotSpecialId,
   loadYamlFile,
   sortSourceAndYmlFiles
 } from "./util";
-
-interface CheckException {
-  groups: Record<string, string[]>;
-  ignoredIds: Set<string>;
-}
-
-/**
- * Combines exception files into a single exception object.
- */
-export async function combineExceptionFiles(
-  exceptionFiles: string[]
-): Promise<CheckException> {
-  let allIgnoredIds = [];
-  const allGroups = [];
-  await Promise.all(
-    exceptionFiles.map(async file => {
-      const rawJson = (await fs.readFile(file)).toString();
-      const jsonObject = JSON.parse(rawJson);
-      allIgnoredIds = allIgnoredIds.concat(jsonObject.ignoredIds);
-      if (jsonObject.groups) {
-        allGroups.push(jsonObject.groups);
-      }
-    })
-  );
-  const groups = allGroups.reduce(
-    (result, group) => ({ ...result, ...group }),
-    {}
-  );
-  return {
-    groups,
-    // Make sure ignored ids are unique
-    ignoredIds: new Set(allIgnoredIds)
-  };
-}
 
 /**
  * Computes the unused ids from code or YML file for a given locale.

--- a/packages/scripts/src/validate-i18n.ts
+++ b/packages/scripts/src/validate-i18n.ts
@@ -6,6 +6,7 @@ import { extract } from "@formatjs/cli";
 import { isNotSpecialId, loadYamlFile, sortSourceAndYmlFiles } from "./util";
 
 interface CheckException {
+  groups: Record<string, string[]>;
   ignoredIds: Set<string>;
 }
 
@@ -16,15 +17,24 @@ export async function combineExceptionFiles(
   exceptionFiles: string[]
 ): Promise<CheckException> {
   let allIgnoredIds = [];
+  const allGroups = [];
   await Promise.all(
     exceptionFiles.map(async file => {
       const rawJson = (await fs.readFile(file)).toString();
       const jsonObject = JSON.parse(rawJson);
       allIgnoredIds = allIgnoredIds.concat(jsonObject.ignoredIds);
+      if (jsonObject.groups) {
+        allGroups.push(jsonObject.groups);
+      }
     })
   );
   // Make sure ignored ids are unique
+  const groups = allGroups.reduce(
+    (result, group) => ({ ...result, ...group }),
+    {}
+  );
   return {
+    groups,
     ignoredIds: new Set(allIgnoredIds)
   };
 }

--- a/packages/scripts/src/validate-i18n.ts
+++ b/packages/scripts/src/validate-i18n.ts
@@ -118,7 +118,7 @@ async function checkI18n({ exceptionFiles, sourceFiles, ymlFilesByLocale }) {
     } exception files).`
   );
 
-  const { ignoredIds } = await combineExceptionFiles(exceptionFiles);
+  const { groups, ignoredIds } = await combineExceptionFiles(exceptionFiles);
   let errorCount = 0;
   // For each locale, check that all ids in messages are in the yml files.
   // Accessorily, log message ids from yml files that are not used in the code.
@@ -127,7 +127,8 @@ async function checkI18n({ exceptionFiles, sourceFiles, ymlFilesByLocale }) {
       const { idsNotInCode, missingIdsForLocale } = await checkLocale(
         ymlFilesByLocale[locale],
         messageIdsFromCode,
-        ignoredIds
+        ignoredIds,
+        groups
       );
 
       // Print errors.


### PR DESCRIPTION
This PR allows declaring message groups using the `i18n-exceptions.json` file (see one of the files provided in the PR), so that such messages are treated accordingly during validation and are also included in CSV output produced by `collect-i18n-messages`.