### PR TITLE
fix(itinerary-body): change viewer button to link

### DIFF
--- a/packages/itinerary-body/src/styled.tsx
+++ b/packages/itinerary-body/src/styled.tsx
@@ -85,7 +85,7 @@ export const AnchorButton = styled.a`
   }
 `;
 
-export const LinkButton = styled(TransparentButton)`
+export const LinkButton = styled.a`
   color: #008;
   cursor: pointer;
   margin-left: 5px;


### PR DESCRIPTION
Trip and stop viewer buttons inside itinerary are converted to links for a11y purposes.

This changes adjusts the itinerary spacing by 1-2 pixels in a few places! It seemed like overkill to compensate for this change with minute padding/margin additions, but please let me know if this is an issue and I can adjust.