### PR TITLE
Banned routes generator

### DIFF
--- a/packages/trip-form/src/MetroModeSelector/utils.ts
+++ b/packages/trip-form/src/MetroModeSelector/utils.ts
@@ -36,11 +36,9 @@ export function getBannedRoutesFromSubmodes(
   routeModeOverrides: Record<string, string>
 ): string[] {
   const disabledSubmodes = modeSettings.reduce<string[]>((prev, cur) => {
-    if (cur.type === "SUBMODE") {
-      if (!cur.value) {
-        const modeName = cur.modeOverride || cur.addTransportMode.mode;
-        prev.push(modeName);
-      }
+    // Find the disabled override modes
+    if (cur.type === "SUBMODE" && !cur.value) {
+      prev.push(cur.overrideMode);
     }
     return prev;
   }, []);

--- a/packages/trip-form/src/MetroModeSelector/utils.ts
+++ b/packages/trip-form/src/MetroModeSelector/utils.ts
@@ -26,6 +26,32 @@ export function aggregateModes(
 }
 
 /**
+ * Generates a list of banned route IDs based on deselected submodes
+ * We support arbitrary modes (behond GTFS spec), but OTP doesn't
+ * Therefore we might need to use the banned routes API to exclude those routes
+ * when their mode is deselected.
+ */
+export function getBannedRoutesFromSubmodes(
+  modeSettings: ModeSetting[],
+  routeModeOverrides: Record<string, string>
+): string[] {
+  const disabledSubmodes = modeSettings.reduce<string[]>((prev, cur) => {
+    if (cur.type === "SUBMODE") {
+      if (!cur.value) {
+        prev.push(cur.addTransportMode.mode);
+      }
+    }
+    return prev;
+  }, []);
+  // routeModeOverrides has shape {"routeId": "arbitraryMode", ...}
+  const bannedRouteIds = Object.keys(routeModeOverrides).filter(routeId =>
+    disabledSubmodes.includes(routeModeOverrides[routeId])
+  );
+
+  return bannedRouteIds;
+}
+
+/**
  * Filters mode buttons by list of keys, used to find enabled buttons.
  * TODO: Remove this function? Is it needed?
  * @param modeButtonDefinitions All mode definitions

--- a/packages/trip-form/src/MetroModeSelector/utils.ts
+++ b/packages/trip-form/src/MetroModeSelector/utils.ts
@@ -27,7 +27,7 @@ export function aggregateModes(
 
 /**
  * Generates a list of banned route IDs based on deselected submodes
- * We support arbitrary modes (behond GTFS spec), but OTP doesn't
+ * We support arbitrary modes (beyond GTFS spec), but OTP doesn't
  * Therefore we might need to use the banned routes API to exclude those routes
  * when their mode is deselected.
  */

--- a/packages/trip-form/src/MetroModeSelector/utils.ts
+++ b/packages/trip-form/src/MetroModeSelector/utils.ts
@@ -38,7 +38,8 @@ export function getBannedRoutesFromSubmodes(
   const disabledSubmodes = modeSettings.reduce<string[]>((prev, cur) => {
     if (cur.type === "SUBMODE") {
       if (!cur.value) {
-        prev.push(cur.addTransportMode.mode);
+        const modeName = cur.modeOverride || cur.addTransportMode.mode;
+        prev.push(modeName);
       }
     }
     return prev;

--- a/packages/trip-form/src/__tests__/__snapshots__/mode-selector-utils.js.snap
+++ b/packages/trip-form/src/__tests__/__snapshots__/mode-selector-utils.js.snap
@@ -16,12 +16,12 @@ Array [
       },
       Object {
         "addTransportMode": Object {
-          "mode": "HOVERCRAFT",
-          "qualifier": "RENT",
+          "mode": "BUS",
         },
         "applicableMode": "TRANSIT",
         "default": true,
         "key": "enableHovercraft",
+        "overrideMode": "HOVERCRAFT",
         "type": "SUBMODE",
       },
     ],
@@ -172,12 +172,12 @@ Array [
   },
   Object {
     "addTransportMode": Object {
-      "mode": "HOVERCRAFT",
-      "qualifier": "RENT",
+      "mode": "BUS",
     },
     "applicableMode": "TRANSIT",
     "default": true,
     "key": "enableHovercraft",
+    "overrideMode": "HOVERCRAFT",
     "type": "SUBMODE",
     "value": false,
   },

--- a/packages/trip-form/src/__tests__/__snapshots__/mode-selector-utils.js.snap
+++ b/packages/trip-form/src/__tests__/__snapshots__/mode-selector-utils.js.snap
@@ -14,6 +14,16 @@ Array [
         "label": "Use Accessible Routing",
         "type": "CHECKBOX",
       },
+      Object {
+        "addTransportMode": Object {
+          "mode": "HOVERCRAFT",
+          "qualifier": "RENT",
+        },
+        "applicableMode": "TRANSIT",
+        "default": true,
+        "key": "enableHovercraft",
+        "type": "SUBMODE",
+      },
     ],
     "modes": Array [
       Object {
@@ -93,6 +103,7 @@ Object {
   "allowBikeRental": true,
   "bikeReluctance": 2,
   "carReluctance": 3,
+  "enableHovercraft": true,
   "walkReluctance": 2,
   "wheelchair": false,
 }
@@ -157,6 +168,17 @@ Array [
     "key": "wheelchair",
     "label": "Use Accessible Routing",
     "type": "CHECKBOX",
+    "value": false,
+  },
+  Object {
+    "addTransportMode": Object {
+      "mode": "HOVERCRAFT",
+      "qualifier": "RENT",
+    },
+    "applicableMode": "TRANSIT",
+    "default": true,
+    "key": "enableHovercraft",
+    "type": "SUBMODE",
     "value": false,
   },
 ]

--- a/packages/trip-form/src/__tests__/mode-selector-utils.js
+++ b/packages/trip-form/src/__tests__/mode-selector-utils.js
@@ -5,6 +5,7 @@ import {
   convertModeSettingValue,
   extractModeSettingDefaultsToObject,
   filterModeDefitionsByKey,
+  getBannedRoutesFromSubmodes,
   populateSettingWithValue
 } from "../MetroModeSelector/utils";
 
@@ -143,6 +144,13 @@ const modeSettingDefinitions = [
     key: "wheelchair",
     label: "Use Accessible Routing",
     type: "CHECKBOX"
+  },
+  {
+    addTransportMode: { mode: "HOVERCRAFT", qualifier: "RENT" },
+    applicableMode: "TRANSIT",
+    default: true,
+    key: "enableHovercraft",
+    type: "SUBMODE"
   }
 ];
 
@@ -151,7 +159,8 @@ const valueObject = {
   bikeReluctance: 2,
   carReluctance: 3,
   walkReluctance: 2,
-  wheelchair: false
+  wheelchair: false,
+  enableHovercraft: false
 };
 
 function stringsToTransportModes(strs) {
@@ -247,6 +256,21 @@ describe("mode selector utils", () => {
           addSettingsToButton(modeSettingDefinitions)
         )
       ).toMatchSnapshot();
+    });
+  });
+
+  describe("get banned routes from submodes", () => {
+    it("should list the banned route IDs from a disabled submode setting", () => {
+      const routeModeOverrides = {
+        "soundtransit:hover1": "HOVERCRAFT",
+        "soundtransit:train": "LIGHT_RAIL"
+      };
+      const modeSettingsWithValues = modeSettingDefinitions.map(
+        populateSettingWithValue(valueObject)
+      );
+      expect(
+        getBannedRoutesFromSubmodes(modeSettingsWithValues, routeModeOverrides)
+      ).toEqual(["soundtransit:hover1"]);
     });
   });
 });

--- a/packages/trip-form/src/__tests__/mode-selector-utils.js
+++ b/packages/trip-form/src/__tests__/mode-selector-utils.js
@@ -146,10 +146,11 @@ const modeSettingDefinitions = [
     type: "CHECKBOX"
   },
   {
-    addTransportMode: { mode: "HOVERCRAFT", qualifier: "RENT" },
+    addTransportMode: { mode: "BUS" },
     applicableMode: "TRANSIT",
     default: true,
     key: "enableHovercraft",
+    overrideMode: "HOVERCRAFT",
     type: "SUBMODE"
   }
 ];

--- a/packages/trip-form/src/index.ts
+++ b/packages/trip-form/src/index.ts
@@ -13,7 +13,8 @@ import {
   addSettingsToButton,
   aggregateModes,
   convertModeSettingValue,
-  populateSettingWithValue
+  populateSettingWithValue,
+  getBannedRoutesFromSubmodes
 } from "./MetroModeSelector/utils";
 import TripOptions, { Styled as TripOptionsStyled } from "./TripOptions";
 import defaultModeSettings from "../modeSettings.yml";
@@ -27,6 +28,7 @@ export {
   defaultModeSettings,
   DropdownSelector,
   GeneralSettingsPanel,
+  getBannedRoutesFromSubmodes,
   MetroModeSelector,
   ModeButton,
   ModeSelector,

--- a/packages/trip-form/tsconfig.json
+++ b/packages/trip-form/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "lib": ["ES2019", "DOM"],
     "composite": false,
     "outDir": "./lib",
     "rootDir": "./src",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -723,6 +723,7 @@ export type SliderOptions = {
 };
 
 export type CheckboxOptions = {
+  // This transport mode should match an OTP transport mode
   addTransportMode?: TransportMode | TransportMode[];
   default?: boolean;
   label: string;
@@ -733,10 +734,13 @@ export type CheckboxOptions = {
 };
 
 export type TransitSubmodeCheckboxOption = {
-  addTransportMode: TransportMode;
+  // This transport mode should match an OTP transport mode
+  addTransportMode: TransportMode | TransportMode[];
   default?: boolean;
   label: string;
-  modeOverride?: string;
+  // We might want to specify a secondary, "override" mode to this checkbox.
+  // This can be used to generate a list of banned routes that have a matching mode.
+  overrideMode?: string;
   type: "SUBMODE";
   value?: boolean;
 };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -735,7 +735,7 @@ export type CheckboxOptions = {
 
 export type TransitSubmodeCheckboxOption = {
   // This transport mode should match an OTP transport mode
-  addTransportMode: TransportMode | TransportMode[];
+  addTransportMode: TransportMode;
   default?: boolean;
   label: string;
   // We might want to specify a secondary, "override" mode to this checkbox.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -736,6 +736,7 @@ export type TransitSubmodeCheckboxOption = {
   addTransportMode: TransportMode;
   default?: boolean;
   label: string;
+  modeOverride?: string;
   type: "SUBMODE";
   value?: boolean;
 };


### PR DESCRIPTION
In cases where there are route mode overrides in the config, we'll use the banned parameter to exclude routes under a custom submode. This adds a util function to generate a list of banned routes based on the mode settings and route mode overrides. 