### PR TITLE
fix: new mode selector support car

### DIFF
--- a/packages/core-utils/src/__tests__/query-params.ts
+++ b/packages/core-utils/src/__tests__/query-params.ts
@@ -163,6 +163,26 @@ describe("query-gen", () => {
         ["WALK"]
       ]
     );
+
+    expectModes(
+      ["CAR_HAIL", "TRANSIT"],
+      [["TRANSIT"], ["CAR_HAIL", "TRANSIT"]]
+    );
+    expectModes(
+      ["CAR_HAIL", "BICYCLE_RENT", "TRANSIT"],
+      [["TRANSIT"], ["CAR_HAIL", "TRANSIT"], ["BICYCLE_RENT", "TRANSIT"]]
+    );
+    expectModes(
+      ["CAR_HAIL", "BICYCLE_RENT", "TRANSIT", "WALK"],
+      [
+        ["TRANSIT"],
+        ["CAR_HAIL", "TRANSIT"],
+        ["CAR_HAIL", "WALK"],
+        ["BICYCLE_RENT", "TRANSIT"],
+        ["BICYCLE_RENT", "WALK"],
+        ["WALK"]
+      ]
+    );
     expectModes(
       ["FLEX", "TRANSIT", "WALK"],
       [["TRANSIT"], ["FLEX", "TRANSIT"], ["FLEX", "WALK"], ["WALK"]]

--- a/packages/core-utils/src/query-gen.ts
+++ b/packages/core-utils/src/query-gen.ts
@@ -127,7 +127,7 @@ const VALID_COMBOS = [
   ["TRANSIT", "CAR"]
 ];
 
-const BANNED_TOGETHER = ["SCOOTER", "BICYCLE"];
+const BANNED_TOGETHER = ["SCOOTER", "BICYCLE", "CAR"];
 
 export const TRANSIT_SUBMODES = Object.keys(SIMPLIFICATIONS).filter(
   mode => SIMPLIFICATIONS[mode] === "TRANSIT" && mode !== "TRANSIT"
@@ -168,7 +168,9 @@ function isCombinationValid(
   }
 
   // OTP doesn't support multiple non-walk modes
-  if (BANNED_TOGETHER.every(m => combo.find(c => c.mode === m))) return false;
+  if (BANNED_TOGETHER.filter(m => combo.find(c => c.mode === m)).length > 1) {
+    return false;
+  }
 
   return !!VALID_COMBOS.find(
     vc =>


### PR DESCRIPTION
The current new mode selector generates invalid car-based modes. This PR repairs this, quite quickly and quite elegantly.