### PR TITLE
Fix route names printitin

### DIFF
--- a/packages/core-utils/src/__tests__/itinerary.ts
+++ b/packages/core-utils/src/__tests__/itinerary.ts
@@ -4,6 +4,7 @@ import {
   getDisplayedStopId,
   getItineraryCost,
   getLegCost,
+  getLegRouteLongName,
   getLegRouteShortName,
   isTransit
 } from "../itinerary";
@@ -182,18 +183,34 @@ describe("util > itinerary", () => {
     });
   });
   describe("getLegRouteShortName", () => {
-    it("should extract a route number from an OTP1 leg", () => {
+    it("should extract a route short name from an OTP1 leg", () => {
       expect(getLegRouteShortName({ route: "15" })).toBe("15");
       expect(getLegRouteShortName({ route: "15", routeShortName: "31" })).toBe(
         "31"
       );
     });
 
-    it("should extract a route number from an OTP2 leg", () => {
+    it("should extract a route short name from an OTP2 leg", () => {
       expect(
         getLegRouteShortName({
           route: { id: "id15", shortName: "15" },
           routeShortName: "31"
+        })
+      ).toBe("15");
+    });
+  });
+  describe("getLegRouteLongName", () => {
+    it("should extract a route long name from an OTP1 leg", () => {
+      expect(getLegRouteLongName({ route: "15" })).toBeUndefined();
+      expect(
+        getLegRouteLongName({ route: "15", routeLongName: "Candler Road" })
+      ).toBe("Candler Road");
+    });
+    it("should extract a route long name from an OTP2 leg", () => {
+      expect(
+        getLegRouteLongName({
+          route: { id: "id15", longName: "15" },
+          routeLongName: "31"
         })
       ).toBe("15");
     });

--- a/packages/core-utils/src/__tests__/itinerary.ts
+++ b/packages/core-utils/src/__tests__/itinerary.ts
@@ -4,6 +4,7 @@ import {
   getDisplayedStopId,
   getItineraryCost,
   getLegCost,
+  getLegRouteNumber,
   isTransit
 } from "../itinerary";
 
@@ -178,6 +179,23 @@ describe("util > itinerary", () => {
         code: "USD",
         digits: 2
       });
+    });
+  });
+  describe("getLegRouteNumber", () => {
+    it("should extract a route number from an OTP1 leg", () => {
+      expect(getLegRouteNumber({ route: "15" })).toBe("15");
+      expect(getLegRouteNumber({ route: "15", routeShortName: "31" })).toBe(
+        "31"
+      );
+    });
+
+    it("should extract a route number from an OTP2 leg", () => {
+      expect(
+        getLegRouteNumber({
+          route: { id: "id15", shortName: "15" },
+          routeShortName: "31"
+        })
+      ).toBe("15");
     });
   });
 });

--- a/packages/core-utils/src/__tests__/itinerary.ts
+++ b/packages/core-utils/src/__tests__/itinerary.ts
@@ -4,7 +4,7 @@ import {
   getDisplayedStopId,
   getItineraryCost,
   getLegCost,
-  getLegRouteNumber,
+  getLegRouteShortName,
   isTransit
 } from "../itinerary";
 
@@ -181,17 +181,17 @@ describe("util > itinerary", () => {
       });
     });
   });
-  describe("getLegRouteNumber", () => {
+  describe("getLegRouteShortName", () => {
     it("should extract a route number from an OTP1 leg", () => {
-      expect(getLegRouteNumber({ route: "15" })).toBe("15");
-      expect(getLegRouteNumber({ route: "15", routeShortName: "31" })).toBe(
+      expect(getLegRouteShortName({ route: "15" })).toBe("15");
+      expect(getLegRouteShortName({ route: "15", routeShortName: "31" })).toBe(
         "31"
       );
     });
 
     it("should extract a route number from an OTP2 leg", () => {
       expect(
-        getLegRouteNumber({
+        getLegRouteShortName({
           route: { id: "id15", shortName: "15" },
           routeShortName: "31"
         })

--- a/packages/core-utils/src/__tests__/route.js
+++ b/packages/core-utils/src/__tests__/route.js
@@ -1,4 +1,5 @@
 import {
+  getLegRouteNumber,
   getMostReadableTextColor,
   getTransitOperatorFromLeg,
   getTransitOperatorFromOtpRoute,
@@ -197,6 +198,23 @@ describe("util > route", () => {
       expect(getMostReadableTextColor("#f00", "#f00")).toBe("#ffffff");
       expect(getMostReadableTextColor("#fff", "#fff")).toBe("#000000");
       expect(getMostReadableTextColor("#000", "#000")).toBe("#ffffff");
+    });
+  });
+  describe("getLegRouteNumber", () => {
+    it("should extract a route number from an OTP1 leg", () => {
+      expect(getLegRouteNumber({ route: "15" })).toBe("15");
+      expect(getLegRouteNumber({ route: "15", routeShortName: "31" })).toBe(
+        "31"
+      );
+    });
+
+    it("should extract a route number from an OTP2 leg", () => {
+      expect(
+        getLegRouteNumber({
+          route: { id: "id15", shortName: "15" },
+          routeShortName: "31"
+        })
+      ).toBe("15");
     });
   });
 });

--- a/packages/core-utils/src/__tests__/route.js
+++ b/packages/core-utils/src/__tests__/route.js
@@ -1,5 +1,4 @@
 import {
-  getLegRouteNumber,
   getMostReadableTextColor,
   getTransitOperatorFromLeg,
   getTransitOperatorFromOtpRoute,
@@ -198,23 +197,6 @@ describe("util > route", () => {
       expect(getMostReadableTextColor("#f00", "#f00")).toBe("#ffffff");
       expect(getMostReadableTextColor("#fff", "#fff")).toBe("#000000");
       expect(getMostReadableTextColor("#000", "#000")).toBe("#ffffff");
-    });
-  });
-  describe("getLegRouteNumber", () => {
-    it("should extract a route number from an OTP1 leg", () => {
-      expect(getLegRouteNumber({ route: "15" })).toBe("15");
-      expect(getLegRouteNumber({ route: "15", routeShortName: "31" })).toBe(
-        "31"
-      );
-    });
-
-    it("should extract a route number from an OTP2 leg", () => {
-      expect(
-        getLegRouteNumber({
-          route: { id: "id15", shortName: "15" },
-          routeShortName: "31"
-        })
-      ).toBe("15");
     });
   });
 });

--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -692,3 +692,11 @@ export const getLegRouteShortName = (
   }
   return route?.shortName;
 };
+
+/** Extract the route ling name for a leg returned from OTP1 or OTP2. */
+export const getLegRouteLongName = (
+  leg: Pick<Leg, "route" | "routeLongName">
+): string => {
+  const { route, routeLongName } = leg;
+  return typeof route === "string" ? routeLongName : route?.longName;
+};

--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -681,3 +681,14 @@ export const convertGraphQLResponseToLegacy = (leg: any): any => ({
   tripHeadsign: leg.trip?.tripHeadsign,
   tripId: leg.trip?.gtfsId
 });
+
+/** Extracts the route number for a leg returned from OTP1 or OTP2. */
+export const getLegRouteNumber = (
+  leg: Pick<Leg, "route" | "routeShortName">
+): string => {
+  const { route, routeShortName } = leg;
+  if (typeof route === "string") {
+    return typeof routeShortName === "string" ? routeShortName : route;
+  }
+  return route?.shortName;
+};

--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -683,7 +683,7 @@ export const convertGraphQLResponseToLegacy = (leg: any): any => ({
 });
 
 /** Extracts the route number for a leg returned from OTP1 or OTP2. */
-export const getLegRouteNumber = (
+export const getLegRouteShortName = (
   leg: Pick<Leg, "route" | "routeShortName">
 ): string => {
   const { route, routeShortName } = leg;

--- a/packages/core-utils/src/route.ts
+++ b/packages/core-utils/src/route.ts
@@ -471,14 +471,3 @@ export function getMostReadableTextColor(
   // When generating colors, white is preferred.
   return chroma(backgroundColor).luminance() < 0.4 ? "#ffffff" : "#000000";
 }
-
-/** Extracts the route number for a leg returned from OTP1 or OTP2. */
-export const getLegRouteNumber = (
-  leg: Pick<Leg, "route" | "routeShortName">
-): string => {
-  const { route, routeShortName } = leg;
-  if (typeof route === "string") {
-    return typeof routeShortName === "string" ? routeShortName : route;
-  }
-  return route?.shortName;
-};

--- a/packages/core-utils/src/route.ts
+++ b/packages/core-utils/src/route.ts
@@ -471,3 +471,14 @@ export function getMostReadableTextColor(
   // When generating colors, white is preferred.
   return chroma(backgroundColor).luminance() < 0.4 ? "#ffffff" : "#000000";
 }
+
+/** Extracts the route number for a leg returned from OTP1 or OTP2. */
+export const getLegRouteNumber = (
+  leg: Pick<Leg, "route" | "routeShortName">
+): string => {
+  const { route, routeShortName } = leg;
+  if (typeof route === "string") {
+    return typeof routeShortName === "string" ? routeShortName : route;
+  }
+  return route?.shortName;
+};

--- a/packages/icons/src/trimet-leg-icon.js
+++ b/packages/icons/src/trimet-leg-icon.js
@@ -1,12 +1,14 @@
 import React from "react";
 
+import { getLegRouteLongName } from "@opentripplanner/core-utils/lib/itinerary";
 import LegIcon from "./leg-icon";
 import TriMetModeIcon from "./trimet-mode-icon";
 import BiketownIcon from "./companies/biketown-icon";
 
 const TriMetLegIcon = ({ leg, ...props }) => {
   // Custom TriMet icon logic.
-  if (leg.routeLongName && leg.routeLongName.startsWith("Portland Streetcar")) {
+  const routeLongName = getLegRouteLongName(leg);
+  if (routeLongName && routeLongName.startsWith("Portland Streetcar")) {
     return <TriMetModeIcon mode="STREETCAR" {...props} />;
   }
   if (leg.rentedBike) {

--- a/packages/itinerary-body/src/defaults/line-column-content.tsx
+++ b/packages/itinerary-body/src/defaults/line-column-content.tsx
@@ -1,3 +1,7 @@
+import {
+  getLegRouteLongName,
+  getLegRouteShortName
+} from "@opentripplanner/core-utils/lib/itinerary";
 import LocationIcon from "@opentripplanner/location-icon";
 import React, { ReactElement } from "react";
 import { IntlShape, useIntl } from "react-intl";
@@ -52,7 +56,7 @@ export default function LineColumnContent({
   LegIcon,
   toRouteAbbreviation
 }: LineColumnContentProps): ReactElement {
-  const { mode, route, routeColor, routeLongName, transitLeg } = leg;
+  const { mode, routeColor, transitLeg } = leg;
   const intl = useIntl();
   const travelByMessage = intl.formatMessage(
     {
@@ -65,7 +69,7 @@ export default function LineColumnContent({
     }
   );
 
-  const routeNumber = typeof route === "string" ? route : route?.shortName;
+  const routeNumber = getLegRouteShortName(leg);
 
   return (
     <S.LegLine>
@@ -78,7 +82,7 @@ export default function LineColumnContent({
               parseInt(routeNumber, 10) || routeNumber
             )}
             color={routeColor}
-            name={routeLongName || ""}
+            name={getLegRouteLongName(leg) || ""}
           />
         )}
         {!interline && !isDestination && !transitLeg && (

--- a/packages/itinerary-body/src/defaults/line-column-content.tsx
+++ b/packages/itinerary-body/src/defaults/line-column-content.tsx
@@ -65,6 +65,8 @@ export default function LineColumnContent({
     }
   );
 
+  const routeNumber = typeof route === "string" ? route : route?.shortName;
+
   return (
     <S.LegLine>
       {!isDestination && <S.InnerLine mode={mode} routeColor={routeColor} />}
@@ -72,7 +74,9 @@ export default function LineColumnContent({
         {/* TODO: This is a placeholder for a routebadge when we create the transit leg */}
         {!interline && !isDestination && transitLeg && (
           <RouteBadge
-            abbreviation={toRouteAbbreviation(parseInt(route, 10) || route)}
+            abbreviation={toRouteAbbreviation(
+              parseInt(routeNumber, 10) || routeNumber
+            )}
             color={routeColor}
             name={routeLongName || ""}
           />

--- a/packages/itinerary-body/src/defaults/route-description.tsx
+++ b/packages/itinerary-body/src/defaults/route-description.tsx
@@ -1,3 +1,4 @@
+import { getLegRouteShortName } from "@opentripplanner/core-utils/lib/itinerary";
 import React, { ReactElement } from "react";
 
 import * as S from "../styled";
@@ -8,7 +9,7 @@ import RouteLongName from "./route-long-name";
 export default function RouteDescription({
   leg
 }: RouteDescriptionProps): ReactElement {
-  const { routeShortName } = leg;
+  const routeShortName = getLegRouteShortName(leg);
   return (
     <S.LegDescriptionForTransit>
       {routeShortName && (

--- a/packages/itinerary-body/src/defaults/route-long-name.tsx
+++ b/packages/itinerary-body/src/defaults/route-long-name.tsx
@@ -1,3 +1,4 @@
+import { getLegRouteLongName } from "@opentripplanner/core-utils/lib/itinerary";
 import { Leg } from "@opentripplanner/types";
 import React, { HTMLAttributes, ReactElement } from "react";
 import { FormattedMessage } from "react-intl";
@@ -24,7 +25,9 @@ export default function RouteLongName({
   leg,
   style
 }: Props): ReactElement {
-  const { headsign, routeLongName } = leg;
+  const { headsign: otp1Headsign, trip } = leg;
+  const headsign = trip?.tripHeadsign || otp1Headsign;
+  const routeLongName = getLegRouteLongName(leg);
   // Hide route long name if it contains similar information to the headsign
   const hideRouteLongName =
     compareTwoStrings(headsign || "", routeLongName || "") > 0.25 ||

--- a/packages/itinerary-body/src/otp-react-redux/route-description.tsx
+++ b/packages/itinerary-body/src/otp-react-redux/route-description.tsx
@@ -1,3 +1,4 @@
+import { getLegRouteShortName } from "@opentripplanner/core-utils/lib/itinerary";
 import React, { ReactElement } from "react";
 
 import RouteLongName from "../defaults/route-long-name";
@@ -8,7 +9,7 @@ export default function RouteDescription({
   leg,
   LegIcon
 }: RouteDescriptionProps): ReactElement {
-  const { routeShortName } = leg;
+  const routeShortName = getLegRouteShortName(leg);
   return (
     <S.LegDescriptionForTransit>
       <S.LegIconAndRouteShortName>

--- a/packages/printable-itinerary/src/transit-leg.tsx
+++ b/packages/printable-itinerary/src/transit-leg.tsx
@@ -1,4 +1,7 @@
-import coreUtils from "@opentripplanner/core-utils";
+import {
+  getDisplayedStopId,
+  getLegRouteShortName
+} from "@opentripplanner/core-utils/lib/itinerary";
 import { Defaults } from "@opentripplanner/itinerary-body";
 import { GradationMap, Leg, LegIconComponent } from "@opentripplanner/types";
 import React, { ReactElement } from "react";
@@ -7,8 +10,6 @@ import { FormattedMessage } from "react-intl";
 import AccessibilityAnnotation from "./accessibility-annotation";
 import * as S from "./styled";
 import { defaultMessages, strongText } from "./util";
-
-const { getDisplayedStopId } = coreUtils.itinerary;
 
 interface Props {
   accessibilityScoreGradationMap?: GradationMap;
@@ -28,7 +29,7 @@ export default function TransitLeg({
 
   const routeDescription = (
     <>
-      <strong>{leg.routeShortName}</strong> <S.RouteLongName leg={leg} />
+      <strong>{getLegRouteShortName(leg)}</strong> <S.RouteLongName leg={leg} />
     </>
   );
 

--- a/packages/transitive-overlay/src/util.ts
+++ b/packages/transitive-overlay/src/util.ts
@@ -8,6 +8,16 @@ import bearing from "@turf/bearing";
 import distance from "@turf/distance";
 
 import {
+  getLegBounds,
+  getLegRouteLongName,
+  getLegRouteShortName,
+  isAccessMode,
+  isFlex,
+  isRideshareLeg,
+  isTransit
+} from "@opentripplanner/core-utils/lib/itinerary";
+import { getPlaceName } from "@opentripplanner/itinerary-body";
+import {
   Company,
   Itinerary,
   Leg,
@@ -16,17 +26,7 @@ import {
   TransitivePlace,
   TransitiveStop
 } from "@opentripplanner/types";
-import coreUtils from "@opentripplanner/core-utils";
-import { getPlaceName } from "@opentripplanner/itinerary-body";
 import { IntlShape } from "react-intl";
-
-const {
-  getLegBounds,
-  isAccessMode,
-  isFlex,
-  isRideshareLeg,
-  isTransit
-} = coreUtils.itinerary;
 
 const CAR_PARK_ITIN_PREFIX = "itin_car_";
 
@@ -385,12 +385,12 @@ export function itineraryToTransitive(
       const routeLabel =
         typeof getRouteLabel === "function"
           ? getRouteLabel(leg)
-          : leg.routeShortName;
+          : getLegRouteShortName(leg);
       routes[leg.routeId] = {
         agency_id: leg.agencyId,
         route_id: leg.routeId,
         route_short_name: routeLabel || "",
-        route_long_name: leg.routeLongName || "",
+        route_long_name: getLegRouteLongName(leg) || "",
         route_type: leg.routeType,
         route_color: leg.routeColor,
         route_text_color: leg.routeTextColor

--- a/packages/trip-details/src/fare-table.tsx
+++ b/packages/trip-details/src/fare-table.tsx
@@ -5,7 +5,9 @@ import { Transfer } from "@styled-icons/boxicons-regular/Transfer";
 
 import {
   getItineraryCost,
-  getLegCost
+  getLegCost,
+  getLegRouteLongName,
+  getLegRouteShortName
 } from "@opentripplanner/core-utils/lib/itinerary";
 import { useIntl } from "react-intl";
 import { flatten } from "flat";
@@ -120,7 +122,7 @@ const FareTypeTable = ({
         {filteredLegs.map((leg, index) => (
           <tr key={index}>
             <td className="no-zebra">
-              {leg.routeShortName || leg.routeLongName}
+              {getLegRouteShortName(leg) || getLegRouteLongName(leg)}
             </td>
             {colsToRender.map(col => {
               const fare = getLegCost(leg, col.mediumId, col.riderCategoryId);

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -202,6 +202,8 @@ export type Alert = {
   alertDescriptionText?: string;
   alertUrl?: string;
   effectiveStartDate?: number;
+  /** Returned by OTP2 graphql queries, but not by OTP1 */
+  id?: string;
 };
 
 /**
@@ -269,6 +271,22 @@ type FlexPickupBookingInfo = {
   pickupMessage?: string;
 } & FlexBookingInfo;
 
+/** Basic transit route attributes */
+interface BasicRouteInfo {
+  color?: string;
+  id: string;
+  longName?: string;
+  shortName: string;
+  textColor?: string;
+  // TS TODO: route type enum
+  type?: number;
+}
+
+/** Transit route attributes from itinerary legs */
+export type LegRoute = BasicRouteInfo & {
+  alerts?: Alert[];
+};
+
 /**
  * Represents a leg in an itinerary of an OTP plan response. Each leg represents
  * a portion of the overall itinerary that is done until either reaching the
@@ -316,7 +334,7 @@ export type Leg = {
   rentedBike: boolean;
   rentedCar: boolean;
   rentedVehicle: boolean;
-  route?: string;
+  route?: string | LegRoute;
   routeColor?: string;
   routeId?: string;
   routeLongName?: string;
@@ -470,22 +488,15 @@ export type Agency = {
   phone?: string;
   fareUrl?: string;
 };
-export type Route = {
+export type Route = BasicRouteInfo & {
   agency: Agency;
   agencyId?: string | number;
   agencyName?: string | number;
-  shortName: string;
-  longName?: string;
-  mode?: string;
-  id: string;
-  // TS TODO: route type enum
-  type?: number;
-  color?: string;
-  textColor?: string;
-  routeBikesAllowed?: ZeroOrOne;
   bikesAllowed?: ZeroOrOne;
-  sortOrder: number;
   eligibilityRestricted?: ZeroOrOne;
+  mode?: string;
+  routeBikesAllowed?: ZeroOrOne;
+  sortOrder: number;
   sortOrderSet: boolean;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3241,25 +3241,6 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
-"@opentripplanner/core-utils@^9.0.3":
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-9.0.3.tgz#c1ebdcc3ad5999fb28427102c9be7d7268f6bd37"
-  integrity sha512-8P3Bi41jF7z18P/soo6lEw+nrqarsyGMAxivsF1/kMJdRo4wnakp0zcrVZjDXTxoR6LPtj6Kkuxv3JQFO9jKiw==
-  dependencies:
-    "@conveyal/lonlat" "^1.4.1"
-    "@mapbox/polyline" "^1.1.0"
-    "@opentripplanner/geocoder" "^1.4.1"
-    "@styled-icons/foundation" "^10.34.0"
-    "@turf/along" "^6.0.1"
-    bowser "^2.7.0"
-    chroma-js "^2.4.2"
-    date-fns "^2.28.0"
-    date-fns-tz "^1.2.2"
-    graphql "^16.6.0"
-    lodash.clonedeep "^4.5.0"
-    lodash.isequal "^4.5.0"
-    qs "^6.9.1"
-
 "@opentripplanner/types@6.0.0-alpha.4":
   version "6.0.0-alpha.4"
   resolved "https://registry.yarnpkg.com/@opentripplanner/types/-/types-6.0.0-alpha.4.tgz#dee3c06675e30c596159d182ed707e7710cd937c"


### PR DESCRIPTION
Requires #635.
This PR fixes the rendering of route long names on the printable-itinerary package.
