### PR TITLE
bugfix: remove *1000 calculations to reintroduce accurate years in alerts in TORA

### DIFF
--- a/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
@@ -113,7 +113,7 @@ export default function AlertsBody({
                       description="Text with the time and date an alert takes effect"
                       id="otpUi.TransitLegBody.AlertsBody.effectiveTimeAndDate"
                       values={{
-                        dateTime: effectiveStartDate * 1000,
+                        dateTime: effectiveStartDate,
                         day: <AlertDay dayDiff={dayDiff} />
                       }}
                     />
@@ -127,7 +127,7 @@ export default function AlertsBody({
                       description="Text with the date an alert takes effect"
                       id="otpUi.TransitLegBody.AlertsBody.effectiveDate"
                       values={{
-                        dateTime: effectiveStartDate * 1000
+                        dateTime: effectiveStartDate
                       }}
                     />
                   )}


### PR DESCRIPTION
This pull request addresses an issue on TORA for Trimet. The issue is such that within the Alerts Body our years for the dates for which alerts have been effective since suddenly increased to wild numbers. In the attached image, you'll see that the years are hundreds of centuries in the future.

This commit includes a tweak that removes the *1000 calculation to the effectiveTime variable in the Alerts-Body file within the ItineraryBody package.

![image](https://github.com/opentripplanner/otp-ui/assets/31577015/a696f89b-053e-4f78-a571-3e6f2345765f)
