### PR TITLE
Correctly Request Alerts in GraphQL Query

### DIFF
--- a/packages/core-utils/src/planQuery.graphql
+++ b/packages/core-utils/src/planQuery.graphql
@@ -53,6 +53,13 @@ query Plan(
           timezone
           url
         }
+        alerts {
+          alertDescriptionText
+          alertHeaderText
+          alertUrl
+          effectiveStartDate
+          id
+        }
         arrivalDelay
         departureDelay
         distance


### PR DESCRIPTION
An oversight prevented leg-based alerts from rendering. this PR rectifies this.