### PR TITLE
Change addTransportMode type

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -723,7 +723,7 @@ export type SliderOptions = {
 };
 
 export type CheckboxOptions = {
-  addTransportMode?: TransportMode;
+  addTransportMode?: TransportMode | TransportMode[];
   default?: boolean;
   label: string;
   type: "CHECKBOX";


### PR DESCRIPTION
Cherry-picked from https://github.com/opentripplanner/otp-ui/pull/672 so we can get a stable version of it. Adds support for an array of `TransportMode`