### PR TITLE
Allow false value in mode setting

### DIFF
--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -31,7 +31,7 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "@opentripplanner/types": "^6.0.0-alpha.9",
+    "@opentripplanner/types": "^7.0.0-alpha.9",
     "@types/chroma-js": "^2.1.4"
   }
 }

--- a/packages/core-utils/src/query-gen.ts
+++ b/packages/core-utils/src/query-gen.ts
@@ -231,7 +231,8 @@ export function generateOtp2Query(
 
     // If we assign a value on true, return the value (or null) instead of a boolean.
     if (cur.type === "CHECKBOX" && cur.truthValue) {
-      prev[cur.key] = cur.value === true ? cur.truthValue : null;
+      prev[cur.key] =
+        cur.value === true ? cur.truthValue : cur.falseValue ?? null;
     }
     return prev;
   }, {}) as ModeSettingValues;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -712,6 +712,7 @@ export type CheckboxOptions = {
   label: string;
   type: "CHECKBOX";
   truthValue?: boolean | string | number;
+  falseValue?: boolean | string | number;
   value?: boolean;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3284,6 +3284,11 @@
   resolved "https://registry.yarnpkg.com/@opentripplanner/types/-/types-7.0.0-alpha.2.tgz#d10c69f99b2da6d1e80ab5989520bde8e558627b"
   integrity sha512-IzQwBcxkoyM+r/W7u+nzICf/6QnreLKppkrZZNl0yVxFiT6RBOd0U2UxMxLPYuRd/3awQabI3/qQ3/6ZxMWPfA==
 
+"@opentripplanner/types@^7.0.0-alpha.9":
+  version "7.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/types/-/types-7.0.0-alpha.9.tgz#175ede990d9b08815779a65d4e2bd24c97e3c33d"
+  integrity sha512-joGI+ae2qwdSdypOyjg1lmYF6BVKquGHbjBGA7uzO1vosMnFR3pPNCWmOC4pHW6w8PI5w5Z7wmVFDbdsQamDEA==
+
 "@peculiar/asn1-schema@^2.1.6", "@peculiar/asn1-schema@^2.3.0":
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.3.3.tgz#21418e1f3819e0b353ceff0c2dad8ccb61acd777"


### PR DESCRIPTION
This PR allows a `falseValue` to be set in a checkbox mode setting, which will allow us to override the OTP default value for unchecked options. 