### PR TITLE
Handle null fareproduct IDs in core-utils

### DIFF
--- a/packages/core-utils/src/__tests__/__mocks__/fare-products-itinerary.json
+++ b/packages/core-utils/src/__tests__/__mocks__/fare-products-itinerary.json
@@ -151,6 +151,22 @@
           }
         },
         {
+          "id": "77a8ba05-8081-301f-9fe4-777dcd10ae02",
+          "product": {
+            "id": "regular",
+            "name": "regular",
+            "price": {
+              "currency": {
+                "code": "USD",
+                "digits": 2
+              },
+              "amount": 2.75
+            },
+            "riderCategory": null,
+            "medium": null
+          }
+        },
+        {
           "id": "0740913d-0e0a-34ab-9518-014f2025b1a8",
           "product": {
             "id": "orca:farePayment",

--- a/packages/core-utils/src/__tests__/itinerary.js
+++ b/packages/core-utils/src/__tests__/itinerary.js
@@ -148,6 +148,14 @@ describe("util > itinerary", () => {
         digits: 2
       });
     });
+    it("should calculate the total cost of an itinerary will null ids", () => {
+      const result = getItineraryCost(fareProductItinerary.legs, null, null);
+      expect(result.amount).toEqual(2.75);
+      expect(result.currency).toEqual({
+        code: "USD",
+        digits: 2
+      });
+    });
     it("should return undefined when the keys are invalid", () => {
       const result = getItineraryCost(
         fareProductItinerary.legs,

--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -569,12 +569,15 @@ export function getLegCost(
 ): { price?: Money; transferAmount?: Money | undefined } {
   if (!leg.fareProducts) return { price: undefined };
   const relevantFareProducts = leg.fareProducts.filter(({ product }) => {
+    // riderCategory and medium can be specifically defined as null to handle
+    // generic GTFS based fares from OTP when there is no fare model
     return (
       (product.riderCategory === null ? null : product.riderCategory.id) ===
         riderCategoryId &&
       (product.medium === null ? null : product.medium.id) === mediumId
     );
   });
+  // Custom fare models return "rideCost", generic GTFS fares return "regular"
   const totalCost = relevantFareProducts.find(
     fp => fp.product.name === "rideCost" || fp.product.name === "regular"
   )?.product?.price;

--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -564,18 +564,19 @@ export function getDisplayedStopId(placeOrStop: Place | Stop): string {
  */
 export function getLegCost(
   leg: Leg,
-  mediumId: string,
-  riderCategoryId: string
+  mediumId: string | null,
+  riderCategoryId: string | null
 ): { price?: Money; transferAmount?: Money | undefined } {
   if (!leg.fareProducts) return { price: undefined };
   const relevantFareProducts = leg.fareProducts.filter(({ product }) => {
     return (
-      product.riderCategory.id === riderCategoryId &&
-      product.medium.id === mediumId
+      (product.riderCategory === null ? null : product.riderCategory.id) ===
+        riderCategoryId &&
+      (product.medium === null ? null : product.medium.id) === mediumId
     );
   });
   const totalCost = relevantFareProducts.find(
-    fp => fp.product.name === "rideCost"
+    fp => fp.product.name === "rideCost" || fp.product.name === "regular"
   )?.product?.price;
   const transferFareProduct = relevantFareProducts.find(
     fp => fp.product.name === "transfer"
@@ -596,8 +597,8 @@ export function getLegCost(
  */
 export function getItineraryCost(
   legs: Leg[],
-  mediumId: string,
-  riderCategoryId: string
+  mediumId: string | null,
+  riderCategoryId: string | null
 ): Money | undefined {
   const legCosts = legs
     .filter(leg => leg.fareProducts?.length > 0)


### PR DESCRIPTION
This PR allows core-utils to handle null ID values in fare products which can be returned by OTP on instances without specific fare modules. (GTFS fares)