### PR TITLE
fix(mode-selector): Fix vert alignment of transit modes

### DIFF
--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -293,7 +293,7 @@ export function legElevationAtDistance(
     const elevDistanceSpan = points[i][0] - start[0];
     if (distance >= traversed && distance <= traversed + elevDistanceSpan) {
       // Distance falls within this point and the previous one;
-      // compute & return iterpolated elevation value
+      // compute & return interpolated elevation value
       if (start[1] === null) {
         console.warn(
           "Elevation value does not exist for distance.",
@@ -369,7 +369,7 @@ export function getElevationProfile(
  * @see https://stackoverflow.com/questions/118241/calculate-text-width-with-javascript/21015393#21015393
  */
 export function getTextWidth(text: string, font = "22px Arial"): number {
-  // Create custom type for function including re-used canvas object
+  // Create custom type for function including reused canvas object
   type GetTextWidth = typeof getTextWidth & { canvas: HTMLCanvasElement };
 
   // re-use canvas object for better performance

--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -372,7 +372,7 @@ export function getTextWidth(text: string, font = "22px Arial"): number {
   // Create custom type for function including reused canvas object
   type GetTextWidth = typeof getTextWidth & { canvas: HTMLCanvasElement };
 
-  // re-use canvas object for better performance
+  // reuse canvas object for better performance
   const canvas =
     (getTextWidth as GetTextWidth).canvas ||
     ((getTextWidth as GetTextWidth).canvas = document.createElement("canvas"));

--- a/packages/core-utils/src/query.js
+++ b/packages/core-utils/src/query.js
@@ -171,7 +171,7 @@ export function expandOtpFlexMode(mode) {
   const modes = reduceOtpFlexModes(mode.split(","));
   return modes
     .map(m => {
-      // If both the expanded and shrunk modes are included, remove the exapnded one
+      // If both the expanded and shrunk modes are included, remove the expanded one
       if (m === "FLEX_EGRESS" || m === "FLEX_ACCESS" || m === "FLEX_DIRECT") {
         if (mode.includes("FLEX")) return "";
       }

--- a/packages/trip-form/src/MetroModeSelector/MetroModeSelector.story.tsx
+++ b/packages/trip-form/src/MetroModeSelector/MetroModeSelector.story.tsx
@@ -80,7 +80,7 @@ const modeSettingDefinitionsWithDropdown = [
     default: true,
     key: "tram",
     iconName: "tram",
-    label: "Tram but long",
+    label: "Tram",
     addTransportMode: {
       mode: "TRAM"
     },

--- a/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
+++ b/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
@@ -21,8 +21,8 @@ export const defaultMessages: Record<string, string> = flatten(
 const SubmodeGrid = styled.div`
   align-items: center;
   display: grid;
-  grid-template-columns: 1fr 1fr;
   grid-column: span 2;
+  grid-template-columns: 1fr 1fr;
   width: 100%;
 `;
 

--- a/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
+++ b/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
@@ -85,7 +85,7 @@ const ModeSettingRenderer = ({
   const labelWithIcon =
     "icon" in setting ? (
       <FormLabelIconWrapper>
-        <div role="none">{setting.icon}</div>
+        {setting.icon && <div role="none">{setting.icon}</div>}
         <div>{label}</div>
       </FormLabelIconWrapper>
     ) : (

--- a/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
+++ b/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
@@ -19,10 +19,11 @@ export const defaultMessages: Record<string, string> = flatten(
 );
 
 const SubmodeGrid = styled.div`
+  align-items: center;
   display: grid;
   grid-template-columns: 1fr 1fr;
-  width: 100%;
   grid-column: span 2;
+  width: 100%;
 `;
 
 const SettingsPanel = styled.fieldset`
@@ -52,9 +53,6 @@ export const SubSettingsCheckbox = styled(CheckboxSelector)<{
 }>`
   display: ${props => (props.flexbox ? "flex" : "inherit")};
   margin-left: 4px;
-  input {
-    vertical-align: middle;
-  }
 `;
 
 const FormLabelIconWrapper = styled.span`

--- a/packages/trip-form/src/MetroModeSelector/index.tsx
+++ b/packages/trip-form/src/MetroModeSelector/index.tsx
@@ -104,13 +104,12 @@ const ModeButtonWrapper = styled.span<{
     bottom: 0;
     left: 4px;
     position: absolute;
-    right: 4px;
   }
 
   & > button:focus {
     clip: initial;
     height: initial;
-    width: initial;
+    width: calc(100% - 8px);
   }
 
   & > input:checked + label {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6564,11 +6564,6 @@ bottleneck@^2.18.1:
   resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
   integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
 
-bowser@^2.7.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
-  integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
-
 boxen@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-5.1.2.tgz#788cb686fc83c1f486dfa8a40c68fc2b831d2b50"


### PR DESCRIPTION
This PR fixes vertical alignment of transit mode icons and text when a mode name that spans over two lines is next to a mode with a 1-line name.
This PR also fixes the expand button size for keyboard access.

| Before | After |
|---|---|
| ![before screenshot](https://github.com/opentripplanner/otp-ui/assets/56846598/cd059528-d3f4-4ef8-ab57-70ded951dd14) | ![after screenshot](https://github.com/opentripplanner/otp-ui/assets/56846598/b945519f-14c4-4c94-bc4c-6ad596a4b928) |