### PR TITLE
Handle fareproduct use IDs correctly

### DIFF
--- a/packages/core-utils/src/__tests__/itinerary.js
+++ b/packages/core-utils/src/__tests__/itinerary.js
@@ -164,5 +164,20 @@ describe("util > itinerary", () => {
       );
       expect(result).toBeUndefined();
     });
+    it("should exclude duplicated fareProduct uses based on ID", () => {
+      const legsWithDuplicatedProducts = [...fareProductItinerary.legs];
+      legsWithDuplicatedProducts[3].fareProducts =
+        legsWithDuplicatedProducts[1].fareProducts;
+      const result = getItineraryCost(
+        fareProductItinerary.legs,
+        "orca:cash",
+        "orca:regular"
+      );
+      expect(result.amount).toEqual(2.75);
+      expect(result.currency).toEqual({
+        code: "USD",
+        digits: 2
+      });
+    });
   });
 });

--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -620,7 +620,7 @@ export function getItineraryCost(
       }
       return prev;
     }, [])
-    .map(prodUse => prodUse.price);
+    .map(productUse => productUse.price);
 
   if (legCosts.length === 0) return undefined;
   // Calculate the total

--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -566,7 +566,7 @@ export function getLegCost(
   leg: Leg,
   mediumId: string | null,
   riderCategoryId: string | null
-): { price?: Money; transferAmount?: Money | undefined } {
+): { price?: Money; transferAmount?: Money | undefined; useId?: string } {
   if (!leg.fareProducts) return { price: undefined };
   const relevantFareProducts = leg.fareProducts.filter(({ product }) => {
     // riderCategory and medium can be specifically defined as null to handle
@@ -577,17 +577,19 @@ export function getLegCost(
       (product.medium === null ? null : product.medium.id) === mediumId
     );
   });
+
   // Custom fare models return "rideCost", generic GTFS fares return "regular"
-  const totalCost = relevantFareProducts.find(
+  const totalCostProduct = relevantFareProducts.find(
     fp => fp.product.name === "rideCost" || fp.product.name === "regular"
-  )?.product?.price;
+  );
   const transferFareProduct = relevantFareProducts.find(
     fp => fp.product.name === "transfer"
   );
 
   return {
-    price: totalCost,
-    transferAmount: transferFareProduct?.product.price
+    price: totalCostProduct.product.price,
+    transferAmount: transferFareProduct?.product.price,
+    useId: totalCostProduct.id
   };
 }
 
@@ -604,10 +606,24 @@ export function getItineraryCost(
   riderCategoryId: string | null
 ): Money | undefined {
   const legCosts = legs
+    // Only legs with fares (no walking legs)
     .filter(leg => leg.fareProducts?.length > 0)
-    .map(leg => getLegCost(leg, mediumId, riderCategoryId).price)
-    .filter(cost => cost !== undefined);
+    // Get the leg cost object of each leg
+    .map(leg => getLegCost(leg, mediumId, riderCategoryId))
+    .filter(cost => cost.price !== undefined)
+    // Filter out duplicate use IDs
+    // One fare product can be used on multiple legs,
+    // and we don't want to count it more than once.
+    .reduce<{ useId: string; price: Money }[]>((prev, cur) => {
+      if (prev.some(p => p.useId !== cur.useId)) {
+        prev.push({ useId: cur.useId, price: cur.price });
+      }
+      return prev;
+    }, [])
+    .map(prodUse => prodUse.price);
+
   if (legCosts.length === 0) return undefined;
+  // Calculate the total
   return legCosts.reduce<Money>(
     (prev, cur) => ({
       amount: prev.amount + cur?.amount || 0,

--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -587,9 +587,9 @@ export function getLegCost(
   );
 
   return {
-    price: totalCostProduct.product.price,
+    price: totalCostProduct?.product.price,
     transferAmount: transferFareProduct?.product.price,
-    useId: totalCostProduct.id
+    useId: totalCostProduct?.id
   };
 }
 
@@ -615,7 +615,7 @@ export function getItineraryCost(
     // One fare product can be used on multiple legs,
     // and we don't want to count it more than once.
     .reduce<{ useId: string; price: Money }[]>((prev, cur) => {
-      if (prev.some(p => p.useId !== cur.useId)) {
+      if (!prev.some(p => p.useId === cur.useId)) {
         prev.push({ useId: cur.useId, price: cur.price });
       }
       return prev;

--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -566,7 +566,11 @@ export function getLegCost(
   leg: Leg,
   mediumId: string | null,
   riderCategoryId: string | null
-): { price?: Money; transferAmount?: Money | undefined; useId?: string } {
+): {
+  price?: Money;
+  transferAmount?: Money | undefined;
+  productUseId?: string;
+} {
   if (!leg.fareProducts) return { price: undefined };
   const relevantFareProducts = leg.fareProducts.filter(({ product }) => {
     // riderCategory and medium can be specifically defined as null to handle
@@ -589,7 +593,7 @@ export function getLegCost(
   return {
     price: totalCostProduct?.product.price,
     transferAmount: transferFareProduct?.product.price,
-    useId: totalCostProduct?.id
+    productUseId: totalCostProduct?.id
   };
 }
 
@@ -614,9 +618,9 @@ export function getItineraryCost(
     // Filter out duplicate use IDs
     // One fare product can be used on multiple legs,
     // and we don't want to count it more than once.
-    .reduce<{ useId: string; price: Money }[]>((prev, cur) => {
-      if (!prev.some(p => p.useId === cur.useId)) {
-        prev.push({ useId: cur.useId, price: cur.price });
+    .reduce<{ productUseId: string; price: Money }[]>((prev, cur) => {
+      if (!prev.some(p => p.productUseId === cur.productUseId)) {
+        prev.push({ productUseId: cur.productUseId, price: cur.price });
       }
       return prev;
     }, [])


### PR DESCRIPTION
This fixes fares being counted multiple times when a fare module doesn't provide per-leg fares.