### PR TITLE
map-popup: hide popup when clicking action button

### DIFF
--- a/packages/otp2-tile-overlay/src/index.tsx
+++ b/packages/otp2-tile-overlay/src/index.tsx
@@ -150,7 +150,7 @@ const OTP2TileLayerWithPopup = ({
             configCompanies={configCompanies}
             entity={{ ...clickedEntity, id: clickedEntity?.id || clickedEntity?.gtfsId }}
             setLocation={setLocation ? (location) => { setClickedEntity(null); setLocation(location) } : null}
-            setViewedStop={setViewedStop}
+            setViewedStop={setViewedStop ? (stop) => { setClickedEntity(null);setViewedStop(stop) } : null}
           />
 
         </Popup>

--- a/packages/park-and-ride-overlay/src/index.tsx
+++ b/packages/park-and-ride-overlay/src/index.tsx
@@ -48,7 +48,14 @@ const ParkAndRideOverlay = (props: Props): JSX.Element => {
                       lon: location.x,
                       name
                     }}
-                    setLocation={setLocation}
+                    setLocation={
+                      setLocation
+                        ? l => {
+                            setLocation(null);
+                            setLocation(l);
+                          }
+                        : null
+                    }
                   />
                 </BaseMapStyled.PopupRow>
               </BaseMapStyled.MapOverlayPopup>


### PR DESCRIPTION
This was sort of annoying -- you'd click "view stop" but then the popup would just linger! This PR resolves this issue.