### PR TITLE
add period to trigger semantic release

### DIFF
--- a/packages/stops-overlay/src/index.tsx
+++ b/packages/stops-overlay/src/index.tsx
@@ -151,7 +151,7 @@ const StopsOverlay = (props: Props): JSX.Element => {
           paint={{
             "circle-color": color || "#fff",
             "circle-opacity": 0.9,
-            // TODO: Use tinycolor to generate outline with appropriate contrast
+            // TODO: Use tinycolor to generate outline with appropriate contrast.
             "circle-stroke-color": color ? "#fff" : "#333",
             "circle-stroke-width": 2
           }}


### PR DESCRIPTION
https://github.com/opentripplanner/otp-ui/pull/599 Didn't include a breaking change commit, so this seeks to rectify that