### PR TITLE
Itinerary-body: Add trip accessiblity translations

### DIFF
--- a/packages/itinerary-body/i18n/ko.yml
+++ b/packages/itinerary-body/i18n/ko.yml
@@ -81,6 +81,12 @@ otpUi:
       car: 차로
       escooter: 전자 스쿠터로
       walk: 걸어서
+    tripAccessibility:
+      inaccessible: 액세스 불가
+      itineraryAccessibility: "이 이동편의 휠체어 액세스 가능 여부:\_"
+      legAccessibility: "이 이동편 구간의 휠체어 액세스 가능 여부:\_"
+      likelyAccessible: 액세스 가능 확률 높음
+      unclear: 알 수 없음
     viewOnMap: 지도 보기
   TransitLegBody:
     AlertsBody:

--- a/packages/itinerary-body/i18n/ru.yml
+++ b/packages/itinerary-body/i18n/ru.yml
@@ -80,6 +80,12 @@ otpUi:
       car: на авто
       escooter: на электросамокате
       walk: пешком
+    tripAccessibility:
+      inaccessible: недоступно
+      itineraryAccessibility: "Доступность для инвалидных колясок на этом отрезке поездки: \_"
+      legAccessibility: "Доступность для инвалидных колясок на этом отрезке поездки: \_"
+      likelyAccessible: Скорее всего доступно
+      unclear: неизвестно
     viewOnMap: Просмотреть на карте
   TransitLegBody:
     AlertsBody:

--- a/packages/itinerary-body/i18n/tl.yml
+++ b/packages/itinerary-body/i18n/tl.yml
@@ -84,6 +84,12 @@ otpUi:
       car: sasakyan
       escooter: e-scooter
       walk: walking
+    tripAccessibility:
+      inaccessible: hindi ma-access
+      itineraryAccessibility: "Pagiging accessible sa wheelchair ng biyaheng ito:\_"
+      legAccessibility: "Pagiging accessible sa wheelchair ng leg ng biyaheng ito:\_"
+      likelyAccessible: malamang na naa-access
+      unclear: hindi alam
     viewOnMap: Tingnan sa mapa
   TransitLegBody:
     AlertsBody:

--- a/packages/itinerary-body/i18n/vi.yml
+++ b/packages/itinerary-body/i18n/vi.yml
@@ -81,6 +81,12 @@ otpUi:
       car: bằng xe hơi
       escooter: bằng xe tay ga điện tử
       walk: bằng cách đi bộ
+    tripAccessibility:
+      inaccessible: không thể tiếp cận
+      itineraryAccessibility: "Khả năng tiếp cận của xe lăn trong chuyến đi này:\_"
+      legAccessibility: "Khả năng tiếp cận của xe lăn trong đoạn này của chuyến đi:\_"
+      likelyAccessible: có thể tiếp cận
+      unclear: không rõ
     viewOnMap: Xem trên bản đồ
   TransitLegBody:
     AlertsBody:

--- a/packages/itinerary-body/i18n/zh_Hans.yml
+++ b/packages/itinerary-body/i18n/zh_Hans.yml
@@ -81,6 +81,12 @@ otpUi:
       car: 乘车
       escooter: 乘坐电动滑板车
       walk: 步行出
+    tripAccessibility:
+      inaccessible: 无法访问
+      itineraryAccessibility: 这段行程的轮椅无障碍通道情况：
+      legAccessibility: 这段步行行程的轮椅无障碍通道情况：
+      likelyAccessible: 可能可访问
+      unclear: 未知
     viewOnMap: 在地图上查看
   TransitLegBody:
     AlertsBody:


### PR DESCRIPTION
This PR adds translations provided by client for trip accessibility labels and qualifiers.