### PR TITLE
fix(printable-itinerary): Use latest itinerary-body, fix route name render

### DIFF
--- a/packages/printable-itinerary/package.json
+++ b/packages/printable-itinerary/package.json
@@ -11,7 +11,7 @@
   "private": false,
   "dependencies": {
     "@opentripplanner/core-utils": "^11.0.2",
-    "@opentripplanner/itinerary-body": "^5.0.5"
+    "@opentripplanner/itinerary-body": "^5.0.7"
   },
   "devDependencies": {
     "@opentripplanner/icons": "^2.0.4"

--- a/packages/printable-itinerary/src/PrintableItinerary.story.tsx
+++ b/packages/printable-itinerary/src/PrintableItinerary.story.tsx
@@ -1,3 +1,4 @@
+import { convertGraphQLResponseToLegacy } from "@opentripplanner/core-utils/lib/itinerary";
 import { ClassicLegIcon, TriMetLegIcon } from "@opentripplanner/icons";
 import React from "react";
 import styled from "styled-components";
@@ -27,6 +28,13 @@ const StyledPrintableItinerary = styled(PrintableItinerary)`
     background-color: pink;
   }
 `;
+
+function withLegacyLegs(itinerary) {
+  return {
+    ...itinerary,
+    legs: itinerary.legs.map(convertGraphQLResponseToLegacy)
+  };
+}
 
 export default {
   title: "PrintableItinerary",
@@ -140,7 +148,7 @@ export const EScooterRentalTransitItinerary = () => (
 export const TncTransitItinerary = () => (
   <PrintableItinerary
     config={config}
-    itinerary={tncTransitTncItinerary}
+    itinerary={withLegacyLegs(tncTransitTncItinerary)}
     LegIcon={TriMetLegIcon}
   />
 );

--- a/packages/printable-itinerary/src/transit-leg.tsx
+++ b/packages/printable-itinerary/src/transit-leg.tsx
@@ -1,4 +1,7 @@
-import coreUtils from "@opentripplanner/core-utils";
+import {
+  getDisplayedStopId,
+  getLegRouteShortName
+} from "@opentripplanner/core-utils/lib/itinerary";
 import { Defaults } from "@opentripplanner/itinerary-body";
 import { GradationMap, Leg, LegIconComponent } from "@opentripplanner/types";
 import React, { ReactElement } from "react";
@@ -7,8 +10,6 @@ import { FormattedMessage } from "react-intl";
 import AccessibilityAnnotation from "./accessibility-annotation";
 import * as S from "./styled";
 import { defaultMessages, strongText } from "./util";
-
-const { getDisplayedStopId } = coreUtils.itinerary;
 
 interface Props {
   accessibilityScoreGradationMap?: GradationMap;
@@ -28,7 +29,7 @@ export default function TransitLeg({
 
   const routeDescription = (
     <>
-      <strong>{leg.routeShortName}</strong> <S.RouteLongName leg={leg} />
+      <strong>{getLegRouteShortName(leg)}</strong> <S.RouteLongName leg={leg} />
     </>
   );
 


### PR DESCRIPTION
This PR makes the printable itinerary print correct route numbers and headsigns with OTP2 responses.