### PR TITLE
fix: alert timings in seconds instead of milliseconds, following OTP2

### DIFF
--- a/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
@@ -113,7 +113,7 @@ export default function AlertsBody({
                       description="Text with the time and date an alert takes effect"
                       id="otpUi.TransitLegBody.AlertsBody.effectiveTimeAndDate"
                       values={{
-                        dateTime: effectiveStartDate,
+                        dateTime: effectiveStartDate * 1000,
                         day: <AlertDay dayDiff={dayDiff} />
                       }}
                     />
@@ -127,7 +127,7 @@ export default function AlertsBody({
                       description="Text with the date an alert takes effect"
                       id="otpUi.TransitLegBody.AlertsBody.effectiveDate"
                       values={{
-                        dateTime: effectiveStartDate
+                        dateTime: effectiveStartDate * 1000
                       }}
                     />
                   )}

--- a/packages/itinerary-body/src/__mocks__/itineraries/bike-rental-transit-bike-rental.json
+++ b/packages/itinerary-body/src/__mocks__/itineraries/bike-rental-transit-bike-rental.json
@@ -1144,12 +1144,12 @@
       "alerts": [
         {
           "alertUrl": "http://trimet.org/alerts/",
-          "effectiveStartDate": 1562950483000,
+          "effectiveStartDate": 1562950483,
           "alertDescriptionText": "For trips to Parkrose/Sumner Transit Center, no service to the stop at NE Sandy & 47th (Stop ID 5094) due to long-term construction. Use the temporary stop located at NE Sandy & 48th (Stop ID 14073)."
         },
         {
           "alertUrl": "http://trimet.org/alerts/",
-          "effectiveStartDate": 1564601290000,
+          "effectiveStartDate": 1564601290,
           "alertDescriptionText": "For trips to Tigard Transit Center, no service to the stop at NE Sandy & 91st (Stop ID 5145) due to PBOT sidewalk construction. Use temporary stop on the west side of 91st.  "
         }
       ],

--- a/packages/itinerary-body/src/__mocks__/itineraries/bike-transit-bike.json
+++ b/packages/itinerary-body/src/__mocks__/itineraries/bike-transit-bike.json
@@ -434,12 +434,12 @@
       "alerts": [
         {
           "alertUrl": "https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/",
-          "effectiveStartDate": 1573083439000,
+          "effectiveStartDate": 1573083439,
           "alertDescriptionText": "The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages."
         },
         {
           "alertUrl": "http://trimet.org/alerts/",
-          "effectiveStartDate": 1572827580000,
+          "effectiveStartDate": 1572827580,
           "alertDescriptionText": "The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms. "
         }
       ],

--- a/packages/itinerary-body/src/__mocks__/itineraries/park-and-ride.json
+++ b/packages/itinerary-body/src/__mocks__/itineraries/park-and-ride.json
@@ -2057,12 +2057,12 @@
       "alerts": [
         {
           "alertUrl": "https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/",
-          "effectiveStartDate": 1573083439000,
+          "effectiveStartDate": 1573083439,
           "alertDescriptionText": "The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages."
         },
         {
           "alertUrl": "http://trimet.org/alerts/",
-          "effectiveStartDate": 1572827580000,
+          "effectiveStartDate": 1572827580,
           "alertDescriptionText": "The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms. "
         }
       ],

--- a/packages/itinerary-body/src/__mocks__/itineraries/walk-transit-walk.json
+++ b/packages/itinerary-body/src/__mocks__/itineraries/walk-transit-walk.json
@@ -196,17 +196,17 @@
       "alerts": [
         {
           "alertUrl": "http://trimet.org/alerts/",
-          "effectiveStartDate": 1576471800000,
+          "effectiveStartDate": 1576471800,
           "alertDescriptionText": "TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911."
         },
         {
           "alertUrl": "https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/",
-          "effectiveStartDate": 1573083439000,
+          "effectiveStartDate": 1573083439,
           "alertDescriptionText": "The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages."
         },
         {
           "alertUrl": "http://trimet.org/alerts/",
-          "effectiveStartDate": 1572827580000,
+          "effectiveStartDate": 1572827580,
           "alertDescriptionText": "The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms. "
         }
       ],


### PR DESCRIPTION
OTP2 uses seconds instead of milliseconds to represent alert dates. This PR resolves alerts showing up as 1970