### PR TITLE
fix: support new OTP geocoder `agencies` field

### DIFF
--- a/packages/geocoder/src/apis/otp/index.ts
+++ b/packages/geocoder/src/apis/otp/index.ts
@@ -17,6 +17,7 @@ type OTPGeocoderResponse = {
     name: string,
     id: string,
     agencies?: { id: string, name: string }[]
+    feedPublisher?: { name: string }
     modes: string[]
   }[]
 } | undefined

--- a/packages/geocoder/src/apis/otp/index.ts
+++ b/packages/geocoder/src/apis/otp/index.ts
@@ -16,6 +16,7 @@ type OTPGeocoderResponse = {
     code?: string | undefined,
     name: string,
     id: string,
+    agencies?: { id: string, name: string }[]
     modes: string[]
   }[]
 } | undefined

--- a/packages/geocoder/src/geocoders/otp.ts
+++ b/packages/geocoder/src/geocoders/otp.ts
@@ -5,6 +5,24 @@ import type { AutocompleteQuery, MultiGeocoderResponse } from "./types";
 import Geocoder from "./abstract-geocoder";
 import { OTPGeocoderResponse } from "../apis/otp";
 
+
+const generateLabel = stop => {
+  let brackets = ""
+  if (stop?.agencies?.[0]?.name) {
+    brackets += stop.agencies[0].name
+  } else if (stop?.feedPublisher?.name) {
+    brackets += stop.feedPublisher.name
+  }
+  if (stop?.code) {
+    if (brackets !== "") brackets += " "
+    brackets += stop.code
+  }
+
+  if (brackets === "") return stop.name
+
+  return `${stop.name} (${brackets})`
+}
+
 /**
  * Allows fetching results from OTP instance with the geocoder endpoint enabled
  */
@@ -21,33 +39,21 @@ export default class OTPGeocoder extends Geocoder {
 
 
   rewriteAutocompleteResponse(response: OTPGeocoderResponse): MultiGeocoderResponse {
-
-    const generateLabel = stop => {
-      let brackets = ""
-      if (stop?.agencies?.[0]?.name) {
-        brackets += stop.agencies[0].name
-      } else if (stop?.feedPublisher?.name) {
-        brackets += stop.feedPublisher.name
-      } 
-      if (stop?.code) {
-        if (brackets !== "") brackets += " "
-        brackets += stop.code
-      }
-
-      if (brackets === "") return stop.name
-
-    return `${stop.name} (${brackets})`
-    }
-
     return {
-        features: response?.results?.map(stop => ({
-            geometry: { type: "Point", coordinates: [stop.coordinate.lon, stop.coordinate.lat] },
-            id: stop.id, 
-            // TODO: if non-stops are supported, these need to be detected here and 
-            // this layer property updated accordingly
-            properties: { layer: "stops", source: "otp", modes: stop.modes, name: stop.name, label: generateLabel(stop) }, 
-            type: "Feature"
-        })),
+      features: response?.results?.map(stop => ({
+        geometry: { type: "Point", coordinates: [stop.coordinate.lon, stop.coordinate.lat] },
+        id: stop.id,
+        // TODO: if non-stops are supported, these need to be detected here and 
+        // this layer property updated accordingly
+        properties: {
+          layer: "stops",
+          source: "otp",
+          modes: stop.modes,
+          name: stop.name,
+          label: generateLabel(stop)
+        },
+        type: "Feature"
+      })),
       type: "FeatureCollection"
     };
   }

--- a/packages/geocoder/src/geocoders/otp.ts
+++ b/packages/geocoder/src/geocoders/otp.ts
@@ -21,7 +21,22 @@ export default class OTPGeocoder extends Geocoder {
 
 
   rewriteAutocompleteResponse(response: OTPGeocoderResponse): MultiGeocoderResponse {
-    const generateLabel = stop => stop.code ? `${stop.name} (${stop?.agencies?.[0] ? `${stop?.agencies?.[0].name} ` : ""}${stop.code})` : stop.name
+
+    const generateLabel = stop => {
+      let brackets = ""
+      if (stop?.agencies?.[0]?.name) {
+        brackets += stop.agencies[0].name
+      } else if (stop?.feedPublisher?.name) {
+        brackets += stop.feedPublisher.name
+      } 
+      if (stop?.code) {
+        brackets += ` ${stop.code}`
+      }
+
+      if (brackets === "") return stop.name
+
+    return `${stop.name} (${brackets})`
+    }
 
     return {
         features: response?.results?.map(stop => ({

--- a/packages/geocoder/src/geocoders/otp.ts
+++ b/packages/geocoder/src/geocoders/otp.ts
@@ -21,7 +21,7 @@ export default class OTPGeocoder extends Geocoder {
 
 
   rewriteAutocompleteResponse(response: OTPGeocoderResponse): MultiGeocoderResponse {
-    const generateLabel = stop => stop.code ? `${stop.name} (${stop.code})` : stop.name
+    const generateLabel = stop => stop.code ? `${stop.name} (${stop?.agencies?.[0] ? `${stop?.agencies?.[0].name} ` : ""}${stop.code})` : stop.name
 
     return {
         features: response?.results?.map(stop => ({

--- a/packages/geocoder/src/geocoders/otp.ts
+++ b/packages/geocoder/src/geocoders/otp.ts
@@ -30,7 +30,8 @@ export default class OTPGeocoder extends Geocoder {
         brackets += stop.feedPublisher.name
       } 
       if (stop?.code) {
-        brackets += ` ${stop.code}`
+        if (brackets !== "") brackets += " "
+        brackets += stop.code
       }
 
       if (brackets === "") return stop.name


### PR DESCRIPTION
Support for https://github.com/opentripplanner/OpenTripPlanner/pull/5634

No localization, but I think this is fine since there are no English words and all the GTFS will be non-localized anyway