### PR TITLE
fix(core-utils): Set agencyId when converting graphql resp to legacy.

### DIFF
--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -655,6 +655,7 @@ const pickupDropoffTypeToOtp1 = otp2Type => {
 export const convertGraphQLResponseToLegacy = (leg: any): any => ({
   ...leg,
   agencyBrandingUrl: leg.agency?.url,
+  agencyId: leg.agency?.id,
   agencyName: leg.agency?.name,
   agencyUrl: leg.agency?.url,
   alightRule: pickupDropoffTypeToOtp1(leg.dropoffType),


### PR DESCRIPTION
This PR populates the `agencyId` of an itinerary from graphql responses, for use in determining agency logos in itinerary-body.