### PR TITLE
feat(trip-form): expose mode setting renderer

### DIFF
--- a/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
+++ b/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
@@ -73,13 +73,18 @@ const FormLabelIconWrapper = styled.span`
   }
 `;
 
-const ModeSettingRenderer = ({
+/**
+ * Renders a mode setting definition
+ * @param onChange function for when the value changes, and the setting to be rendered
+ * @returns JSX Element to render
+ */
+export const ModeSettingRenderer = ({
   onChange,
   setting
 }: {
   onChange: (QueryParamChangeEvent) => void;
   setting: ModeSetting;
-}) => {
+}): JSX.Element => {
   const intl = useIntl();
   const { label, labelHigh, labelLow } = generateModeSettingLabels(
     setting.type,

--- a/packages/trip-form/src/index.ts
+++ b/packages/trip-form/src/index.ts
@@ -15,6 +15,7 @@ import {
   convertModeSettingValue,
   populateSettingWithValue
 } from "./MetroModeSelector/utils";
+import { ModeSettingRenderer } from "./MetroModeSelector/SubSettingsPane";
 import TripOptions, { Styled as TripOptionsStyled } from "./TripOptions";
 import defaultModeSettings from "../modeSettings.yml";
 
@@ -30,6 +31,7 @@ export {
   MetroModeSelector,
   ModeButton,
   ModeSelector,
+  ModeSettingRenderer,
   populateSettingWithValue,
   SettingsSelectorPanel,
   SliderSelector,


### PR DESCRIPTION
We need the mode setting renderer to show custom mode setting options in calltaker, whose options panel is not in OTP UI. This allows us to reuse this renderer.