### PR TITLE
fix(icons): Pass leg prop from classicicon to modeicon

### DIFF
--- a/packages/icons/src/icon-renderer.js
+++ b/packages/icons/src/icon-renderer.js
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-const StyledTable = styled.table`
+export const StyledTable = styled.table`
   border-collapse: collapse;
   border-spacing: 0;
   font-family: system-ui;

--- a/packages/icons/src/leg-icon.js
+++ b/packages/icons/src/leg-icon.js
@@ -20,7 +20,13 @@ const LegIcon = ({ getCompanyIcon, leg, ModeIcon, ...props }) => {
   // Do this for P&R, K&R and TNC trips without company icon
   if (iconStr && iconStr.startsWith("CAR")) iconStr = "CAR";
 
-  return <ModeIcon mode={iconStr} leg={leg} {...props} />;
+  const shorterLeg = {
+    longName: leg.longName,
+    shortName: leg.shortName,
+    routeId: leg.routeId
+  };
+
+  return <ModeIcon mode={iconStr} leg={shorterLeg} {...props} />;
 };
 
 LegIcon.propTypes = {

--- a/packages/icons/src/leg-icon.js
+++ b/packages/icons/src/leg-icon.js
@@ -22,11 +22,11 @@ const LegIcon = ({ getCompanyIcon, leg, ModeIcon, ...props }) => {
 
   const shorterLeg = {
     longName: leg.longName,
-    shortName: leg.shortName,
-    routeId: leg.routeId
+    routeId: leg.routeId,
+    shortName: leg.shortName
   };
 
-  return <ModeIcon mode={iconStr} leg={shorterLeg} {...props} />;
+  return <ModeIcon leg={shorterLeg} mode={iconStr} {...props} />;
 };
 
 LegIcon.propTypes = {

--- a/packages/icons/src/leg-icon.js
+++ b/packages/icons/src/leg-icon.js
@@ -20,7 +20,7 @@ const LegIcon = ({ getCompanyIcon, leg, ModeIcon, ...props }) => {
   // Do this for P&R, K&R and TNC trips without company icon
   if (iconStr && iconStr.startsWith("CAR")) iconStr = "CAR";
 
-  return <ModeIcon mode={iconStr} {...props} />;
+  return <ModeIcon mode={iconStr} leg={leg} {...props} />;
 };
 
 LegIcon.propTypes = {

--- a/packages/icons/src/stories/classic-mode-icon.story.js
+++ b/packages/icons/src/stories/classic-mode-icon.story.js
@@ -3,6 +3,7 @@ import React from "react";
 import ClassicModeIcon from "../classic-mode-icon";
 
 import ModeIconRenderer from "./mode-icon-renderer";
+import CustomModeIconRenderer from "./custom-mode-icon-renderer";
 
 export default {
   title: "Icons/ClassicModeIcon",
@@ -12,3 +13,5 @@ export default {
 export const ClassicModeIconExamples = () => (
   <ModeIconRenderer component={ClassicModeIcon} />
 );
+
+export const ModeIconOverrideByRouteId = () => <CustomModeIconRenderer />;

--- a/packages/icons/src/stories/custom-mode-icon-renderer.js
+++ b/packages/icons/src/stories/custom-mode-icon-renderer.js
@@ -1,0 +1,41 @@
+import React from "react";
+import { StyledTable } from "../icon-renderer";
+import ClassicModeIcon from "../classic-mode-icon";
+import CustomModeIcon from "./custom-mode-icon";
+
+const walkTransitWalkItinerary = require("@opentripplanner/itinerary-body/src/__mocks__/itineraries/walk-transit-walk.json");
+
+const exampleLeg = walkTransitWalkItinerary.legs[1];
+
+const CustomModeIconRenderer = () => {
+  return (
+    <StyledTable>
+      <thead>
+        <tr>
+          <th>{exampleLeg.mode}</th>
+          <th>Result</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Classic Mode</td>
+          <td>
+            <div>
+              <ClassicModeIcon mode={exampleLeg.mode} leg={exampleLeg} />
+            </div>
+          </td>
+        </tr>
+        <tr>
+          <td>Custom Mode by Route Id</td>
+          <td>
+            <div>
+              <CustomModeIcon mode={exampleLeg.mode} leg={exampleLeg} />
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </StyledTable>
+  );
+};
+
+export default CustomModeIconRenderer;

--- a/packages/icons/src/stories/custom-mode-icon-renderer.js
+++ b/packages/icons/src/stories/custom-mode-icon-renderer.js
@@ -7,35 +7,33 @@ const walkTransitWalkItinerary = require("@opentripplanner/itinerary-body/src/__
 
 const exampleLeg = walkTransitWalkItinerary.legs[1];
 
-const CustomModeIconRenderer = () => {
-  return (
-    <StyledTable>
-      <thead>
-        <tr>
-          <th>{exampleLeg.mode}</th>
-          <th>Result</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>Classic Mode</td>
-          <td>
-            <div>
-              <ClassicModeIcon mode={exampleLeg.mode} leg={exampleLeg} />
-            </div>
-          </td>
-        </tr>
-        <tr>
-          <td>Custom Mode by Route Id</td>
-          <td>
-            <div>
-              <CustomModeIcon mode={exampleLeg.mode} leg={exampleLeg} />
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </StyledTable>
-  );
-};
+const CustomModeIconRenderer = () => (
+  <StyledTable>
+    <thead>
+      <tr>
+        <th>{exampleLeg.mode}</th>
+        <th>Result</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Classic Mode</td>
+        <td>
+          <div>
+            <ClassicModeIcon leg={exampleLeg} mode={exampleLeg.mode} />
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td>Custom Mode by Route Id</td>
+        <td>
+          <div>
+            <CustomModeIcon mode={exampleLeg.mode} leg={exampleLeg} />
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </StyledTable>
+);
 
 export default CustomModeIconRenderer;

--- a/packages/icons/src/stories/custom-mode-icon.js
+++ b/packages/icons/src/stories/custom-mode-icon.js
@@ -3,10 +3,10 @@ import React from "react";
 import { ClassicGondola } from "../classic";
 import ClassicModeIcon from "../classic-mode-icon";
 
-function CustomModeIcon({ mode, leg, ...props }) {
+function CustomModeIcon({ leg, mode, ...props }) {
   if (!mode) return null;
   if (leg?.routeId === "TriMet:100") return <ClassicGondola {...props} />;
-  return <ClassicModeIcon mode={mode} leg={leg} props={props} />;
+  return <ClassicModeIcon leg={leg} mode={mode} props={props} />;
 }
 
 export default CustomModeIcon;

--- a/packages/icons/src/stories/custom-mode-icon.js
+++ b/packages/icons/src/stories/custom-mode-icon.js
@@ -1,0 +1,12 @@
+import React from "react";
+
+import { ClassicGondola } from "../classic";
+import ClassicModeIcon from "../classic-mode-icon";
+
+function CustomModeIcon({ mode, leg, ...props }) {
+  if (!mode) return null;
+  if (leg?.routeId === "TriMet:100") return <ClassicGondola {...props} />;
+  return <ClassicModeIcon mode={mode} leg={leg} props={props} />;
+}
+
+export default CustomModeIcon;

--- a/packages/trip-details/package.json
+++ b/packages/trip-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentripplanner/trip-details",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "description": "A component for displaying details about a trip planning itinerary",
   "main": "lib/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
In some cases, `ModeIcon` requires the `leg` prop, but `ClassicIcon` does not pass it. This fixes that!