### PR TITLE
Wheelchair accessible labeling

### DIFF
--- a/packages/itinerary-body/i18n/en-US.yml
+++ b/packages/itinerary-body/i18n/en-US.yml
@@ -81,6 +81,12 @@ otpUi:
       car: by car
       escooter: by e-scooter
       walk: by walking
+    tripAccessibility:
+      inaccessible: inaccessible
+      itineraryAccessibility: "Wheelchair accessibility of this trip: "
+      legAccessibility: "Wheelchair accessibility of this trip leg: "
+      likelyAccessible: likely accessible
+      unclear: unknown
     viewOnMap: View on map
   TransitLegBody:
     AlertsBody:

--- a/packages/itinerary-body/i18n/fr.yml
+++ b/packages/itinerary-body/i18n/fr.yml
@@ -85,6 +85,12 @@ otpUi:
       car: en voiture
       escooter: en trottinette
       walk: à pied
+    tripAccessibility:
+      inaccessible: inaccessible
+      itineraryAccessibility: "Accessibilité de ce trajet en fauteuil roulant : "
+      legAccessibility: "Accessibilité de cette étape en fauteuil roulant : "
+      likelyAccessible: probablement accessible
+      unclear: inconnue
     viewOnMap: Afficher sur le plan
   TransitLegBody:
     AlertsBody:

--- a/packages/itinerary-body/i18n/i18n-exceptions.json
+++ b/packages/itinerary-body/i18n/i18n-exceptions.json
@@ -1,0 +1,7 @@
+{
+  "ignoredIds": ["otpUi.ItineraryBody.tripAccessibility.accessible"],
+
+  "groups": {
+    "otpUi.ItineraryBody.tripAccessibility.*Accessibility": ["itinerary", "leg"]
+  }
+}

--- a/packages/itinerary-body/src/ItineraryBody/accessibility-rating.tsx
+++ b/packages/itinerary-body/src/ItineraryBody/accessibility-rating.tsx
@@ -2,6 +2,8 @@ import { GradationMap } from "@opentripplanner/types";
 import React, { ReactElement } from "react";
 import styled from "styled-components";
 import { Wheelchair } from "@styled-icons/foundation/Wheelchair";
+import { useIntl } from "react-intl";
+import { InvisibleAdditionalDetails } from "../styled";
 
 interface WrapperProps {
   border: boolean;
@@ -39,6 +41,7 @@ const TextWrapper = styled.span`
 interface Props {
   gradationMap?: GradationMap;
   grayscale?: boolean;
+  isLeg?: boolean;
   large?: boolean;
   score: number;
 }
@@ -50,17 +53,34 @@ interface Props {
 const AccessibilityRating = ({
   gradationMap,
   grayscale = false,
+  isLeg = false,
   large = false,
   score
 }: Props): ReactElement => {
+  const intl = useIntl();
   // Provide default mapping
   const mapping = gradationMap || {
-    0.0: { color: "#ffe4e5", text: "❌" },
+    0.0: {
+      color: "#ffe4e5",
+      icon: "❌",
+      text: intl.formatMessage({
+        id: `otpUi.ItineraryBody.tripAccessibility.inaccessible`
+      })
+    },
     0.5: {
       color: "#dbe9ff",
-      text: "？"
+      icon: "？",
+      text: intl.formatMessage({
+        id: `otpUi.ItineraryBody.tripAccessibility.unclear`
+      })
     },
-    0.9: { color: "#bfffb5", text: "✅" }
+    0.9: {
+      color: "#bfffb5",
+      icon: "✅",
+      text: intl.formatMessage({
+        id: `otpUi.ItineraryBody.tripAccessibility.likelyAccessible`
+      })
+    }
   };
 
   // Find the highest (including equality) key for our score.
@@ -75,15 +95,28 @@ const AccessibilityRating = ({
   // External configuration may report "0.0" as 0, so include fallback
   const mapped = mapping[mappedKey] || mapping[0.0];
 
+  const accessibilityPreface = intl.formatMessage({
+    id: `otpUi.ItineraryBody.tripAccessibility.${
+      isLeg ? "legAccessibility" : "itineraryAccessibility"
+    }`
+  });
+
+  const accessibilityScore = mapped.text;
+
+  const accessibilityLabel = accessibilityPreface + accessibilityScore;
+
   return (
     <Wrapper
       border={grayscale}
       color={grayscale ? "transparent" : mapped.color}
       large={large}
-      title={mapped.text}
+      title={accessibilityLabel}
     >
+      <InvisibleAdditionalDetails>
+        {accessibilityLabel}
+      </InvisibleAdditionalDetails>
       <Wheelchair style={{ flex: "2", height: "100%", minWidth: "20px" }} />
-      <StatusWrapper>
+      <StatusWrapper aria-hidden>
         {/* Show either icon or text if no icon given */}
         {mapped.icon || <TextWrapper>{mapped.text}</TextWrapper>}
       </StatusWrapper>

--- a/packages/itinerary-body/src/ItineraryBody/place-row.tsx
+++ b/packages/itinerary-body/src/ItineraryBody/place-row.tsx
@@ -103,8 +103,10 @@ export default function PlaceRow({
         {/* Custom rendering of the departure/arrival time of the specified leg. */}
         <TimeColumnContent isDestination={isDestination} leg={leg} />
         {!isDestination && leg.accessibilityScore && (
+          // TODO: Reorder markup so accessibility info doesn't fall between time and destination.
           <AccessibilityRating
             gradationMap={accessibilityScoreGradationMap}
+            isLeg
             score={leg.accessibilityScore}
           />
         )}


### PR DESCRIPTION
Provides invisible labeling for wheelchair accessibility badges so that users with AT can identify whether a leg or itinerary is wheelchair accessible.

See discussion on #675, closed due to mishandled merge