### PR TITLE
fix(core-utils): adds position information to stop query

### DIFF
--- a/packages/core-utils/src/planQuery.graphql
+++ b/packages/core-utils/src/planQuery.graphql
@@ -111,6 +111,8 @@ query Plan(
             code
             gtfsId
             id
+            lat
+            lon
           }
           vertexType
         }
@@ -213,6 +215,8 @@ query Plan(
             code
             gtfsId
             id
+            lat
+            lon
           }
           vertexType
         }


### PR DESCRIPTION
The from/to fields in the plan query needed lat lon information. 

Currently in use via alpha branch in nearby-view PR.