### PR TITLE
fix(geocoder/otp): correctly accept `stop.code` as optional

### DIFF
--- a/packages/geocoder/src/apis/otp/index.ts
+++ b/packages/geocoder/src/apis/otp/index.ts
@@ -13,7 +13,7 @@ type OTPGeocoderResponse = {
       lat: number,
       lon: number,
     },
-    code: string,
+    code?: string | undefined,
     name: string,
     id: string,
     modes: string[]

--- a/packages/geocoder/src/geocoders/otp.ts
+++ b/packages/geocoder/src/geocoders/otp.ts
@@ -21,13 +21,15 @@ export default class OTPGeocoder extends Geocoder {
 
 
   rewriteAutocompleteResponse(response: OTPGeocoderResponse): MultiGeocoderResponse {
+    const generateLabel = stop => stop.code ? `${stop.name} (${stop.code})` : stop.name
+
     return {
         features: response?.results?.map(stop => ({
             geometry: { type: "Point", coordinates: [stop.coordinate.lon, stop.coordinate.lat] },
             id: stop.id, 
             // TODO: if non-stops are supported, these need to be detected here and 
             // this layer property updated accordingly
-            properties: { layer: "stops", source: "otp", modes: stop.modes, name: stop.name, label: `${stop.name} (${stop.code})` }, 
+            properties: { layer: "stops", source: "otp", modes: stop.modes, name: stop.name, label: generateLabel(stop) }, 
             type: "Feature"
         })),
       type: "FeatureCollection"


### PR DESCRIPTION
The OTP geocoder response was not correctly implemented. `stop.code` is optional. This means we were sometimes rendering `(undefined)`. This PR corrects this mistake.