### PR TITLE
Fix transit leg spacing

### DIFF
--- a/packages/itinerary-body/src/AccessLegBody/mapillary-button.tsx
+++ b/packages/itinerary-body/src/AccessLegBody/mapillary-button.tsx
@@ -38,8 +38,9 @@ const Container = styled.a`
   }
 
   &::before {
-    content: "| ";
+    content: "|";
     cursor: auto;
+    margin: 0 0.25em;
   }
 `;
 

--- a/packages/itinerary-body/src/styled.tsx
+++ b/packages/itinerary-body/src/styled.tsx
@@ -286,7 +286,7 @@ export const LegDescription = styled.span`
 
 // additional description added to ClickableLeg for screenreaders
 export const InvisibleAdditionalDetails = styled.span`
-  display: block;
+  display: inline-block;
   grid-row-start: 2;
   grid-column-start: 1;
   height: 0;
@@ -468,6 +468,9 @@ export const PlaceSubheader = styled.div`
   padding-top: 1px;
 
   /* Reduce vertical space and fix horizontal alignment of stop id and stop viewer link for transit stops. */
+  /* Also, increase vertical space after so that transit/access instructions
+     aren't too squeezed with the stop id and Stop Viewer link. */
+  margin-bottom: 10px;
   margin-top: -14px;
 `;
 

--- a/packages/itinerary-body/src/styled.tsx
+++ b/packages/itinerary-body/src/styled.tsx
@@ -576,7 +576,7 @@ export const StepsHeader = styled(TransparentButton)`
   color: #676767;
   font-size: 13px;
   font-style: normal;
-  width: 100%;
+  padding: 0;
 `;
 
 export const StepIconContainer = styled.div`


### PR DESCRIPTION
This PR polishes the spacing for items that follow a transit stop location header (see screenshot. Left: before; right: after).

<img width="384" alt="image" src="https://github.com/opentripplanner/otp-ui/assets/56846598/3565176a-a837-4863-93ff-8315fd4852e1">
