### PR TITLE
Fix Crash on Missing Route Data (itin-body)

### DIFF
--- a/packages/itinerary-body/src/stories/itinerary-body-defaults-wrapper.tsx
+++ b/packages/itinerary-body/src/stories/itinerary-body-defaults-wrapper.tsx
@@ -58,7 +58,7 @@ export default class ItineraryBodyDefaultsWrapper extends Component<
       showViewTripButton,
       styledItinerary,
       TimeColumnContent,
-      toRouteAbbreviation = r => r.toString().substr(0, 2),
+      toRouteAbbreviation = r => r?.toString()?.substr(0, 2),
       TransitLegSubheader,
       TransitLegSummary,
       AlertToggleIcon,


### PR DESCRIPTION
we treated a value that is optional as non optional. this is now corrected