### PR TITLE
feat(base-map): Add support for i18n on map controls

### DIFF
--- a/.storybook/react-intl.js
+++ b/.storybook/react-intl.js
@@ -15,6 +15,7 @@ const locales = ["en-US", "fr", "es", "vi", "ko", "zh", "unknown"];
  * FIXME: remove in favor of a loop on package names.
  */ 
 const packages = [
+  "base-map",
   "endpoints-overlay",
   "from-to-location-picker",
   "itinerary-body",
@@ -35,6 +36,7 @@ if (!isRunningJest()) {
   // Populate messages if not running snapshots.
   // (Message printouts would be unnecessary replicated in snapshots without that check.)
   packages.forEach((pkg) => {
+    console.log(pkg)
     locales.forEach((locale) => {
       // Chinese-simplified is assigned a special file name by Weblate.
       const localeFile = locale === "zh" ? "zh_Hans" : locale;

--- a/.storybook/react-intl.js
+++ b/.storybook/react-intl.js
@@ -36,7 +36,6 @@ if (!isRunningJest()) {
   // Populate messages if not running snapshots.
   // (Message printouts would be unnecessary replicated in snapshots without that check.)
   packages.forEach((pkg) => {
-    console.log(pkg)
     locales.forEach((locale) => {
       // Chinese-simplified is assigned a special file name by Weblate.
       const localeFile = locale === "zh" ? "zh_Hans" : locale;

--- a/packages/base-map/i18n/en-US.yml
+++ b/packages/base-map/i18n/en-US.yml
@@ -1,20 +1,9 @@
 otpUi:
   mapControls:
-    AttributionControl:
-      MapFeedback: Map feedback
-      ToggleAttribution: Toggle attribution
     CooperativeGesturesHandler:
       MacHelpText: Use ⌘ + scroll to zoom the map
       MobileHelpText: Use two fingers to move the map
       WindowsHelpText: Use Ctrl + scroll to zoom the map
-    FullscreenControl:
-      Enter: Enter fullscreen
-      Exit: Exit fullscreen
-    GeolocateControl:
-      FindMyLocation: Find my location
-      LocationNotAvailable: Location not available
-    LogoControl:
-      Title: MapLibre logo
     NavigationControl:
       ResetBearing: Reset bearing to north
       ZoomIn: Zoom in
@@ -25,6 +14,3 @@ otpUi:
       Meters: m
       Miles: mi
       NauticalMiles: nm
-    TerrainControl:
-      Disable: Disable terrain
-      Enable: Enable terrain

--- a/packages/base-map/i18n/en-US.yml
+++ b/packages/base-map/i18n/en-US.yml
@@ -1,0 +1,30 @@
+otpUi:
+  mapControls:
+    AttributionControl:
+      MapFeedback: Map feedback
+      ToggleAttribution: Toggle attribution
+    CooperativeGesturesHandler:
+      MacHelpText: Use ⌘ + scroll to zoom the map
+      MobileHelpText: Use two fingers to move the map
+      WindowsHelpText: Use Ctrl + scroll to zoom the map
+    FullscreenControl:
+      Enter: Enter fullscreen
+      Exit: Exit fullscreen
+    GeolocateControl:
+      FindMyLocation: Find my location
+      LocationNotAvailable: Location not available
+    LogoControl:
+      Title: MapLibre logo
+    NavigationControl:
+      ResetBearing: Reset bearing to north
+      ZoomIn: Zoom in
+      ZoomOut: Zoom out
+    ScaleControl:
+      Feet: ft
+      Kilometers: km
+      Meters: m
+      Miles: mi
+      NauticalMiles: nm
+    TerrainControl:
+      Disable: Disable terrain
+      Enable: Enable terrain

--- a/packages/base-map/i18n/es.yml
+++ b/packages/base-map/i18n/es.yml
@@ -1,0 +1,16 @@
+otpUi:
+  mapControls:
+    CooperativeGesturesHandler:
+      MacHelpText: Use ⌘ + scroll to zoom the map
+      MobileHelpText: Use two fingers to move the map
+      WindowsHelpText: Use Ctrl + scroll to zoom the map
+    NavigationControl:
+      ResetBearing: Dirección norte
+      ZoomIn: Acercar
+      ZoomOut: Alejar el zoom
+    ScaleControl:
+      Feet: ft
+      Kilometers: km
+      Meters: m
+      Miles: mi
+      NauticalMiles: nm

--- a/packages/base-map/i18n/es.yml
+++ b/packages/base-map/i18n/es.yml
@@ -1,13 +1,13 @@
 otpUi:
   mapControls:
     CooperativeGesturesHandler:
-      MacHelpText: Use ⌘ + scroll to zoom the map
-      MobileHelpText: Use two fingers to move the map
-      WindowsHelpText: Use Ctrl + scroll to zoom the map
+      MacHelpText: Use ⌘ +  desplazar para hacer zoom al mapa
+      MobileHelpText: Use dos dedos para mover el mapa
+      WindowsHelpText: Use Ctrl + desplazar para hacer zoom al mapa
     NavigationControl:
-      ResetBearing: Dirección norte
+      ResetBearing: Reestablecer en dirección norte
       ZoomIn: Acercar
-      ZoomOut: Alejar el zoom
+      ZoomOut: Alejar
     ScaleControl:
       Feet: ft
       Kilometers: km

--- a/packages/base-map/i18n/fr.yml
+++ b/packages/base-map/i18n/fr.yml
@@ -1,0 +1,16 @@
+otpUi:
+  mapControls:
+    CooperativeGesturesHandler:
+      MacHelpText: Utilisez ⌘ + défil pour zoomer sur la carte
+      MobileHelpText: Utilisez deux doigts pour déplacer la carte
+      WindowsHelpText: Utilisez Ctrl + défil pour zoomer sur la carte
+    NavigationControl:
+      ResetBearing: Repositioner le nord en haut de la carte
+      ZoomIn: Zoom avant
+      ZoomOut: Zoom arrière
+    ScaleControl:
+      Feet: ft
+      Kilometers: km
+      Meters: m
+      Miles: mi
+      NauticalMiles: nm

--- a/packages/base-map/i18n/i18n-exceptions.json
+++ b/packages/base-map/i18n/i18n-exceptions.json
@@ -5,7 +5,7 @@
       "MobileHelpText",
       "WindowsHelpText"
     ],
-    "otpUi.mapControls.NavigationControl.*Controls": [
+    "otpUi.mapControls.NavigationControl.*": [
       "ResetBearing",
       "ZoomIn",
       "ZoomOut"

--- a/packages/base-map/i18n/i18n-exceptions.json
+++ b/packages/base-map/i18n/i18n-exceptions.json
@@ -1,0 +1,21 @@
+{
+  "groups": {
+    "otpUi.mapControls.CooperativeGesturesHandler.*HelpText": [
+      "MacHelpText",
+      "MobileHelpText",
+      "WindowsHelpText"
+    ],
+    "otpUi.mapControls.NavigationControl.*Controls": [
+      "ResetBearing",
+      "ZoomIn",
+      "ZoomOut"
+    ],
+    "otpUi.mapControls.ScaleControl.*Measurements": [
+      "Feet",
+      "Kilometers",
+      "Meters",
+      "Miles",
+      "NauticalMiles"
+    ]
+  }
+}

--- a/packages/base-map/i18n/i18n-exceptions.json
+++ b/packages/base-map/i18n/i18n-exceptions.json
@@ -1,6 +1,6 @@
 {
   "groups": {
-    "otpUi.mapControls.CooperativeGesturesHandler.*HelpText": [
+    "otpUi.mapControls.CooperativeGesturesHandler.*": [
       "MacHelpText",
       "MobileHelpText",
       "WindowsHelpText"
@@ -10,7 +10,7 @@
       "ZoomIn",
       "ZoomOut"
     ],
-    "otpUi.mapControls.ScaleControl.*Measurements": [
+    "otpUi.mapControls.ScaleControl.*": [
       "Feet",
       "Kilometers",
       "Meters",

--- a/packages/base-map/i18n/ko.yml
+++ b/packages/base-map/i18n/ko.yml
@@ -1,9 +1,9 @@
 otpUi:
   mapControls:
     CooperativeGesturesHandler:
-      MacHelpText: Use ⌘ + scroll to zoom the map
-      MobileHelpText: Use two fingers to move the map
-      WindowsHelpText: Use Ctrl + scroll to zoom the map
+      MacHelpText: ⌘ + 스크롤을 사용하여 지도를 확대 또는 축소
+      MobileHelpText: 두 손가락을 사용하여 지도 이동
+      WindowsHelpText: 스크롤을 사용하여 지도를 확대 또는 축소
     NavigationControl:
       ResetBearing: 북쪽 방향 재설정
       ZoomIn: 확대

--- a/packages/base-map/i18n/ko.yml
+++ b/packages/base-map/i18n/ko.yml
@@ -1,0 +1,16 @@
+otpUi:
+  mapControls:
+    CooperativeGesturesHandler:
+      MacHelpText: Use ⌘ + scroll to zoom the map
+      MobileHelpText: Use two fingers to move the map
+      WindowsHelpText: Use Ctrl + scroll to zoom the map
+    NavigationControl:
+      ResetBearing: 북쪽 방향 재설정
+      ZoomIn: 확대
+      ZoomOut: 축소
+    ScaleControl:
+      Feet: ft
+      Kilometers: km
+      Meters: m
+      Miles: mi
+      NauticalMiles: nm

--- a/packages/base-map/i18n/ru.yml
+++ b/packages/base-map/i18n/ru.yml
@@ -1,0 +1,16 @@
+otpUi:
+  mapControls:
+    CooperativeGesturesHandler:
+      MacHelpText: Use ⌘ + scroll to zoom the map
+      MobileHelpText: Use two fingers to move the map
+      WindowsHelpText: Use Ctrl + scroll to zoom the map
+    NavigationControl:
+      ResetBearing: Сбросить азимут на север
+      ZoomIn: Увеличить масштаб
+      ZoomOut: Уменьшить масштаб
+    ScaleControl:
+      Feet: ft
+      Kilometers: km
+      Meters: m
+      Miles: mi
+      NauticalMiles: nm

--- a/packages/base-map/i18n/ru.yml
+++ b/packages/base-map/i18n/ru.yml
@@ -1,9 +1,9 @@
 otpUi:
   mapControls:
     CooperativeGesturesHandler:
-      MacHelpText: Use ⌘ + scroll to zoom the map
-      MobileHelpText: Use two fingers to move the map
-      WindowsHelpText: Use Ctrl + scroll to zoom the map
+      MacHelpText: Используйте комбинацию ⌘ + прокрутка, чтобы изменить масштаб карты
+      MobileHelpText: Перемещение карты выполняется с помощью двух пальцев
+      WindowsHelpText: Используйте комбинацию Ctrl + прокрутка, чтобы изменить масштаб карты
     NavigationControl:
       ResetBearing: Сбросить азимут на север
       ZoomIn: Увеличить масштаб

--- a/packages/base-map/i18n/tl.yml
+++ b/packages/base-map/i18n/tl.yml
@@ -1,0 +1,16 @@
+otpUi:
+  mapControls:
+    CooperativeGesturesHandler:
+      MacHelpText: Use ⌘ + scroll to zoom the map
+      MobileHelpText: Use two fingers to move the map
+      WindowsHelpText: Use Ctrl + scroll to zoom the map
+    NavigationControl:
+      ResetBearing: I-reset ang bearing sa hilaga
+      ZoomIn: Mag-zoom In
+      ZoomOut: Mag-zoom Out
+    ScaleControl:
+      Feet: ft
+      Kilometers: km
+      Meters: m
+      Miles: mi
+      NauticalMiles: nm

--- a/packages/base-map/i18n/tl.yml
+++ b/packages/base-map/i18n/tl.yml
@@ -1,9 +1,9 @@
 otpUi:
   mapControls:
     CooperativeGesturesHandler:
-      MacHelpText: Use ⌘ + scroll to zoom the map
-      MobileHelpText: Use two fingers to move the map
-      WindowsHelpText: Use Ctrl + scroll to zoom the map
+      MacHelpText: Gamitin ang ⌘ + scroll para mag-zoom sa mapa
+      MobileHelpText: Gumamit ng dalawang daliri para igalaw ang mapa
+      WindowsHelpText: Gamitin ang Ctrl + scroll para mag-zoom sa mapa
     NavigationControl:
       ResetBearing: I-reset ang bearing sa hilaga
       ZoomIn: Mag-zoom In

--- a/packages/base-map/i18n/vi.yml
+++ b/packages/base-map/i18n/vi.yml
@@ -1,9 +1,9 @@
 otpUi:
   mapControls:
     CooperativeGesturesHandler:
-      MacHelpText: Use ⌘ + scroll to zoom the map
-      MobileHelpText: Use two fingers to move the map
-      WindowsHelpText: Use Ctrl + scroll to zoom the map
+      MacHelpText: Sử dụng phím ⌘ + nút cuộn để phóng to/thu nhỏ bản đồ
+      MobileHelpText: Sử dụng hai ngón tay để di chuyển bản đồ
+      WindowsHelpText: Sử dụng phím Ctrl + nút cuộn để phóng to/thu nhỏ bản đồ
     NavigationControl:
       ResetBearing: Đặt lại phương hướng về hướng bắc
       ZoomIn: Phóng to

--- a/packages/base-map/i18n/vi.yml
+++ b/packages/base-map/i18n/vi.yml
@@ -1,0 +1,16 @@
+otpUi:
+  mapControls:
+    CooperativeGesturesHandler:
+      MacHelpText: Use ⌘ + scroll to zoom the map
+      MobileHelpText: Use two fingers to move the map
+      WindowsHelpText: Use Ctrl + scroll to zoom the map
+    NavigationControl:
+      ResetBearing: Đặt lại phương hướng về hướng bắc
+      ZoomIn: Phóng to
+      ZoomOut: Thu nhỏ
+    ScaleControl:
+      Feet: ft
+      Kilometers: km
+      Meters: m
+      Miles: mi
+      NauticalMiles: nm

--- a/packages/base-map/i18n/zh_Hans.yml
+++ b/packages/base-map/i18n/zh_Hans.yml
@@ -1,11 +1,11 @@
 otpUi:
   mapControls:
     CooperativeGesturesHandler:
-      MacHelpText: Use ⌘ + scroll to zoom the map
-      MobileHelpText: Use two fingers to move the map
-      WindowsHelpText: Use Ctrl + scroll to zoom the map
+      MacHelpText: 使用⌘並捲動，可縮放地圖
+      MobileHelpText: 以兩指移動地圖
+      WindowsHelpText: 使用Ctrl並捲動，可縮放地圖
     NavigationControl:
-      ResetBearing: 重置方位向北
+      ResetBearing: 將方位重設為北方
       ZoomIn: 放大
       ZoomOut: 缩小
     ScaleControl:

--- a/packages/base-map/i18n/zh_Hans.yml
+++ b/packages/base-map/i18n/zh_Hans.yml
@@ -1,0 +1,16 @@
+otpUi:
+  mapControls:
+    CooperativeGesturesHandler:
+      MacHelpText: Use ⌘ + scroll to zoom the map
+      MobileHelpText: Use two fingers to move the map
+      WindowsHelpText: Use Ctrl + scroll to zoom the map
+    NavigationControl:
+      ResetBearing: 重置方位向北
+      ZoomIn: 放大
+      ZoomOut: 缩小
+    ScaleControl:
+      Feet: ft
+      Kilometers: km
+      Meters: m
+      Miles: mi
+      NauticalMiles: nm

--- a/packages/base-map/src/index.tsx
+++ b/packages/base-map/src/index.tsx
@@ -7,7 +7,7 @@ import { useIntl } from "react-intl";
 import * as Styled from "./styled";
 import * as util from "./util";
 import MarkerWithPopup from "./MarkerWithPopup";
-import mapControlTranslationObject from "./mapControlLocale";
+import generateMapControlTranslations from "./mapControlLocale";
 
 /**
  * The BaseMap component renders a MapLibre map
@@ -137,7 +137,7 @@ const BaseMap = ({
       {...mapLibreProps}
       id={id}
       latitude={viewState.latitude}
-      locale={mapControlTranslationObject(intl)}
+      locale={generateMapControlTranslations(intl)}
       longitude={viewState.longitude}
       mapLib={maplibregl}
       mapStyle={activeBaseLayer}

--- a/packages/base-map/src/index.tsx
+++ b/packages/base-map/src/index.tsx
@@ -2,9 +2,12 @@ import React, { useCallback, useEffect, useState } from "react";
 import { Map, MapProps } from "react-map-gl";
 import maplibregl, { Event } from "maplibre-gl";
 
+import { useIntl } from "react-intl";
+
 import * as Styled from "./styled";
 import * as util from "./util";
 import MarkerWithPopup from "./MarkerWithPopup";
+import mapControlFields from "./mapControlLocale";
 
 /**
  * The BaseMap component renders a MapLibre map
@@ -76,6 +79,8 @@ const BaseMap = ({
     zoom: initZoom
   });
 
+  const intl = useIntl();
+
   // Firefox and Safari on iOS: hover is not triggered when the user touches the layer selector
   // (unlike Firefox or Chromium on Android), so we have to detect touch and trigger hover ourselves.
   const [fakeMobileHover, setFakeHover] = useState(false);
@@ -132,6 +137,7 @@ const BaseMap = ({
       {...mapLibreProps}
       id={id}
       latitude={viewState.latitude}
+      locale={mapControlFields(intl)}
       longitude={viewState.longitude}
       mapLib={maplibregl}
       mapStyle={activeBaseLayer}

--- a/packages/base-map/src/index.tsx
+++ b/packages/base-map/src/index.tsx
@@ -7,7 +7,7 @@ import { useIntl } from "react-intl";
 import * as Styled from "./styled";
 import * as util from "./util";
 import MarkerWithPopup from "./MarkerWithPopup";
-import mapControlFields from "./mapControlLocale";
+import mapControlTranslationObject from "./mapControlLocale";
 
 /**
  * The BaseMap component renders a MapLibre map
@@ -137,7 +137,7 @@ const BaseMap = ({
       {...mapLibreProps}
       id={id}
       latitude={viewState.latitude}
-      locale={mapControlFields(intl)}
+      locale={mapControlTranslationObject(intl)}
       longitude={viewState.longitude}
       mapLib={maplibregl}
       mapStyle={activeBaseLayer}

--- a/packages/base-map/src/mapControlLocale.tsx
+++ b/packages/base-map/src/mapControlLocale.tsx
@@ -3,69 +3,39 @@ import { IntlShape } from "react-intl";
 // Creates a language file to pass to MapLibre that has this format:
 // https://github.com/maplibre/maplibre-gl-js/blob/main/src/ui/default_locale.ts
 
-const mapControlFields = (intl: IntlShape): any => {
-  return {
-    "AttributionControl.ToggleAttribution": intl.formatMessage({
-      id: "otpUi.mapControls.AttributionControl.ToggleAttribution"
-    }),
-    "AttributionControl.MapFeedback": intl.formatMessage({
-      id: "otpUi.mapControls.AttributionControl.MapFeedback"
-    }),
-    "FullscreenControl.Enter": intl.formatMessage({
-      id: "otpUi.mapControls.FullscreenControl.Enter"
-    }),
-    "FullscreenControl.Exit": intl.formatMessage({
-      id: "otpUi.mapControls.FullscreenControl.Exit"
-    }),
-    "GeolocateControl.FindMyLocation": intl.formatMessage({
-      id: "otpUi.mapControls.GeolocateControl.FindMyLocation"
-    }),
-    "GeolocateControl.LocationNotAvailable": intl.formatMessage({
-      id: "otpUi.mapControls.GeolocateControl.LocationNotAvailable"
-    }),
-    "LogoControl.Title": intl.formatMessage({
-      id: "otpUi.mapControls.LogoControl.Title"
-    }),
-    "NavigationControl.ResetBearing": intl.formatMessage({
-      id: "otpUi.mapControls.NavigationControl.ResetBearing"
-    }),
-    "NavigationControl.ZoomIn": intl.formatMessage({
-      id: "otpUi.mapControls.NavigationControl.ZoomIn"
-    }),
-    "NavigationControl.ZoomOut": intl.formatMessage({
-      id: "otpUi.mapControls.NavigationControl.ZoomOut"
-    }),
-    "ScaleControl.Feet": intl.formatMessage({
-      id: "otpUi.mapControls.ScaleControl.Feet"
-    }),
-    "ScaleControl.Meters": intl.formatMessage({
-      id: "otpUi.mapControls.ScaleControl.Meters"
-    }),
-    "ScaleControl.Kilometers": intl.formatMessage({
-      id: "otpUi.mapControls.ScaleControl.Kilometers"
-    }),
-    "ScaleControl.Miles": intl.formatMessage({
-      id: "otpUi.mapControls.ScaleControl.Miles"
-    }),
-    "ScaleControl.NauticalMiles": intl.formatMessage({
-      id: "otpUi.mapControls.ScaleControl.NauticalMiles"
-    }),
-    "TerrainControl.Enable": intl.formatMessage({
-      id: "otpUi.mapControls.TerrainControl.Enable"
-    }),
-    "TerrainControl.Disable": intl.formatMessage({
-      id: "otpUi.mapControls.TerrainControl.Disable"
-    }),
-    "CooperativeGesturesHandler.WindowsHelpText": intl.formatMessage({
-      id: "otpUi.mapControls.CooperativeGesturesHandler.WindowsHelpText"
-    }),
-    "CooperativeGesturesHandler.MacHelpText": intl.formatMessage({
-      id: "otpUi.mapControls.CooperativeGesturesHandler.MacHelpText"
-    }),
-    "CooperativeGesturesHandler.MobileHelpText": intl.formatMessage({
-      id: "otpUi.mapControls.CooperativeGesturesHandler.MobileHelpText"
-    })
-  };
+const MAP_CONTROL_TRANSLATION_KEYS = [
+  "AttributionControl.ToggleAttribution",
+  "AttributionControl.MapFeedback",
+  "FullscreenControl.Enter",
+  "FullscreenControl.Exit",
+  "GeolocateControl.FindMyLocation",
+  "GeolocateControl.LocationNotAvailable",
+  "LogoControl.Title",
+  "NavigationControl.ResetBearing",
+  "NavigationControl.ZoomIn",
+  "NavigationControl.ZoomOut",
+  "ScaleControl.Feet",
+  "ScaleControl.Meters",
+  "ScaleControl.Kilometers",
+  "ScaleControl.Miles",
+  "ScaleControl.NauticalMiles",
+  "TerrainControl.Enable",
+  "TerrainControl.Disable",
+  "CooperativeGesturesHandler.WindowsHelpText",
+  "CooperativeGesturesHandler.MacHelpText",
+  "CooperativeGesturesHandler.MobileHelpText"
+];
+
+const mapControlTranslationObject = (intl: IntlShape): any => {
+  const languageObject = {};
+
+  MAP_CONTROL_TRANSLATION_KEYS.forEach(x => {
+    languageObject[x] = intl.formatMessage({
+      id: `otpUi.mapControls.${x}`
+    });
+  });
+
+  return languageObject;
 };
 
-export default mapControlFields;
+export default mapControlTranslationObject;

--- a/packages/base-map/src/mapControlLocale.tsx
+++ b/packages/base-map/src/mapControlLocale.tsx
@@ -4,13 +4,6 @@ import { IntlShape } from "react-intl";
 // https://github.com/maplibre/maplibre-gl-js/blob/main/src/ui/default_locale.ts
 
 const MAP_CONTROL_TRANSLATION_KEYS = [
-  "AttributionControl.ToggleAttribution",
-  "AttributionControl.MapFeedback",
-  "FullscreenControl.Enter",
-  "FullscreenControl.Exit",
-  "GeolocateControl.FindMyLocation",
-  "GeolocateControl.LocationNotAvailable",
-  "LogoControl.Title",
   "NavigationControl.ResetBearing",
   "NavigationControl.ZoomIn",
   "NavigationControl.ZoomOut",
@@ -19,8 +12,6 @@ const MAP_CONTROL_TRANSLATION_KEYS = [
   "ScaleControl.Kilometers",
   "ScaleControl.Miles",
   "ScaleControl.NauticalMiles",
-  "TerrainControl.Enable",
-  "TerrainControl.Disable",
   "CooperativeGesturesHandler.WindowsHelpText",
   "CooperativeGesturesHandler.MacHelpText",
   "CooperativeGesturesHandler.MobileHelpText"
@@ -28,7 +19,7 @@ const MAP_CONTROL_TRANSLATION_KEYS = [
 
 const mapControlTranslationObject = (
   intl: IntlShape
-): { [key: string]: string } => {
+): Record<string, string> => {
   const languageObject = {};
 
   MAP_CONTROL_TRANSLATION_KEYS.forEach(x => {

--- a/packages/base-map/src/mapControlLocale.tsx
+++ b/packages/base-map/src/mapControlLocale.tsx
@@ -1,0 +1,71 @@
+import { IntlShape } from "react-intl";
+
+// Creates a language file to pass to MapLibre that has this format:
+// https://github.com/maplibre/maplibre-gl-js/blob/main/src/ui/default_locale.ts
+
+const mapControlFields = (intl: IntlShape): any => {
+  return {
+    "AttributionControl.ToggleAttribution": intl.formatMessage({
+      id: "otpUi.mapControls.AttributionControl.ToggleAttribution"
+    }),
+    "AttributionControl.MapFeedback": intl.formatMessage({
+      id: "otpUi.mapControls.AttributionControl.MapFeedback"
+    }),
+    "FullscreenControl.Enter": intl.formatMessage({
+      id: "otpUi.mapControls.FullscreenControl.Enter"
+    }),
+    "FullscreenControl.Exit": intl.formatMessage({
+      id: "otpUi.mapControls.FullscreenControl.Exit"
+    }),
+    "GeolocateControl.FindMyLocation": intl.formatMessage({
+      id: "otpUi.mapControls.GeolocateControl.FindMyLocation"
+    }),
+    "GeolocateControl.LocationNotAvailable": intl.formatMessage({
+      id: "otpUi.mapControls.GeolocateControl.LocationNotAvailable"
+    }),
+    "LogoControl.Title": intl.formatMessage({
+      id: "otpUi.mapControls.LogoControl.Title"
+    }),
+    "NavigationControl.ResetBearing": intl.formatMessage({
+      id: "otpUi.mapControls.NavigationControl.ResetBearing"
+    }),
+    "NavigationControl.ZoomIn": intl.formatMessage({
+      id: "otpUi.mapControls.NavigationControl.ZoomIn"
+    }),
+    "NavigationControl.ZoomOut": intl.formatMessage({
+      id: "otpUi.mapControls.NavigationControl.ZoomOut"
+    }),
+    "ScaleControl.Feet": intl.formatMessage({
+      id: "otpUi.mapControls.ScaleControl.Feet"
+    }),
+    "ScaleControl.Meters": intl.formatMessage({
+      id: "otpUi.mapControls.ScaleControl.Meters"
+    }),
+    "ScaleControl.Kilometers": intl.formatMessage({
+      id: "otpUi.mapControls.ScaleControl.Kilometers"
+    }),
+    "ScaleControl.Miles": intl.formatMessage({
+      id: "otpUi.mapControls.ScaleControl.Miles"
+    }),
+    "ScaleControl.NauticalMiles": intl.formatMessage({
+      id: "otpUi.mapControls.ScaleControl.NauticalMiles"
+    }),
+    "TerrainControl.Enable": intl.formatMessage({
+      id: "otpUi.mapControls.TerrainControl.Enable"
+    }),
+    "TerrainControl.Disable": intl.formatMessage({
+      id: "otpUi.mapControls.TerrainControl.Disable"
+    }),
+    "CooperativeGesturesHandler.WindowsHelpText": intl.formatMessage({
+      id: "otpUi.mapControls.CooperativeGesturesHandler.WindowsHelpText"
+    }),
+    "CooperativeGesturesHandler.MacHelpText": intl.formatMessage({
+      id: "otpUi.mapControls.CooperativeGesturesHandler.MacHelpText"
+    }),
+    "CooperativeGesturesHandler.MobileHelpText": intl.formatMessage({
+      id: "otpUi.mapControls.CooperativeGesturesHandler.MobileHelpText"
+    })
+  };
+};
+
+export default mapControlFields;

--- a/packages/base-map/src/mapControlLocale.tsx
+++ b/packages/base-map/src/mapControlLocale.tsx
@@ -26,7 +26,9 @@ const MAP_CONTROL_TRANSLATION_KEYS = [
   "CooperativeGesturesHandler.MobileHelpText"
 ];
 
-const mapControlTranslationObject = (intl: IntlShape): any => {
+const mapControlTranslationObject = (
+  intl: IntlShape
+): { [key: string]: string } => {
   const languageObject = {};
 
   MAP_CONTROL_TRANSLATION_KEYS.forEach(x => {

--- a/packages/base-map/src/mapControlLocale.tsx
+++ b/packages/base-map/src/mapControlLocale.tsx
@@ -3,6 +3,7 @@ import { IntlShape } from "react-intl";
 // Creates a language file to pass to MapLibre that has this format:
 // https://github.com/maplibre/maplibre-gl-js/blob/main/src/ui/default_locale.ts
 
+// TODO: Generate keys from YAML
 const MAP_CONTROL_TRANSLATION_KEYS = [
   "NavigationControl.ResetBearing",
   "NavigationControl.ZoomIn",
@@ -17,7 +18,7 @@ const MAP_CONTROL_TRANSLATION_KEYS = [
   "CooperativeGesturesHandler.MobileHelpText"
 ];
 
-const mapControlTranslationObject = (
+const generateMapControlTranslations = (
   intl: IntlShape
 ): Record<string, string> => {
   const languageObject = {};
@@ -31,4 +32,4 @@ const mapControlTranslationObject = (
   return languageObject;
 };
 
-export default mapControlTranslationObject;
+export default generateMapControlTranslations;


### PR DESCRIPTION
Passes translated strings to MapLibre to override their default map controls.