### PR TITLE
itinerary body: never display `“default vehicle type” `

### DIFF
--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -410,10 +410,10 @@ export function getCompanyForNetwork(
  * @return {string}  A label for use in presentation on a website.
  */
 export function getCompaniesLabelFromNetworks(
-  networks: string[],
+  networks: string[] | string,
   companies: Company[] = []
 ): string {
-  return networks
+  return (Array.isArray(networks) ? networks : [networks])
     .map(network => getCompanyForNetwork(network, companies))
     .filter(co => !!co)
     .map(co => co.label)

--- a/packages/itinerary-body/src/util.ts
+++ b/packages/itinerary-body/src/util.ts
@@ -157,10 +157,11 @@ export function getPlaceName(
     companies
   );
   if (
+    intl &&
     // Don't ever show this useless OTP default string
-    place.name === "Default vehicle type" ||
-    (place.name.match(/-/g) || []).length > 3 ||
-    company?.overridePlaceNames
+    (place.name === "Default vehicle type" ||
+      (place.name.match(/-/g) || []).length > 3 ||
+      company?.overridePlaceNames)
   ) {
     return intl.formatMessage(
       {

--- a/packages/itinerary-body/src/util.ts
+++ b/packages/itinerary-body/src/util.ts
@@ -162,19 +162,17 @@ export function getPlaceName(
     (place.name.match(/-/g) || []).length > 3 ||
     company?.overridePlaceNames
   ) {
-    if (intl) {
-      return intl.formatMessage(
-        {
-          defaultMessage: defaultMessages["otpUi.AccessLegBody.vehicleTitle"],
-          description: "Formats rental vehicle company and type",
-          id: "otpUi.AccessLegBody.vehicleTitle"
-        },
-        {
-          company: company?.label,
-          vehicleType: getVehicleType(place.vertexType, intl)
-        }
-      );
-    }
+    return intl.formatMessage(
+      {
+        defaultMessage: defaultMessages["otpUi.AccessLegBody.vehicleTitle"],
+        description: "Formats rental vehicle company and type",
+        id: "otpUi.AccessLegBody.vehicleTitle"
+      },
+      {
+        company: company?.label,
+        vehicleType: getVehicleType(place.vertexType, intl)
+      }
+    );
   }
   // Default to place name
   return place.name;

--- a/packages/itinerary-body/src/util.ts
+++ b/packages/itinerary-body/src/util.ts
@@ -157,10 +157,12 @@ export function getPlaceName(
     companies
   );
   if (
+    // Don't ever show this useless OTP default string
+    place.name === "Default vehicle type" ||
     (place.name.match(/-/g) || []).length > 3 ||
     company?.overridePlaceNames
   ) {
-    if (company && intl) {
+    if (intl) {
       return intl.formatMessage(
         {
           defaultMessage: defaultMessages["otpUi.AccessLegBody.vehicleTitle"],
@@ -168,7 +170,7 @@ export function getPlaceName(
           id: "otpUi.AccessLegBody.vehicleTitle"
         },
         {
-          company: company.label,
+          company: company?.label,
           vehicleType: getVehicleType(place.vertexType, intl)
         }
       );

--- a/packages/map-popup/src/util.ts
+++ b/packages/map-popup/src/util.ts
@@ -21,7 +21,11 @@ export function makeDefaultGetEntityName(
     let stationName: string | null = entity.name || entity.id;
     // If the station name or id is a giant UUID (with more than 3 "-" characters)
     // best not to show that at all. The company name will still be shown.
-    if ((stationName.match(/-/g) || []).length > 3) {
+    // Also ignore "Default Vehicle Type"
+    if (
+      (stationName.match(/-/g) || []).length > 3 ||
+      stationName === "Default vehicle type"
+    ) {
       stationName = null;
     }
 


### PR DESCRIPTION
We had some override techniques in place, but nothing will be as reliable as this for removing that silly string!