### PR TITLE
Transit vehicle overlay show longname

### DIFF
--- a/packages/transit-vehicle-overlay/src/VehicleTooltip.tsx
+++ b/packages/transit-vehicle-overlay/src/VehicleTooltip.tsx
@@ -14,7 +14,7 @@ const Title = styled.span`
 export default function VehicleTooltip({
   vehicle
 }: VehicleComponentProps): JSX.Element {
-  const { routeShortName, routeType, seconds } = vehicle;
+  const { routeShortName, routeLongName, routeType, seconds } = vehicle;
 
   let name: JSX.Element = <>{routeShortName}</>;
   // This condition avoids processing long route names such as "Portland Streetcar".
@@ -29,7 +29,7 @@ export default function VehicleTooltip({
         description="Formats a route title"
         id="otpUi.TransitVehicleOverlay.routeTitle"
         values={{
-          name: routeShortName,
+          name: routeShortName || routeLongName,
           type: routeType || (
             <FormattedMessage
               defaultMessage={

--- a/packages/transit-vehicle-overlay/src/VehicleTooltip.tsx
+++ b/packages/transit-vehicle-overlay/src/VehicleTooltip.tsx
@@ -16,9 +16,11 @@ export default function VehicleTooltip({
 }: VehicleComponentProps): JSX.Element {
   const { routeShortName, routeLongName, routeType, seconds } = vehicle;
 
-  let name: JSX.Element = <>{routeShortName}</>;
+  const routeName = routeShortName || routeLongName;
+
+  let name: JSX.Element = <>{routeName}</>;
   // This condition avoids processing long route names such as "Portland Streetcar".
-  if (routeShortName?.length <= 5) {
+  if (routeName?.length <= 5) {
     // This produces text such as "MAX Green", "BUS 157",
     // or "Line A" if no routeType is provided.
     name = (
@@ -29,7 +31,7 @@ export default function VehicleTooltip({
         description="Formats a route title"
         id="otpUi.TransitVehicleOverlay.routeTitle"
         values={{
-          name: routeShortName || routeLongName,
+          name: routeName,
           type: routeType || (
             <FormattedMessage
               defaultMessage={

--- a/packages/transit-vehicle-overlay/src/index.tsx
+++ b/packages/transit-vehicle-overlay/src/index.tsx
@@ -97,7 +97,9 @@ const TransitVehicleOverlay = ({
       popupProps={{ offset: [-iconPixels / 2 - iconPadding, 0] }}
       position={[vehicle.lat, vehicle.lon]}
       tooltipContents={
-        vehicle.routeShortName && <TooltipSlot vehicle={vehicle} />
+        (vehicle.routeShortName || vehicle.routeLongName) && (
+          <TooltipSlot vehicle={vehicle} />
+        )
       }
     >
       <StyledContainer vehicle={vehicle}>


### PR DESCRIPTION
Makes the transit vehicle overlay use the long name if the route short name isn't available. This saves us from using a hack in OTP-RR to make the tooltip show up for agencies that don't publish a short name. 