### PR TITLE
fix(geocoder): Export GeocoderConfig type in package index.

### DIFF
--- a/packages/geocoder/src/index.ts
+++ b/packages/geocoder/src/index.ts
@@ -40,4 +40,9 @@ const getGeocoder = memoize((geocoderConfig: GeocoderConfig & { type: string }) 
 });
 
 export default getGeocoder;
-export type { SearchQuery, AutocompleteQuery, ReverseQuery };
+export type {
+  AutocompleteQuery,
+  GeocoderConfig,
+  ReverseQuery,
+  SearchQuery
+};


### PR DESCRIPTION
A PR so that the geocoder config type can simply be imported as
```js
import { GeocoderConfig } from "@opentripplanner/geocoder";
```
