### PR TITLE
refactor: pass otp2 custom config colors

### DIFF
--- a/packages/otp2-tile-overlay/src/Otp2TileOverlay.story.tsx
+++ b/packages/otp2-tile-overlay/src/Otp2TileOverlay.story.tsx
@@ -6,6 +6,8 @@ export default {
   title: "OTP2 Tile Layer"
 };
 
+// TODO: Add story to illustrate "color" prop passed from overlay.
+
 export const OtpTileLayer = (): JSX.Element => {
   const [endpoint, setEndpoint] = useState("https://fake-otp-server.com/otp");
   return (

--- a/packages/otp2-tile-overlay/src/index.tsx
+++ b/packages/otp2-tile-overlay/src/index.tsx
@@ -14,6 +14,7 @@ import { LAYER_PAINT } from "./util"
 const SOURCE_ID = "otp2-tiles"
 
 const OTP2TileLayerWithPopup = ({
+  color,
   configCompanies,
   id,
   network,
@@ -27,6 +28,7 @@ const OTP2TileLayerWithPopup = ({
    * bikeshare companies. If this is provided, scooter/bikeshare company names can be rendered in the
    * default scooter/bike popup.
    */
+  color?: string;
   configCompanies?: ConfiguredCompany[]
   id: string
   name?: string
@@ -129,7 +131,7 @@ const OTP2TileLayerWithPopup = ({
         filter={network ? ["all", ["==", "network", network]] : ["all"]}
         id={id}
         key={id}
-        paint={LAYER_PAINT[type]}
+        paint={LAYER_PAINT(color)[type]}
         source={SOURCE_ID}
         source-layer={type}
         type="circle"
@@ -168,12 +170,13 @@ const OTP2TileLayerWithPopup = ({
  * @returns               Array of <Source> and <OTP2TileLayerWithPopup> components
  */
 const generateOTP2TileLayers = (
-  layers: { name?: string; network?: string; type: string, initiallyVisible?: boolean }[],
+  layers: { color?: string; name?: string; network?: string; type: string, initiallyVisible?: boolean }[],
   endpoint: string,
   setLocation?: (location: MapLocationActionArg) => void,
   setViewedStop?: ({ stopId }: { stopId: string }) => void,
   configCompanies?: ConfiguredCompany[]
 ): JSX.Element[] => {
+  console.log(layers)
   return [
     <Source
       // @ts-expect-error we use a nonstandard prop
@@ -185,11 +188,12 @@ const generateOTP2TileLayers = (
       url={`${endpoint}/${layers.map((l) => l.type).join(",")}/tilejson.json`}
     />,
     ...layers.map((layer) => {
-      const { name, network, type, initiallyVisible } = layer
+      const { color, name, network, type, initiallyVisible } = layer
 
       const id = `${type}${network ? `-${network}` : ""}`
       return (
         <OTP2TileLayerWithPopup
+          color={color}
           configCompanies={configCompanies}
           id={id}
           key={id}

--- a/packages/otp2-tile-overlay/src/index.tsx
+++ b/packages/otp2-tile-overlay/src/index.tsx
@@ -9,7 +9,7 @@ import React, { useCallback, useEffect, useState } from "react"
 import { Layer, Popup, Source, useMap } from "react-map-gl"
 
 // eslint-disable-next-line prettier/prettier
-import { LAYER_PAINT } from "./util"
+import { generateLayerPaint } from "./util"
 
 const SOURCE_ID = "otp2-tiles"
 
@@ -131,7 +131,7 @@ const OTP2TileLayerWithPopup = ({
         filter={network ? ["all", ["==", "network", network]] : ["all"]}
         id={id}
         key={id}
-        paint={LAYER_PAINT(color)[type]}
+        paint={generateLayerPaint(color)[type]}
         source={SOURCE_ID}
         source-layer={type}
         type="circle"

--- a/packages/otp2-tile-overlay/src/index.tsx
+++ b/packages/otp2-tile-overlay/src/index.tsx
@@ -176,7 +176,6 @@ const generateOTP2TileLayers = (
   setViewedStop?: ({ stopId }: { stopId: string }) => void,
   configCompanies?: ConfiguredCompany[]
 ): JSX.Element[] => {
-  console.log(layers)
   return [
     <Source
       // @ts-expect-error we use a nonstandard prop

--- a/packages/otp2-tile-overlay/src/util.ts
+++ b/packages/otp2-tile-overlay/src/util.ts
@@ -8,37 +8,39 @@ const generateFloatingVehicleColor = (formFactor: string) => [
 ];
 
 // eslint-disable-next-line import/prefer-default-export
-export const LAYER_PAINT = {
-  rentalStations: {
-    "circle-color": generateFloatingVehicleColor("formFactors"),
-    "circle-opacity": 0.9,
-    "circle-stroke-color": "#333",
-    "circle-stroke-width": 3
-  },
-  rentalVehicles: {
-    "circle-color": generateFloatingVehicleColor("formFactor"),
-    "circle-opacity": 0.9,
-    "circle-stroke-color": "#333",
-    "circle-stroke-width": 2
-  },
-  stations: {
-    "circle-color": "#fff",
-    "circle-opacity": 0.9,
-    "circle-radius": 10,
-    "circle-stroke-color": "#333",
-    "circle-stroke-width": 3
-  },
-  stops: {
-    "circle-color": "#fff",
-    "circle-opacity": 0.9,
-    "circle-stroke-color": "#333",
-    "circle-stroke-width": 2
-  },
-  vehicleParking: {
-    "circle-color": "black",
-    "circle-opacity": 0.9,
-    "circle-radius": 10,
-    "circle-stroke-color": "#333",
-    "circle-stroke-width": 3
-  }
+export const LAYER_PAINT = (color?: string): any => {
+  return {
+    rentalStations: {
+      "circle-color": color || generateFloatingVehicleColor("formFactors"),
+      "circle-opacity": 0.9,
+      "circle-stroke-color": "#333",
+      "circle-stroke-width": 3
+    },
+    rentalVehicles: {
+      "circle-color": color || generateFloatingVehicleColor("formFactor"),
+      "circle-opacity": 0.9,
+      "circle-stroke-color": "#333",
+      "circle-stroke-width": 2
+    },
+    stations: {
+      "circle-color": color || "#fff",
+      "circle-opacity": 0.9,
+      "circle-radius": 10,
+      "circle-stroke-color": "#333",
+      "circle-stroke-width": 3
+    },
+    stops: {
+      "circle-color": color || "#fff",
+      "circle-opacity": 0.9,
+      "circle-stroke-color": "#333",
+      "circle-stroke-width": 2
+    },
+    vehicleParking: {
+      "circle-color": color || "black",
+      "circle-opacity": 0.9,
+      "circle-radius": 10,
+      "circle-stroke-color": "#333",
+      "circle-stroke-width": 3
+    }
+  };
 };

--- a/packages/otp2-tile-overlay/src/util.ts
+++ b/packages/otp2-tile-overlay/src/util.ts
@@ -8,7 +8,7 @@ const generateFloatingVehicleColor = (formFactor: string) => [
 ];
 
 // eslint-disable-next-line import/prefer-default-export
-export const LAYER_PAINT = (color?: string): any => {
+export const generateLayerPaint = (color?: string): any => {
   return {
     rentalStations: {
       "circle-color": color || generateFloatingVehicleColor("formFactors"),


### PR DESCRIPTION
Pass custom config color into OTP2 map layers.

<img width="394" alt="image" src="https://github.com/opentripplanner/otp-ui/assets/115499534/a97336a4-8fb6-4d0c-a48a-62b7a85c9c2c">
