### PR TITLE
OTP2 Elevation Data Compatibility 

### DIFF
--- a/packages/core-utils/src/planQuery.graphql
+++ b/packages/core-utils/src/planQuery.graphql
@@ -213,9 +213,9 @@ query Plan(
           }
           area
           distance
-          elevationProfile {
-            distance
-            elevation
+          elevation: elevationProfile {
+            first: distance
+            second: elevation
           }
           lat
           lon


### PR DESCRIPTION
We did not support elevation data from OTP2. This PR changes our query to work with our OTP1 compatible elevation UI