### PR TITLE
Get real agency id in graphql plan request

### DIFF
--- a/packages/core-utils/src/planQuery.graphql
+++ b/packages/core-utils/src/planQuery.graphql
@@ -48,7 +48,7 @@ query Plan(
             effectiveStartDate
             id
           }
-          id
+          gtfsId: id
           name
           timezone
           url

--- a/packages/core-utils/src/planQuery.graphql
+++ b/packages/core-utils/src/planQuery.graphql
@@ -157,7 +157,7 @@ query Plan(
             id
           }
           color
-          id
+          gtfsId: id
           longName
           shortName
           textColor


### PR DESCRIPTION
The agency id we get at the moment is generated. This PR uses the real one instead