### PR TITLE
Only render routeName badge when routeName exists

### DIFF
--- a/packages/transitive-overlay/src/route-layers.ts
+++ b/packages/transitive-overlay/src/route-layers.ts
@@ -37,7 +37,7 @@ export function patternToRouteFeature(
   const properties = {
     color: `#${route.route_color || "000080"}`,
     name: routeName,
-    nameUpper: routeNameUpper,
+    nameUpper: routeName.length === 0 ? "" : routeNameUpper,
     routeType: route.route_type,
     textColor: `#${route.route_text_color || "eee"}`,
     type: "route"


### PR DESCRIPTION
Small fix to only show background for transitive route name badge if we are passing a route name.


| Before | After |
|--------|-------|
|![image](https://github.com/opentripplanner/otp-ui/assets/115499534/6cb9c946-230c-411e-bf57-8c6e21d86941)|![image](https://github.com/opentripplanner/otp-ui/assets/115499534/c95d77c7-b07f-4706-bae1-425d90bc07d7)|