### PR TITLE
feat(geocoder/photon): allow to use a custom Photon geocoding service

### DIFF
--- a/packages/geocoder/src/__snapshots__/index.test.js.snap
+++ b/packages/geocoder/src/__snapshots__/index.test.js.snap
@@ -982,3 +982,409 @@ Object {
   "type": "FeatureCollection",
 }
 `;
+
+exports[`geocoder PHOTON should get location from geocode feature 1`] = `
+Object {
+  "lat": 45.51621,
+  "lon": -122.67325,
+  "name": "Mill Ends Park, Southwest Naito Parkway, Downtown, OR, 97204, Portland, États-Unis d'Amérique",
+  "rawGeocodedFeature": Object {
+    "geometry": Object {
+      "coordinates": Array [
+        -122.67325,
+        45.51621,
+      ],
+      "type": "Point",
+    },
+    "properties": Object {
+      "city": "Portland",
+      "country": "États-Unis d'Amérique",
+      "district": "Downtown",
+      "label": "Mill Ends Park, Southwest Naito Parkway, Downtown, OR, 97204, Portland, États-Unis d'Amérique",
+      "name": "Mill Ends Park",
+      "postcode": "97204",
+      "state": "OR",
+      "street": "Southwest Naito Parkway",
+    },
+  },
+}
+`;
+
+exports[`geocoder PHOTON should make autocomplete query 1`] = `
+Object {
+  "features": Array [
+    Object {
+      "geometry": Object {
+        "coordinates": Array [
+          -122.67325034999999,
+          45.51621765,
+        ],
+        "type": "Point",
+      },
+      "properties": Object {
+        "country": "États-Unis d'Amérique",
+        "countrycode": "US",
+        "extent": Array [
+          -122.673255,
+          45.5162209,
+          -122.6732457,
+          45.5162144,
+        ],
+        "label": "Mill Ends Park, États-Unis d'Amérique",
+        "name": "Mill Ends Park",
+        "osm_id": 156366633,
+        "osm_key": "leisure",
+        "osm_type": "W",
+        "osm_value": "park",
+        "type": "locality",
+      },
+      "type": "Feature",
+    },
+    Object {
+      "geometry": Object {
+        "coordinates": Array [
+          -122.6733766,
+          45.5162784,
+        ],
+        "type": "Point",
+      },
+      "properties": Object {
+        "city": "Portland",
+        "country": "États-Unis d'Amérique",
+        "countrycode": "US",
+        "county": "Multnomah",
+        "district": "Downtown",
+        "label": "Mill Ends Park, Southwest Naito Parkway, Downtown, OR, 97204, Portland, États-Unis d'Amérique",
+        "name": "Mill Ends Park",
+        "osm_id": 4243944023,
+        "osm_key": "tourism",
+        "osm_type": "N",
+        "osm_value": "information",
+        "postcode": "97204",
+        "state": "OR",
+        "street": "Southwest Naito Parkway",
+        "type": "house",
+      },
+      "type": "Feature",
+    },
+    Object {
+      "geometry": Object {
+        "coordinates": Array [
+          -2.4756598,
+          53.7547536,
+        ],
+        "type": "Point",
+      },
+      "properties": Object {
+        "city": "Blackburn",
+        "country": "Royaume-Uni",
+        "countrycode": "GB",
+        "county": "Blackburn with Darwen",
+        "district": "Four Lane Ends",
+        "extent": Array [
+          -2.4758741,
+          53.7548952,
+          -2.4749263,
+          53.7544719,
+        ],
+        "label": "New Mill Street, Four Lane Ends, Angleterre, BB1 6JS, Blackburn, Royaume-Uni",
+        "name": "New Mill Street",
+        "osm_id": 130281365,
+        "osm_key": "highway",
+        "osm_type": "W",
+        "osm_value": "residential",
+        "postcode": "BB1 6JS",
+        "state": "Angleterre",
+        "type": "street",
+      },
+      "type": "Feature",
+    },
+    Object {
+      "geometry": Object {
+        "coordinates": Array [
+          -2.0318091,
+          53.8904692,
+        ],
+        "type": "Point",
+      },
+      "properties": Object {
+        "city": "Cowling",
+        "country": "Royaume-Uni",
+        "countrycode": "GB",
+        "county": "North Yorkshire",
+        "district": "Cowling",
+        "extent": Array [
+          -2.0319873,
+          53.8905873,
+          -2.0317233,
+          53.8903037,
+        ],
+        "label": "The Old Saw Mill, Cowling, Angleterre, BD22 0JT, Cowling, Royaume-Uni",
+        "locality": "Lane Ends",
+        "name": "The Old Saw Mill",
+        "osm_id": 194668944,
+        "osm_key": "highway",
+        "osm_type": "W",
+        "osm_value": "residential",
+        "postcode": "BD22 0JT",
+        "state": "Angleterre",
+        "type": "street",
+      },
+      "type": "Feature",
+    },
+    Object {
+      "geometry": Object {
+        "coordinates": Array [
+          -74.4846831,
+          40.7940011,
+        ],
+        "type": "Point",
+      },
+      "properties": Object {
+        "city": "Morristown",
+        "country": "États-Unis d'Amérique",
+        "countrycode": "US",
+        "county": "Morris",
+        "label": "The Decorating Store at Terminal Mill Ends, Mount Kemble Avenue, NJ, 07960, Morristown, États-Unis d'Amérique",
+        "name": "The Decorating Store at Terminal Mill Ends",
+        "osm_id": 9634530317,
+        "osm_key": "shop",
+        "osm_type": "N",
+        "osm_value": "interior_decoration",
+        "postcode": "07960",
+        "state": "NJ",
+        "street": "Mount Kemble Avenue",
+        "type": "house",
+      },
+      "type": "Feature",
+    },
+  ],
+  "type": "FeatureCollection",
+}
+`;
+
+exports[`geocoder PHOTON should make reverse query 1`] = `
+Object {
+  "lat": 45.516198,
+  "lon": -122.67324,
+  "name": "Mill Ends Park, États-Unis d'Amérique",
+  "rawGeocodedFeature": Object {
+    "geometry": Object {
+      "coordinates": Array [
+        -122.67325034999999,
+        45.51621765,
+      ],
+      "type": "Point",
+    },
+    "properties": Object {
+      "country": "États-Unis d'Amérique",
+      "countrycode": "US",
+      "extent": Array [
+        -122.673255,
+        45.5162209,
+        -122.6732457,
+        45.5162144,
+      ],
+      "name": "Mill Ends Park",
+      "osm_id": 156366633,
+      "osm_key": "leisure",
+      "osm_type": "W",
+      "osm_value": "park",
+      "type": "locality",
+    },
+    "type": "Feature",
+  },
+}
+`;
+
+exports[`geocoder PHOTON should make reverse query with featurecollection enabled 1`] = `
+Object {
+  "features": Array [
+    Object {
+      "geometry": Object {
+        "coordinates": Array [
+          -122.67325034999999,
+          45.51621765,
+        ],
+        "type": "Point",
+      },
+      "properties": Object {
+        "country": "États-Unis d'Amérique",
+        "countrycode": "US",
+        "extent": Array [
+          -122.673255,
+          45.5162209,
+          -122.6732457,
+          45.5162144,
+        ],
+        "label": "Mill Ends Park, États-Unis d'Amérique",
+        "name": "Mill Ends Park",
+        "osm_id": 156366633,
+        "osm_key": "leisure",
+        "osm_type": "W",
+        "osm_value": "park",
+        "type": "locality",
+      },
+      "type": "Feature",
+    },
+  ],
+  "point": Object {
+    "lat": 45.516198,
+    "lon": -122.67324,
+  },
+  "type": "FeatureCollection",
+}
+`;
+
+exports[`geocoder PHOTON should make search query 1`] = `
+Object {
+  "features": Array [
+    Object {
+      "geometry": Object {
+        "coordinates": Array [
+          -122.67325034999999,
+          45.51621765,
+        ],
+        "type": "Point",
+      },
+      "properties": Object {
+        "country": "États-Unis d'Amérique",
+        "countrycode": "US",
+        "extent": Array [
+          -122.673255,
+          45.5162209,
+          -122.6732457,
+          45.5162144,
+        ],
+        "label": "Mill Ends Park, États-Unis d'Amérique",
+        "name": "Mill Ends Park",
+        "osm_id": 156366633,
+        "osm_key": "leisure",
+        "osm_type": "W",
+        "osm_value": "park",
+        "type": "locality",
+      },
+      "type": "Feature",
+    },
+    Object {
+      "geometry": Object {
+        "coordinates": Array [
+          -122.6733766,
+          45.5162784,
+        ],
+        "type": "Point",
+      },
+      "properties": Object {
+        "city": "Portland",
+        "country": "États-Unis d'Amérique",
+        "countrycode": "US",
+        "county": "Multnomah",
+        "district": "Downtown",
+        "label": "Mill Ends Park, Southwest Naito Parkway, Downtown, OR, 97204, Portland, États-Unis d'Amérique",
+        "name": "Mill Ends Park",
+        "osm_id": 4243944023,
+        "osm_key": "tourism",
+        "osm_type": "N",
+        "osm_value": "information",
+        "postcode": "97204",
+        "state": "OR",
+        "street": "Southwest Naito Parkway",
+        "type": "house",
+      },
+      "type": "Feature",
+    },
+    Object {
+      "geometry": Object {
+        "coordinates": Array [
+          -2.4756598,
+          53.7547536,
+        ],
+        "type": "Point",
+      },
+      "properties": Object {
+        "city": "Blackburn",
+        "country": "Royaume-Uni",
+        "countrycode": "GB",
+        "county": "Blackburn with Darwen",
+        "district": "Four Lane Ends",
+        "extent": Array [
+          -2.4758741,
+          53.7548952,
+          -2.4749263,
+          53.7544719,
+        ],
+        "label": "New Mill Street, Four Lane Ends, Angleterre, BB1 6JS, Blackburn, Royaume-Uni",
+        "name": "New Mill Street",
+        "osm_id": 130281365,
+        "osm_key": "highway",
+        "osm_type": "W",
+        "osm_value": "residential",
+        "postcode": "BB1 6JS",
+        "state": "Angleterre",
+        "type": "street",
+      },
+      "type": "Feature",
+    },
+    Object {
+      "geometry": Object {
+        "coordinates": Array [
+          -2.0318091,
+          53.8904692,
+        ],
+        "type": "Point",
+      },
+      "properties": Object {
+        "city": "Cowling",
+        "country": "Royaume-Uni",
+        "countrycode": "GB",
+        "county": "North Yorkshire",
+        "district": "Cowling",
+        "extent": Array [
+          -2.0319873,
+          53.8905873,
+          -2.0317233,
+          53.8903037,
+        ],
+        "label": "The Old Saw Mill, Cowling, Angleterre, BD22 0JT, Cowling, Royaume-Uni",
+        "locality": "Lane Ends",
+        "name": "The Old Saw Mill",
+        "osm_id": 194668944,
+        "osm_key": "highway",
+        "osm_type": "W",
+        "osm_value": "residential",
+        "postcode": "BD22 0JT",
+        "state": "Angleterre",
+        "type": "street",
+      },
+      "type": "Feature",
+    },
+    Object {
+      "geometry": Object {
+        "coordinates": Array [
+          -74.4846831,
+          40.7940011,
+        ],
+        "type": "Point",
+      },
+      "properties": Object {
+        "city": "Morristown",
+        "country": "États-Unis d'Amérique",
+        "countrycode": "US",
+        "county": "Morris",
+        "label": "The Decorating Store at Terminal Mill Ends, Mount Kemble Avenue, NJ, 07960, Morristown, États-Unis d'Amérique",
+        "name": "The Decorating Store at Terminal Mill Ends",
+        "osm_id": 9634530317,
+        "osm_key": "shop",
+        "osm_type": "N",
+        "osm_value": "interior_decoration",
+        "postcode": "07960",
+        "state": "NJ",
+        "street": "Mount Kemble Avenue",
+        "type": "house",
+      },
+      "type": "Feature",
+    },
+  ],
+  "type": "FeatureCollection",
+}
+`;

--- a/packages/geocoder/src/apis/photon/index.ts
+++ b/packages/geocoder/src/apis/photon/index.ts
@@ -7,8 +7,7 @@ import type { LonLatOutput } from "@conveyal/lonlat"
 import type { AutocompleteQuery, ReverseQuery, SearchQuery } from "../../geocoders/types"
 import type { PhotonResponse } from "./types";
 
-const AUTOCOMPLETE_URL =
-    "https://photon.komoot.io/api";
+const AUTOCOMPLETE_URL = "https://photon.komoot.io/api";
 const GEOCODE_URL = "https://photon.komoot.io/api";
 const REVERSE_URL = "https://photon.komoot.io/reverse";
 
@@ -59,7 +58,8 @@ async function autocomplete({
   focusPoint,
   options,
   size = 20,
-  text
+  text,
+  url = AUTOCOMPLETE_URL
 }: AutocompleteQuery): Promise<PhotonResponse> {
   // build query
   const query: PhotonQuery = { limit: size, q: text };
@@ -68,12 +68,8 @@ async function autocomplete({
     const { lat, lon }: LonLatOutput = normalize(focusPoint);
     query.lat = lat.toString();
     query.lon = lon.toString();
-    const res = await run({
-      options,
-      query,
-      url: AUTOCOMPLETE_URL
-    });
-    return res
+    const res = await run({ options, query, url });
+    return res;
   }
   if (boundary) {
     const { country, rect } = boundary;
@@ -88,11 +84,7 @@ async function autocomplete({
     }
   }
 
-  return run({
-    options,
-    query,
-    url: AUTOCOMPLETE_URL
-  });
+  return run({ options, query, url });
 }
 
 /**
@@ -111,7 +103,8 @@ function search({
   focusPoint,
   options,
   size = 10,
-  text
+  text,
+  url = GEOCODE_URL
 }: SearchQuery): Promise<PhotonResponse> {
   if (!text) return Promise.resolve({ items: [] });
 
@@ -126,7 +119,7 @@ function search({
     query.lon = lon.toString();
   }
 
-  return run({ options, query, url: GEOCODE_URL });
+  return run({ options, query, url });
 }
 
 /**
@@ -139,7 +132,7 @@ function search({
  * @param  {Object} $0.options                  options to pass to fetch (e.g., custom headers)
  * @return {Promise}                            A Promise that'll get resolved with search result
  */
-function reverse({ options, point }: ReverseQuery): Promise<PhotonResponse> {
+function reverse({ options, point, url = REVERSE_URL }: ReverseQuery): Promise<PhotonResponse> {
   const query: PhotonQuery = {
   };
 
@@ -151,7 +144,7 @@ function reverse({ options, point }: ReverseQuery): Promise<PhotonResponse> {
     throw new GeocoderException("No point provided for reverse geocoder.");
   }
 
-  return run({ options, query, url: REVERSE_URL }).then(res => ({
+  return run({ options, query, url }).then(res => ({
     ...res,
     point
   }));

--- a/packages/geocoder/src/geocoders/photon.ts
+++ b/packages/geocoder/src/geocoders/photon.ts
@@ -40,7 +40,7 @@ export default class PhotonGeocoder extends Geocoder {
       focusPoint,
       options,
       size,
-      url: baseUrl ? `${baseUrl}/autocomplete` : undefined,
+      url: baseUrl ? `${baseUrl}/api` : undefined,
       ...query
     };
   }
@@ -58,7 +58,7 @@ export default class PhotonGeocoder extends Geocoder {
       focusPoint,
       options,
       size,
-      url: baseUrl ? `${baseUrl}/search` : undefined,
+      url: baseUrl ? `${baseUrl}/api` : undefined,
       ...query
     };
   }

--- a/packages/geocoder/src/index.test.js
+++ b/packages/geocoder/src/index.test.js
@@ -24,6 +24,9 @@ describe("geocoder", () => {
       apiKey: "dummy-here-key",
       type: "HERE"
     },
+    {
+      type: "PHOTON"
+    },
     // this entry represents no geocoder configuration. In this case it is
     // expected that the NoApiGeocoder will be used.
     undefined
@@ -96,6 +99,19 @@ describe("geocoder", () => {
     .query(true)
     .replyWithFile(200, mockResponsePath("here", "reverse-response.json"));
 
+  // nocks for PHOTON
+  nock("https://photon.komoot.io/")
+    // autocomplete & search
+    .get("/api")
+    .twice()
+    .query(true)
+    .replyWithFile(200, mockResponsePath("photon", "search-response.json"))
+    // reverse
+    .get("/reverse")
+    .twice()
+    .query(true)
+    .replyWithFile(200, mockResponsePath("photon", "reverse-response.json"));
+
   geocoders.forEach(geocoder => {
     const geocoderType = geocoder ? geocoder.type : "NoApiGeocoder";
     // the describe is in quotes to bypass a lint rule
@@ -162,6 +178,25 @@ describe("geocoder", () => {
               },
               properties: {
                 label: "Mill Ends Park, Portland, OR, USA"
+              }
+            };
+            break;
+          case "PHOTON":
+            mockFeature = {
+              geometry: {
+                coordinates: [-122.67325, 45.51621],
+                type: "Point"
+              },
+              properties: {
+                label:
+                  "Mill Ends Park, Southwest Naito Parkway, Downtown, OR, 97204, Portland, États-Unis d'Amérique",
+                country: "États-Unis d'Amérique",
+                city: "Portland",
+                postcode: "97204",
+                street: "Southwest Naito Parkway",
+                district: "Downtown",
+                name: "Mill Ends Park",
+                state: "OR"
               }
             };
             break;

--- a/packages/geocoder/src/test-fixtures/photon/reverse-response.json
+++ b/packages/geocoder/src/test-fixtures/photon/reverse-response.json
@@ -1,0 +1,31 @@
+{
+  "features": [
+    {
+      "geometry": {
+        "coordinates": [
+          -122.67325034999999,
+          45.51621765
+        ],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_type": "W",
+        "osm_id": 156366633,
+        "extent": [
+          -122.673255,
+          45.5162209,
+          -122.6732457,
+          45.5162144
+        ],
+        "country": "États-Unis d'Amérique",
+        "osm_key": "leisure",
+        "countrycode": "US",
+        "osm_value": "park",
+        "name": "Mill Ends Park",
+        "type": "locality"
+      }
+    }
+  ],
+  "type": "FeatureCollection"
+}

--- a/packages/geocoder/src/test-fixtures/photon/search-response.json
+++ b/packages/geocoder/src/test-fixtures/photon/search-response.json
@@ -1,0 +1,145 @@
+{
+  "features": [
+    {
+      "geometry": {
+        "coordinates": [
+          -122.67325034999999,
+          45.51621765
+        ],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_type": "W",
+        "osm_id": 156366633,
+        "extent": [
+          -122.673255,
+          45.5162209,
+          -122.6732457,
+          45.5162144
+        ],
+        "country": "États-Unis d'Amérique",
+        "osm_key": "leisure",
+        "countrycode": "US",
+        "osm_value": "park",
+        "name": "Mill Ends Park",
+        "type": "locality"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          -122.6733766,
+          45.5162784
+        ],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 4243944023,
+        "country": "États-Unis d'Amérique",
+        "city": "Portland",
+        "countrycode": "US",
+        "postcode": "97204",
+        "county": "Multnomah",
+        "type": "house",
+        "osm_type": "N",
+        "osm_key": "tourism",
+        "street": "Southwest Naito Parkway",
+        "district": "Downtown",
+        "osm_value": "information",
+        "name": "Mill Ends Park",
+        "state": "OR"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          -2.4756598,
+          53.7547536
+        ],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 130281365,
+        "extent": [
+          -2.4758741,
+          53.7548952,
+          -2.4749263,
+          53.7544719
+        ],
+        "country": "Royaume-Uni",
+        "city": "Blackburn",
+        "countrycode": "GB",
+        "postcode": "BB1 6JS",
+        "county": "Blackburn with Darwen",
+        "type": "street",
+        "osm_type": "W",
+        "osm_key": "highway",
+        "district": "Four Lane Ends",
+        "osm_value": "residential",
+        "name": "New Mill Street",
+        "state": "Angleterre"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          -2.0318091,
+          53.8904692
+        ],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 194668944,
+        "extent": [
+          -2.0319873,
+          53.8905873,
+          -2.0317233,
+          53.8903037
+        ],
+        "country": "Royaume-Uni",
+        "city": "Cowling",
+        "countrycode": "GB",
+        "postcode": "BD22 0JT",
+        "locality": "Lane Ends",
+        "county": "North Yorkshire",
+        "type": "street",
+        "osm_type": "W",
+        "osm_key": "highway",
+        "district": "Cowling",
+        "osm_value": "residential",
+        "name": "The Old Saw Mill",
+        "state": "Angleterre"
+      }
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          -74.4846831,
+          40.7940011
+        ],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 9634530317,
+        "country": "États-Unis d'Amérique",
+        "city": "Morristown",
+        "countrycode": "US",
+        "postcode": "07960",
+        "county": "Morris",
+        "type": "house",
+        "osm_type": "N",
+        "osm_key": "shop",
+        "street": "Mount Kemble Avenue",
+        "osm_value": "interior_decoration",
+        "name": "The Decorating Store at Terminal Mill Ends",
+        "state": "NJ"
+      }
+    }
+  ],
+  "type": "FeatureCollection"
+}


### PR DESCRIPTION
This change add the ability to use a custom Photon instance instead of the default one at https://photon.komoot.io/.

When the baseUrl is not provided in the configuration, the existing behavior of use the _komoot_ instance is kept.

