### PR TITLE
Align fare table content

### DIFF
--- a/packages/trip-details/src/fare-table.tsx
+++ b/packages/trip-details/src/fare-table.tsx
@@ -50,7 +50,7 @@ const Table = styled.table`
   padding: 0;
 
   td {
-    text-align: right;
+    text-align: center;
   }
   td:nth-of-type(2n + 1) {
     background: #cccccc22;


### PR DESCRIPTION
A quick change to the alignment of the contents inside the table to allow for equal spacing between prices and the edge of the table cells. 

To test: 
- Storybook --> TripDetails --> Leg Fare Products Itinerary
- View on any configuration in otp-rr

Before
![image](https://github.com/opentripplanner/otp-ui/assets/62163307/e49218e5-c365-4458-b3cc-8445486a4345)
After
![image](https://github.com/opentripplanner/otp-ui/assets/62163307/ce35ab63-7376-4f4d-b59c-087f5a493adf)
