### PR TITLE
vehicle rental overlay: avoid crash on missing event param

### DIFF
--- a/packages/vehicle-rental-overlay/src/index.tsx
+++ b/packages/vehicle-rental-overlay/src/index.tsx
@@ -125,8 +125,8 @@ const VehicleRentalOverlay = ({
     });
     map.on("zoom", e => {
       // Avoid too many re-renders by only updating state if we are a whole number value different
-      const newZoom = e.map.getZoom();
-      if (Math.floor(zoom) !== Math.floor(newZoom)) {
+      const { zoom: newZoom } = e.viewState;
+      if (Math.floor(zoom / 2) !== Math.floor(newZoom / 2)) {
         setZoom(newZoom);
       }
     });


### PR DESCRIPTION
Whoops! We accidentally published some code that didn't correctly read the zoom level. This PR reads it correctly. I checked the story, I checked it with otp-rr. I also lowered the UI adjustment threshold to improve performance 