### PR TITLE
Add OTP2 advanced leg route attributes

### DIFF
--- a/packages/itinerary-body/src/defaults/line-column-content.tsx
+++ b/packages/itinerary-body/src/defaults/line-column-content.tsx
@@ -65,7 +65,7 @@ export default function LineColumnContent({
     }
   );
 
-  const routeNumber = typeof route === "string" ? route : route?.shortName;
+  const routeShortName = typeof route === "string" ? route : route?.shortName;
 
   return (
     <S.LegLine>
@@ -75,7 +75,7 @@ export default function LineColumnContent({
         {!interline && !isDestination && transitLeg && (
           <RouteBadge
             abbreviation={toRouteAbbreviation(
-              parseInt(routeNumber, 10) || routeNumber
+              parseInt(routeShortName, 10) || routeShortName
             )}
             color={routeColor}
             name={routeLongName || ""}

--- a/packages/itinerary-body/src/defaults/line-column-content.tsx
+++ b/packages/itinerary-body/src/defaults/line-column-content.tsx
@@ -65,6 +65,8 @@ export default function LineColumnContent({
     }
   );
 
+  const routeNumber = typeof route === "string" ? route : route?.shortName;
+
   return (
     <S.LegLine>
       {!isDestination && <S.InnerLine mode={mode} routeColor={routeColor} />}
@@ -72,7 +74,9 @@ export default function LineColumnContent({
         {/* TODO: This is a placeholder for a routebadge when we create the transit leg */}
         {!interline && !isDestination && transitLeg && (
           <RouteBadge
-            abbreviation={toRouteAbbreviation(parseInt(route, 10) || route)}
+            abbreviation={toRouteAbbreviation(
+              parseInt(routeNumber, 10) || routeNumber
+            )}
             color={routeColor}
             name={routeLongName || ""}
           />

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -202,6 +202,8 @@ export type Alert = {
   alertDescriptionText?: string;
   alertUrl?: string;
   effectiveStartDate?: number;
+  /** Returned by OTP2 graphql queries, but not by OTP1 */
+  id?: string;
 };
 
 /**
@@ -269,6 +271,22 @@ type FlexPickupBookingInfo = {
   pickupMessage?: string;
 } & FlexBookingInfo;
 
+/** Basic transit route attributes */
+interface BasicRouteInfo {
+  color?: string;
+  id: string;
+  longName?: string;
+  shortName: string;
+  textColor?: string;
+  // TS TODO: route type enum
+  type?: number;
+}
+
+/** Transit route attributes from itinerary legs */
+export type LegRoute = BasicRouteInfo & {
+  alerts?: Alert[];
+};
+
 /**
  * Represents a leg in an itinerary of an OTP plan response. Each leg represents
  * a portion of the overall itinerary that is done until either reaching the
@@ -316,7 +334,7 @@ export type Leg = {
   rentedBike: boolean;
   rentedCar: boolean;
   rentedVehicle: boolean;
-  route?: string;
+  route?: string | LegRoute;
   routeColor?: string;
   routeId?: string;
   routeLongName?: string;
@@ -470,22 +488,15 @@ export type Agency = {
   phone?: string;
   fareUrl?: string;
 };
-export type Route = {
+export type Route = BasicRouteInfo & {
   agency: Agency;
   agencyId?: string | number;
   agencyName?: string | number;
-  shortName: string;
-  longName?: string;
-  mode?: string;
-  id: string;
-  // TS TODO: route type enum
-  type?: number;
-  color?: string;
-  textColor?: string;
-  routeBikesAllowed?: ZeroOrOne;
   bikesAllowed?: ZeroOrOne;
-  sortOrder: number;
   eligibilityRestricted?: ZeroOrOne;
+  mode?: string;
+  routeBikesAllowed?: ZeroOrOne;
+  sortOrder: number;
   sortOrderSet: boolean;
 };
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -492,6 +492,7 @@ export type Route = BasicRouteInfo & {
   agency: Agency;
   agencyId?: string | number;
   agencyName?: string | number;
+  // TODO: Add support for enum values, see /packages/core-utils/src/otpSchema.json#L1289.
   bikesAllowed?: ZeroOrOne;
   eligibilityRestricted?: ZeroOrOne;
   mode?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3241,25 +3241,6 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
-"@opentripplanner/core-utils@^9.0.3":
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-9.0.3.tgz#c1ebdcc3ad5999fb28427102c9be7d7268f6bd37"
-  integrity sha512-8P3Bi41jF7z18P/soo6lEw+nrqarsyGMAxivsF1/kMJdRo4wnakp0zcrVZjDXTxoR6LPtj6Kkuxv3JQFO9jKiw==
-  dependencies:
-    "@conveyal/lonlat" "^1.4.1"
-    "@mapbox/polyline" "^1.1.0"
-    "@opentripplanner/geocoder" "^1.4.1"
-    "@styled-icons/foundation" "^10.34.0"
-    "@turf/along" "^6.0.1"
-    bowser "^2.7.0"
-    chroma-js "^2.4.2"
-    date-fns "^2.28.0"
-    date-fns-tz "^1.2.2"
-    graphql "^16.6.0"
-    lodash.clonedeep "^4.5.0"
-    lodash.isequal "^4.5.0"
-    qs "^6.9.1"
-
 "@opentripplanner/types@6.0.0-alpha.4":
   version "6.0.0-alpha.4"
   resolved "https://registry.yarnpkg.com/@opentripplanner/types/-/types-6.0.0-alpha.4.tgz#dee3c06675e30c596159d182ed707e7710cd937c"


### PR DESCRIPTION
This PR adds missing OTP2 leg route attributes to the `Leg` type (see the graphql query template for details).

Should create a fix release for the types package, and no release to the itinerary-body package (that will be handled separately).
