### PR TITLE
fix(core-utils): remove query params conflicting with new mode selector

### DIFF
--- a/packages/core-utils/src/__tests__/__snapshots__/query-params.ts.snap
+++ b/packages/core-utils/src/__tests__/__snapshots__/query-params.ts.snap
@@ -222,21 +222,6 @@ Array [
   },
   Object {
     "applicable": [Function],
-    "high": 10,
-    "label": "walk reluctance",
-    "labelHigh": "More Transit",
-    "labelLow": "More Walking",
-    "low": 1,
-    "name": "walkReluctance",
-    "routingTypes": Array [
-      "ITINERARY",
-      "PROFILE",
-    ],
-    "selector": "SLIDER",
-    "step": 0.5,
-  },
-  Object {
-    "applicable": [Function],
     "default": 20,
     "label": "Max Bike Time",
     "name": "maxBikeTime",
@@ -399,18 +384,6 @@ Array [
     "routingTypes": Array [
       "ITINERARY",
     ],
-  },
-  Object {
-    "applicable": [Function],
-    "default": false,
-    "icon": <ForwardRef(Wheelchair) />,
-    "label": "Prefer Wheelchair Accessible Routes",
-    "name": "wheelchair",
-    "routingTypes": Array [
-      "ITINERARY",
-      "PROFILE",
-    ],
-    "selector": "CHECKBOX",
   },
   Object {
     "name": "bannedRoutes",

--- a/packages/core-utils/src/__tests__/__snapshots__/query.js.snap
+++ b/packages/core-utils/src/__tests__/__snapshots__/query.js.snap
@@ -25,7 +25,6 @@ Object {
   "time": "19:34",
   "to": null,
   "watts": 250,
-  "wheelchair": false,
 }
 `;
 
@@ -54,7 +53,6 @@ Object {
   "time": "19:34",
   "to": null,
   "watts": 250,
-  "wheelchair": false,
 }
 `;
 

--- a/packages/core-utils/src/query-params.js
+++ b/packages/core-utils/src/query-params.js
@@ -3,8 +3,6 @@
 
 // This is only used within stories
 import cloneDeep from "lodash.clonedeep";
-import React from "react";
-import { Wheelchair } from "@styled-icons/foundation/Wheelchair";
 
 import {
   isTransit,
@@ -366,23 +364,6 @@ const queryParams = [
     ]
   },
   {
-    name: "walkReluctance",
-    routingTypes: ["ITINERARY", "PROFILE"],
-    selector: "SLIDER",
-    low: 1,
-    high: 10,
-    step: 0.5,
-    label: "walk reluctance",
-    labelLow: "More Walking",
-    labelHigh: "More Transit",
-    applicable: query =>
-      /* Since this query variable isn't in this list, it's not included in the generated query
-       * It does however allow us to determine if we should show the OTP1 max walk distance
-       * dropdown or the OTP2 walk reluctance slider
-       */
-      !!query.otp2 && query.mode && query.mode.indexOf("WALK") !== -1
-  },
-  {
     /* maxBikeTime -- the maximum time the user will spend biking in minutes */
     name: "maxBikeTime",
     routingTypes: ["PROFILE"],
@@ -599,34 +580,6 @@ const queryParams = [
     name: "companies",
     routingTypes: ["ITINERARY"]
   },
-
-  {
-    /* wheelchair -- whether the user requires a wheelchair-accessible trip */
-    name: "wheelchair",
-    routingTypes: ["ITINERARY", "PROFILE"],
-    default: false,
-    selector: "CHECKBOX",
-    label: "Prefer Wheelchair Accessible Routes",
-    icon: <Wheelchair />,
-    applicable: (query, config) => {
-      if (!query.mode || !config.modes) return false;
-      const configModes = (config.modes.accessModes || []).concat(
-        config.modes.transitModes || []
-      );
-      return query.mode.split(",").some(mode => {
-        const configMode = configModes.find(m => m.mode === mode);
-        if (!configMode || !configMode.showWheelchairSetting) return false;
-        if (
-          configMode.company &&
-          (!query.companies ||
-            !query.companies.split(",").includes(configMode.company))
-        )
-          return false;
-        return true;
-      });
-    }
-  },
-
   {
     name: "bannedRoutes",
     routingTypes: ["ITINERARY"]

--- a/packages/core-utils/src/query.js
+++ b/packages/core-utils/src/query.js
@@ -15,9 +15,7 @@ import {
 /* The list of default parameters considered in the settings panel */
 
 export const defaultParams = [
-  "wheelchair",
   "maxWalkDistance",
-  "walkReluctance",
   "maxWalkTime",
   "maxBikeDistance",
   "maxBikeTime",


### PR DESCRIPTION
BREAKING CHANGE: removes wheelchair and walkReluctance query parameters

Really keeping it simple with this one... Only removing the two parameters that are handled by the new mode selector settings dropdowns. 

Please check the general settings panel story. Does this matter? The settings selector panel and trip options stuff is unchanged.