### PR TITLE
fix(ItineraryBody): fix crash on no latestBookingTime

### DIFF
--- a/packages/itinerary-body/src/TransitLegBody/index.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/index.tsx
@@ -69,7 +69,7 @@ function getFlexMessageValues(info: FlexBookingInfo) {
   // if the leadTime check is ever to be more than just checking the value of
   // daysPrior (which can be done within react-intl)
   const hasPhone = !!info?.contactInfo?.phoneNumber;
-  const leadDays = info.latestBookingTime.daysPrior;
+  const leadDays = info?.latestBookingTime?.daysPrior;
   const phoneNumber = info?.contactInfo?.phoneNumber;
   return {
     action: hasPhone ? (


### PR DESCRIPTION
This fixes a crash happening sometimes when there is no latestBookingTime.