### PR TITLE
fix(vehicle-rental-overlay): fix laggy zooming with vehicle overlay

### DIFF
--- a/packages/vehicle-rental-overlay/src/index.tsx
+++ b/packages/vehicle-rental-overlay/src/index.tsx
@@ -123,9 +123,9 @@ const VehicleRentalOverlay = ({
         setClickedVehicle(event.features?.[0].properties);
       });
     });
-    map.on("zoom", () => {
+    map.on("zoom", e => {
       // Avoid too many re-renders by only updating state if we are a whole number value different
-      const newZoom = map.getZoom();
+      const newZoom = e.map.getZoom();
       if (Math.floor(zoom) !== Math.floor(newZoom)) {
         setZoom(newZoom);
       }


### PR DESCRIPTION
The map zooming was a bit laggy when zooming around but this fixes it by pulling zoom data from the event rather than from up the react tree