### PR TITLE
Show Stop code on non-stop Legs

### DIFF
--- a/packages/itinerary-body/src/AccessLegBody/index.tsx
+++ b/packages/itinerary-body/src/AccessLegBody/index.tsx
@@ -1,11 +1,11 @@
 import { Config, Leg, LegIconComponent } from "@opentripplanner/types";
-import React, { Component, ReactElement } from "react";
+import React, { Component, FunctionComponent, ReactElement } from "react";
 import AnimateHeight from "react-animate-height";
 import { FormattedMessage } from "react-intl";
 import { Duration } from "../defaults";
 
 import * as S from "../styled";
-import { SetActiveLegFunction } from "../types";
+import { SetActiveLegFunction, TransitLegSubheaderProps } from "../types";
 
 import AccessLegSteps from "./access-leg-steps";
 import AccessLegSummary from "./access-leg-summary";
@@ -33,6 +33,7 @@ interface Props {
   setLegDiagram: (leg: Leg) => void;
   showElevationProfile: boolean;
   showLegIcon: boolean;
+  TransitLegSubheader?: FunctionComponent<TransitLegSubheaderProps>;
 }
 
 interface State {
@@ -71,6 +72,7 @@ class AccessLegBody extends Component<Props, State> {
       mapillaryKey,
       setLegDiagram,
       showElevationProfile,
+      TransitLegSubheader,
       showLegIcon
     } = this.props;
     const { expanded } = this.state;
@@ -94,6 +96,9 @@ class AccessLegBody extends Component<Props, State> {
  pickup */}
         {leg && (leg.rentedVehicle || leg.rentedBike || leg.rentedCar) && (
           <RentedVehicleSubheader config={config} leg={leg} />
+        )}
+        {leg.from.stopId && TransitLegSubheader && (
+          <TransitLegSubheader leg={leg} />
         )}
         <S.LegBody>
           <AccessLegSummary

--- a/packages/itinerary-body/src/ItineraryBody/place-row.tsx
+++ b/packages/itinerary-body/src/ItineraryBody/place-row.tsx
@@ -168,6 +168,7 @@ export default function PlaceRow({
               setLegDiagram={setLegDiagram}
               showElevationProfile={showElevationProfile}
               showLegIcon={showLegIcon}
+              TransitLegSubheader={TransitLegSubheader}
             />
           ))}
       </S.PlaceDetails>


### PR DESCRIPTION
"access" legs as opposed to transit legs currently do not show stop information. This PR corrects this.