### PR TITLE
Typeahead Results on Voiceover

### DIFF
--- a/packages/location-field/i18n/en-US.yml
+++ b/packages/location-field/i18n/en-US.yml
@@ -8,7 +8,7 @@ otpUi:
     geocoderUnreachable: Unable to obtain suggestions
     homeLocation: Home
     howToAccessResults: >-
-      Use the down arrow key browse the results list. To select a result, use
+      Use the down arrow key to browse the results list. To select a result, use
       the Enter key.
     myPlaces: My Places
     nearby: Nearby Stops

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -874,7 +874,6 @@ const LocationField = ({
     currentPosition && currentPosition.fetching
       ? intl.formatMessage({ id: "otpUi.LocationField.fetchingLocation" })
       : defaultPlaceholder;
-  const hasNoEnabledOptions = menuItemCount === 0;
   const isExpanded = isStatic || menuVisible;
 
   const textControl = (
@@ -951,7 +950,6 @@ const LocationField = ({
       </S.HiddenContent>
       <ItemList
         // Hide the list from screen readers if no enabled options are shown.
-        aria-hidden={hasNoEnabledOptions}
         aria-label={intl.formatMessage({
           defaultMessage: "Suggested locations",
           description:

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -874,6 +874,7 @@ const LocationField = ({
     currentPosition && currentPosition.fetching
       ? intl.formatMessage({ id: "otpUi.LocationField.fetchingLocation" })
       : defaultPlaceholder;
+  const hasNoEnabledOptions = menuItemCount === 0;
   const isExpanded = isStatic || menuVisible;
 
   const textControl = (
@@ -950,6 +951,7 @@ const LocationField = ({
       </S.HiddenContent>
       <ItemList
         // Hide the list from screen readers if no enabled options are shown.
+        aria-hidden={hasNoEnabledOptions}
         aria-label={intl.formatMessage({
           defaultMessage: "Suggested locations",
           description:

--- a/packages/location-field/src/options.tsx
+++ b/packages/location-field/src/options.tsx
@@ -53,17 +53,14 @@ export const MenuItem = ({
   <S.MenuItemLi
     // Hide disabled choices from screen readers (a relevant status is already provided).
     aria-hidden={disabled || undefined}
-    role={disabled ? undefined : "none"}
+    active={active}
+    id={id}
+    onClick={disabled ? null : onClick}
+    role="option"
+    aria-selected={active}
+    tabIndex={-1}
   >
-    <S.MenuItemA
-      active={active}
-      id={id}
-      onClick={disabled ? null : onClick}
-      role="option"
-      tabIndex={-1}
-    >
-      {children}
-    </S.MenuItemA>
+    {children}
   </S.MenuItemLi>
 );
 

--- a/packages/location-field/src/options.tsx
+++ b/packages/location-field/src/options.tsx
@@ -53,6 +53,9 @@ export const MenuItem = ({
   <S.MenuItemLi
     // Hide disabled choices from screen readers (a relevant status is already provided).
     aria-hidden={disabled || undefined}
+    /* A known issue prevents combobox results to be read out on Voiceover. This is a hack to ensure 
+    AT hear all options - see https://react-spectrum.adobe.com/blog/building-a-combobox.html#voiceover */
+    aria-live={active ? "assertive" : "off"}
     active={active}
     id={id}
     onClick={disabled ? null : onClick}

--- a/packages/location-field/src/styled.ts
+++ b/packages/location-field/src/styled.ts
@@ -74,18 +74,6 @@ export const InputGroup = styled.div`
   position: relative;
 `;
 
-export const MenuItemA = styled.a<{ active?: boolean }>`
-  background-color: ${props => (props.active ? "#337ab7" : "transparent")};
-  clear: both;
-  color: ${props => (props.active ? "#fff" : "#333")};
-  display: block;
-  font-weight: 400;
-  line-height: 1.42857143;
-  padding: 3px 20px;
-  text-decoration: none;
-  white-space: nowrap;
-`;
-
 export const MenuGroupHeader = styled.h2<{
   bgColor?: string;
   fgColor?: string;
@@ -101,7 +89,7 @@ export const MenuGroupHeader = styled.h2<{
   white-space: nowrap;
 `;
 
-export const MenuItemLi = styled.li`
+export const MenuItemLi = styled.li<{ active?: boolean }>`
   &:hover {
     /* TODO: adjust highlight color based on props.color? */
     background-color: #f5f5f5;
@@ -114,6 +102,28 @@ export const MenuItemLi = styled.li`
     background-color: unset;
     cursor: default;
   }
+
+  background-color: ${props => (props.active ? "#337ab7" : "transparent")};
+  clear: both;
+  color: ${props => (props.active ? "#fff" : "#333")};
+  display: block;
+  font-weight: 400;
+  line-height: 1.42857143;
+  padding: 3px 20px;
+  text-decoration: none;
+  white-space: nowrap;
+`;
+
+export const MenuItemA = styled.span<{ active?: boolean }>`
+  background-color: ${props => (props.active ? "#337ab7" : "transparent")};
+  clear: both;
+  color: ${props => (props.active ? "#fff" : "#333")};
+  display: block;
+  font-weight: 400;
+  line-height: 1.42857143;
+  padding: 3px 20px;
+  text-decoration: none;
+  white-space: nowrap;
 `;
 
 export const OptionContainer = styled.span`

--- a/packages/location-field/src/styled.ts
+++ b/packages/location-field/src/styled.ts
@@ -114,18 +114,6 @@ export const MenuItemLi = styled.li<{ active?: boolean }>`
   white-space: nowrap;
 `;
 
-export const MenuItemA = styled.span<{ active?: boolean }>`
-  background-color: ${props => (props.active ? "#337ab7" : "transparent")};
-  clear: both;
-  color: ${props => (props.active ? "#fff" : "#333")};
-  display: block;
-  font-weight: 400;
-  line-height: 1.42857143;
-  padding: 3px 20px;
-  text-decoration: none;
-  white-space: nowrap;
-`;
-
 export const OptionContainer = styled.span`
   display: block;
   padding-top: 5px;


### PR DESCRIPTION
Adjust markup for location field so that typeahead results from geocoder are read to AT (specifically voiceover)

Note for testing that Voiceover is only officially supported on safari!!