### PR TITLE
Update Internal Dependencies (especially trip-details)

### DIFF
--- a/packages/endpoints-overlay/package.json
+++ b/packages/endpoints-overlay/package.json
@@ -19,9 +19,9 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.13",
+    "@opentripplanner/base-map": "^3.0.14",
     "@opentripplanner/location-icon": "^1.4.1",
-    "@opentripplanner/core-utils": "^9.0.0",
+    "@opentripplanner/core-utils": "^9.0.2",
     "flat": "^5.0.2",
     "@styled-icons/fa-solid": "^10.34.0"
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^9.0.0",
+    "@opentripplanner/core-utils": "^9.0.2",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/itinerary-body/package.json
+++ b/packages/itinerary-body/package.json
@@ -10,9 +10,9 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^9.0.0",
+    "@opentripplanner/core-utils": "^9.0.2",
     "@opentripplanner/humanize-distance": "^1.2.0",
-    "@opentripplanner/icons": "^2.0.3",
+    "@opentripplanner/icons": "^2.0.4",
     "@opentripplanner/location-icon": "^1.4.1",
     "@styled-icons/fa-solid": "^10.34.0",
     "@styled-icons/foundation": "^10.34.0",

--- a/packages/location-field/package.json
+++ b/packages/location-field/package.json
@@ -10,7 +10,7 @@
   "private": false,
   "dependencies": {
     "@conveyal/geocoder-arcgis-geojson": "^0.0.3",
-    "@opentripplanner/core-utils": "^9.0.0",
+    "@opentripplanner/core-utils": "^9.0.2",
     "@opentripplanner/geocoder": "1.4.1",
     "@opentripplanner/humanize-distance": "^1.2.0",
     "@opentripplanner/location-icon": "^1.4.1",

--- a/packages/map-popup/package.json
+++ b/packages/map-popup/package.json
@@ -11,9 +11,9 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.13",
-    "@opentripplanner/core-utils": "^9.0.0",
-    "@opentripplanner/from-to-location-picker": "^2.1.7",
+    "@opentripplanner/base-map": "^3.0.14",
+    "@opentripplanner/core-utils": "^9.0.2",
+    "@opentripplanner/from-to-location-picker": "^2.1.8",
     "flat": "^5.0.2"
   },
   "devDependencies": {

--- a/packages/otp2-tile-overlay/package.json
+++ b/packages/otp2-tile-overlay/package.json
@@ -16,10 +16,10 @@
     "react-map-gl": "^7.0.15"
   },
   "dependencies": {
-    "@opentripplanner/map-popup": "^2.0.4"
+    "@opentripplanner/map-popup": "^2.0.5"
   },
   "devDependencies": {
-    "@opentripplanner/base-map": "^3.0.13",
+    "@opentripplanner/base-map": "^3.0.14",
     "@opentripplanner/types": "^6.0.0"
   }
 }

--- a/packages/park-and-ride-overlay/package.json
+++ b/packages/park-and-ride-overlay/package.json
@@ -19,8 +19,8 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.13",
-    "@opentripplanner/from-to-location-picker": "^2.1.7"
+    "@opentripplanner/base-map": "^3.0.14",
+    "@opentripplanner/from-to-location-picker": "^2.1.8"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/printable-itinerary/package.json
+++ b/packages/printable-itinerary/package.json
@@ -10,11 +10,11 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^9.0.0",
-    "@opentripplanner/itinerary-body": "^5.0.0"
+    "@opentripplanner/core-utils": "^9.0.2",
+    "@opentripplanner/itinerary-body": "^5.0.2"
   },
   "devDependencies": {
-    "@opentripplanner/icons": "^2.0.3"
+    "@opentripplanner/icons": "^2.0.4"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/route-viewer-overlay/package.json
+++ b/packages/route-viewer-overlay/package.json
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.0",
-    "@opentripplanner/base-map": "^3.0.13",
-    "@opentripplanner/core-utils": "^9.0.0",
+    "@opentripplanner/base-map": "^3.0.14",
+    "@opentripplanner/core-utils": "^9.0.2",
     "point-in-polygon": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/stop-viewer-overlay/package.json
+++ b/packages/stop-viewer-overlay/package.json
@@ -19,8 +19,8 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.13",
-    "@opentripplanner/core-utils": "^9.0.0"
+    "@opentripplanner/base-map": "^3.0.14",
+    "@opentripplanner/core-utils": "^9.0.2"
   },
   "devDependencies": {
     "@opentripplanner/types": "^6.0.0"

--- a/packages/stops-overlay/package.json
+++ b/packages/stops-overlay/package.json
@@ -19,9 +19,9 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.13",
-    "@opentripplanner/from-to-location-picker": "^2.1.7",
-    "@opentripplanner/map-popup": "^2.0.4",
+    "@opentripplanner/base-map": "^3.0.14",
+    "@opentripplanner/from-to-location-picker": "^2.1.8",
+    "@opentripplanner/map-popup": "^2.0.5",
     "flat": "^5.0.2"
   },
   "devDependencies": {

--- a/packages/transit-vehicle-overlay/package.json
+++ b/packages/transit-vehicle-overlay/package.json
@@ -9,9 +9,9 @@
   "module": "esm/index.js",
   "private": false,
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.13",
-    "@opentripplanner/core-utils": "^9.0.0",
-    "@opentripplanner/icons": "^2.0.3",
+    "@opentripplanner/base-map": "^3.0.14",
+    "@opentripplanner/core-utils": "^9.0.2",
+    "@opentripplanner/icons": "^2.0.4",
     "flat": "^5.0.2"
   },
   "devDependencies": {

--- a/packages/transitive-overlay/package.json
+++ b/packages/transitive-overlay/package.json
@@ -20,9 +20,9 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.1",
-    "@opentripplanner/base-map": "^3.0.13",
-    "@opentripplanner/core-utils": "^9.0.0",
-    "@opentripplanner/itinerary-body": "^5.0.0",
+    "@opentripplanner/base-map": "^3.0.14",
+    "@opentripplanner/core-utils": "^9.0.2",
+    "@opentripplanner/itinerary-body": "^5.0.2",
     "@turf/bbox": "^6.5.0",
     "@turf/bearing": "^6.5.0",
     "@turf/destination": "^6.5.0",
@@ -32,7 +32,7 @@
     "lodash.isequal": "^4.5.0"
   },
   "devDependencies": {
-    "@opentripplanner/endpoints-overlay": "^2.0.7",
+    "@opentripplanner/endpoints-overlay": "^2.0.8",
     "@opentripplanner/types": "^6.0.0"
   },
   "peerDependencies": {

--- a/packages/trip-details/package.json
+++ b/packages/trip-details/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^9.0.0-alpha.36",
+    "@opentripplanner/core-utils": "^9.0.2",
     "@styled-icons/fa-solid": "^10.34.0",
     "flat": "^5.0.2",
     "react-animate-height": "^3.0.4"

--- a/packages/trip-form/package.json
+++ b/packages/trip-form/package.json
@@ -10,7 +10,7 @@
   "types": "lib/index.d.ts",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "^9.0.0",
+    "@opentripplanner/core-utils": "^9.0.2",
     "@floating-ui/react": "^0.19.2",
     "@styled-icons/bootstrap": "^10.34.0",
     "@styled-icons/boxicons-regular": "^10.38.0",

--- a/packages/trip-viewer-overlay/package.json
+++ b/packages/trip-viewer-overlay/package.json
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.0",
-    "@opentripplanner/base-map": "^3.0.13",
-    "@opentripplanner/core-utils": "^9.0.0"
+    "@opentripplanner/base-map": "^3.0.14",
+    "@opentripplanner/core-utils": "^9.0.2"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/vehicle-rental-overlay/package.json
+++ b/packages/vehicle-rental-overlay/package.json
@@ -19,10 +19,10 @@
     "url": "git+https://github.com/opentripplanner/otp-ui.git"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "^3.0.13",
-    "@opentripplanner/core-utils": "^9.0.0",
-    "@opentripplanner/from-to-location-picker": "^2.1.7",
-    "@opentripplanner/map-popup": "^2.0.4",
+    "@opentripplanner/base-map": "^3.0.14",
+    "@opentripplanner/core-utils": "^9.0.2",
+    "@opentripplanner/from-to-location-picker": "^2.1.8",
+    "@opentripplanner/map-popup": "^2.0.5",
     "@styled-icons/fa-solid": "^10.34.0",
     "flat": "^5.0.2",
     "lodash.memoize": "^4.1.2"

--- a/packages/zoom-based-markers/package.json
+++ b/packages/zoom-based-markers/package.json
@@ -19,8 +19,8 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/core-utils": "^9.0.0",
-    "@opentripplanner/base-map": "^3.0.13"
+    "@opentripplanner/core-utils": "^9.0.2",
+    "@opentripplanner/base-map": "^3.0.14"
   },
   "devDependencies": {
     "@opentripplanner/types": "^6.0.0"


### PR DESCRIPTION
Need to get the new core utils version into trip details, thought I'd update everything along the way. 

FYI: With new Yarn we can use the `workspace:` protocol and no longer do these PRs.