### PR TITLE
feat(core-utils): Add gtfsId to GraphQL query

### DIFF
--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -670,7 +670,7 @@ export const convertGraphQLResponseToLegacy = (leg: any): any => ({
   },
   route: leg.route?.shortName,
   routeColor: leg.route?.color,
-  routeId: leg.route?.id,
+  routeId: leg.route?.gtfsId,
   routeLongName: leg.route?.longName,
   routeShortName: leg.route?.shortName,
   routeTextColor: leg.route?.textColor,

--- a/packages/core-utils/src/planQuery.graphql
+++ b/packages/core-utils/src/planQuery.graphql
@@ -157,6 +157,7 @@ query Plan(
             id
           }
           color
+          gtfsId
           id
           longName
           shortName


### PR DESCRIPTION
Adds the `gtfsId` to the graphQL route object, and replaces the route id in `convertGraphQLResponseToLegacy`