### PR TITLE
Small mode selector enhancements

### DIFF
--- a/packages/trip-form/src/MetroModeSelector/MetroModeSelector.story.tsx
+++ b/packages/trip-form/src/MetroModeSelector/MetroModeSelector.story.tsx
@@ -71,6 +71,14 @@ const modeSettingDefinitionsWithDropdown = [
   ...modeSettingDefinitions,
   {
     applicableMode: "TRANSIT",
+    default: "blue",
+    key: "busColor",
+    label: "Bus Color",
+    options: [{ value: "blue", text: "Blue" }],
+    type: "DROPDOWN"
+  },
+  {
+    applicableMode: "TRANSIT",
     default: true,
     key: "tram",
     iconName: "tram",

--- a/packages/trip-form/src/MetroModeSelector/MetroModeSelector.story.tsx
+++ b/packages/trip-form/src/MetroModeSelector/MetroModeSelector.story.tsx
@@ -71,17 +71,10 @@ const modeSettingDefinitionsWithDropdown = [
   ...modeSettingDefinitions,
   {
     applicableMode: "TRANSIT",
-    default: "blue",
-    key: "busColor",
-    label: "Bus Color",
-    options: [{ value: "blue", text: "Blue" }],
-    type: "DROPDOWN"
-  },
-  {
-    applicableMode: "TRANSIT",
     default: true,
     key: "tram",
-    label: "Tram",
+    iconName: "tram",
+    label: "Tram but long",
     addTransportMode: {
       mode: "TRAM"
     },
@@ -91,7 +84,7 @@ const modeSettingDefinitionsWithDropdown = [
     applicableMode: "TRANSIT",
     default: true,
     key: "bus",
-    label: "Bus",
+    label: "MARTA Rail",
     iconName: "bus",
     addTransportMode: {
       mode: "BUS"

--- a/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
+++ b/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
@@ -50,7 +50,7 @@ const SettingsPanel = styled.fieldset`
 export const SubSettingsCheckbox = styled(CheckboxSelector)<{
   flexbox: boolean;
 }>`
-  display: ${props => (props.flexbox ? "flex" : "block")};
+  display: ${props => (props.flexbox ? "flex" : "inherit")};
   margin-left: 4px;
   input {
     vertical-align: middle;
@@ -88,7 +88,7 @@ const ModeSettingRenderer = ({
     "icon" in setting ? (
       <FormLabelIconWrapper>
         <div role="none">{setting.icon}</div>
-        <div> {label}</div>
+        <div>{label}</div>
       </FormLabelIconWrapper>
     ) : (
       label

--- a/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
+++ b/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
@@ -50,7 +50,7 @@ const SettingsPanel = styled.fieldset`
 export const SubSettingsCheckbox = styled(CheckboxSelector)<{
   flexbox: boolean;
 }>`
-  display: ${props => (props.flexbox ? "flex" : "box")};
+  display: ${props => (props.flexbox ? "flex" : "block")};
   margin-left: 4px;
   input {
     vertical-align: middle;

--- a/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
+++ b/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
@@ -58,8 +58,8 @@ export const SubSettingsCheckbox = styled(CheckboxSelector)<{
 `;
 
 const FormLabelIconWrapper = styled.span`
-  display: flex;
   align-items: center;
+  display: flex;
   gap: 4px;
   svg {
     width: 16px;

--- a/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
+++ b/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
@@ -47,7 +47,10 @@ const SettingsPanel = styled.fieldset`
   }
 `;
 
-export const SubSettingsCheckbox = styled(CheckboxSelector)`
+export const SubSettingsCheckbox = styled(CheckboxSelector)<{
+  flexbox: boolean;
+}>`
+  display: ${props => (props.flexbox ? "flex" : "box")};
   margin-left: 4px;
   input {
     vertical-align: middle;
@@ -55,6 +58,9 @@ export const SubSettingsCheckbox = styled(CheckboxSelector)`
 `;
 
 const FormLabelIconWrapper = styled.span`
+  display: flex;
+  align-items: center;
+  gap: 4px;
   svg {
     width: 16px;
     height: 16px;
@@ -81,7 +87,8 @@ const ModeSettingRenderer = ({
   const labelWithIcon =
     "icon" in setting ? (
       <FormLabelIconWrapper>
-        <span role="none">{setting.icon}</span> {label}
+        <div role="none">{setting.icon}</div>
+        <div> {label}</div>
       </FormLabelIconWrapper>
     ) : (
       label
@@ -92,6 +99,7 @@ const ModeSettingRenderer = ({
     case "SUBMODE":
       return (
         <SubSettingsCheckbox
+          flexbox={setting.type === "SUBMODE"}
           label={labelWithIcon}
           name={setting.key}
           onChange={onChange}

--- a/packages/trip-form/src/MetroModeSelector/index.tsx
+++ b/packages/trip-form/src/MetroModeSelector/index.tsx
@@ -250,7 +250,8 @@ function ModeButton({
     useDismiss(context)
   ]);
 
-  const renderDropdown = open && modeButton.enabled;
+  const renderDropdown =
+    open && modeButton.enabled && modeButton.modeSettings?.length > 0;
   const interactionProps = getReferenceProps();
 
   // ARIA roles are added by the `useRole` hook.


### PR DESCRIPTION
This PR does two things:
- Disables the hover element if there are no sub settings to be displayed.
- Uses flexbox to fix weird wrapping that was happening on long mode settings