### PR TITLE
Itinerary Body Support OTP2 Place Names

### DIFF
--- a/packages/itinerary-body/src/util.ts
+++ b/packages/itinerary-body/src/util.ts
@@ -152,7 +152,10 @@ export function getPlaceName(
   // Other times, it can be a name with relevant information for the user.
   // Here we detect if the name is just a UUID and generate a better name.
   // It is also possible to configure station name overrides in the config using overridePlaceNames.
-  const company = getCompanyForNetwork(place.networks?.[0], companies);
+  const company = getCompanyForNetwork(
+    place.networks?.[0] || place?.rentalVehicle?.network,
+    companies
+  );
   if (
     (place.name.match(/-/g) || []).length > 3 ||
     company?.overridePlaceNames


### PR DESCRIPTION
I think this is a regression... This method was only reading OTP1 type place names. This PR adds OTP2 support. A future PR will be needed to get this fix into the map components. 

This fixes rental bikes showing up as "Default vehicle type" and instead uses the company name.