### PR TITLE
fix: add `areaStops` layer support

### DIFF
--- a/packages/geocoder/package.json
+++ b/packages/geocoder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentripplanner/geocoder",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Geocoding tools for multiple geocoding providers",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/packages/otp2-tile-overlay/src/Otp2TileOverlay.story.tsx
+++ b/packages/otp2-tile-overlay/src/Otp2TileOverlay.story.tsx
@@ -29,7 +29,7 @@ export const OtpTileLayer = (): JSX.Element => {
       stops loaded from OTP tiles.
       <BaseMap center={[0, 0]} zoom={3} style={{ height: "80vh" }}>
         {generateOTP2TileLayers(
-          [{ type: "stops" }],
+          [{ type: "stops" }, { type: "areaStops" }],
           `${endpoint}/routers/default/vectorTiles`
         )}
       </BaseMap>

--- a/packages/otp2-tile-overlay/src/index.tsx
+++ b/packages/otp2-tile-overlay/src/index.tsx
@@ -136,7 +136,6 @@ const OTP2TileLayerWithPopup = ({
     filter = ["!=", ["get", "routes"], ["literal", "[]"]]
   }
 
-  // Weird bug: the isArea layers only work properly with node 16!
   const isArea = AREA_TYPES.includes(type)
   return (
     <>
@@ -149,8 +148,7 @@ const OTP2TileLayerWithPopup = ({
             "#",
             ["case", ["!=", ["index-of", ",", ["get", "routeColors"]], -1], ["slice", ["get", "routeColors"], 0, ["index-of", ",", ["get", "routeColors"]]], ["get", "routeColors"]]
           ],
-          "fill-opacity": 0.3,
-          "fill-outline-color": "#333",
+          "fill-opacity": 0.2,
         }}
         source-layer={type}
         source={SOURCE_ID}
@@ -160,17 +158,17 @@ const OTP2TileLayerWithPopup = ({
         filter={filter}
         id={`${id}-outline`}
         layout={{ "line-join": "round", "line-cap": "round" }}
-        source={SOURCE_ID}
-        source-layer={type}
         paint={{
           "line-color": [
             "concat",
             "#",
             ["case", ["!=", ["index-of", ",", ["get", "routeColors"]], -1], ["slice", ["get", "routeColors"], 0, ["index-of", ",", ["get", "routeColors"]]], ["get", "routeColors"]]
           ],
-          "line-opacity": 1,
-          "line-width": 4
+          "line-opacity": 0.8,
+          "line-width": 3
         }}
+        source-layer={type}
+        source={SOURCE_ID}
         type="line"
       />}
       {!isArea && <Layer

--- a/packages/otp2-tile-overlay/src/index.tsx
+++ b/packages/otp2-tile-overlay/src/index.tsx
@@ -143,8 +143,6 @@ const OTP2TileLayerWithPopup = ({
       {isArea && <Layer
         filter={filter}
         id={`${id}-fill`}
-        source={SOURCE_ID}
-        source-layer={type}
         paint={{
           "fill-color": [
             "concat",
@@ -154,6 +152,8 @@ const OTP2TileLayerWithPopup = ({
           "fill-opacity": 0.3,
           "fill-outline-color": "#333",
         }}
+        source-layer={type}
+        source={SOURCE_ID}
         type="fill"
       />}
       {isArea && <Layer

--- a/packages/otp2-tile-overlay/src/util.ts
+++ b/packages/otp2-tile-overlay/src/util.ts
@@ -29,6 +29,26 @@ export const generateLayerPaint = (color?: string): any => {
       "circle-stroke-color": "#333",
       "circle-stroke-width": 3
     },
+    areaStops: {
+      "circle-color": [
+        "concat",
+        "#",
+        [
+          "case",
+          ["!=", ["index-of", ",", ["get", "routeColors"]], -1],
+          [
+            "slice",
+            ["get", "routeColors"],
+            0,
+            ["index-of", ",", ["get", "routeColors"]]
+          ],
+          ["get", "routeColors"]
+        ]
+      ],
+      "circle-opacity": 0.9,
+      "circle-stroke-color": "#333",
+      "circle-stroke-width": 2
+    },
     stops: {
       "circle-color": color || "#fff",
       "circle-opacity": 0.9,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3246,6 +3246,11 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
+"@opentripplanner/types@6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/types/-/types-6.4.0.tgz#6f7a3475ea982c7b7d8b2f1383a6d775dfabe62a"
+  integrity sha512-PS+CUwETLf0WzAUZg3qiey+SBigaf0CfknKF1XMOM+zJVc2c8nN34hgnwV7sS+RKs030KZFAgIn8p035ErcBuQ==
+
 "@peculiar/asn1-schema@^2.1.6", "@peculiar/asn1-schema@^2.3.0":
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.3.3.tgz#21418e1f3819e0b353ceff0c2dad8ccb61acd777"


### PR DESCRIPTION
This add support for the new OTP areaStops layer. I feel like implementation is not perfect. Looking for advice