### PR TITLE
fix(core-utils): replace route id with gtfs id

### DIFF
--- a/packages/core-utils/src/planQuery.graphql
+++ b/packages/core-utils/src/planQuery.graphql
@@ -157,7 +157,7 @@ query Plan(
             id
           }
           color
-          id
+          id: gtfsId
           longName
           shortName
           textColor


### PR DESCRIPTION
Replaces the randomly generated route ID with `gtfsId`, in order to apply things like `routeModeOverrides` to itineraries.

I could not think of a reason the randomly generated id shouldn't be replaced, and itineraries look fine in testing but please let me know if the id should be kept and a new `gtfsId` field should be added.