### PR TITLE
fix: support `maxVehicleAge` realtime vehicle filtering based on last update

### DIFF
--- a/packages/transit-vehicle-overlay/src/index.tsx
+++ b/packages/transit-vehicle-overlay/src/index.tsx
@@ -40,6 +40,13 @@ type Props = {
   iconPixels?: number;
 
   /**
+   * This number of seconds is used to determine the cutoff for ignoring a realtime vehicle
+   * update. This is helpful to remove vehicles that have stopped broadcasting their location
+   * from the map.
+   */
+  maxVehicleAge: number;
+
+  /**
    * Component that renders the icons given transit modes.
    */
   ModeIcon: FC<ModeIconProps>;
@@ -70,13 +77,17 @@ const TransitVehicleOverlay = ({
   IconContainer = DefaultIconContainer,
   iconPadding = 2,
   iconPixels = 20,
+  maxVehicleAge = Infinity,
   ModeIcon,
   TooltipSlot = VehicleTooltip,
   VehicleIcon = DefaultVehicleIcon,
   vehicles
 }: Props): ReactNode => {
   const validVehicles = vehicles?.filter(
-    vehicle => !!vehicle?.lat && !!vehicle?.lon
+    vehicle =>
+      !!vehicle?.lat &&
+      !!vehicle?.lon &&
+      Date.now() - (vehicle?.lastUpdated || Date.now()) < maxVehicleAge
   );
   // Don't render if no map or no vehicles are defined.
   // (ZoomBasedMarkers will also not render below the minimum zoom threshold defined in the symbols prop.)

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -104,6 +104,7 @@ export type TransitVehicle = {
 
   status?: string;
   reportDate?: string;
+  lastUpdated?: number;
   seconds?: number;
 
   stopSequence?: number;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -97,25 +97,25 @@ export type ZoomBasedSymbol = {
  * Describes the objects from the real-time vehicle service.
  */
 export type TransitVehicle = {
-  routeShortName?: string;
-  routeLongName?: string;
-  routeType?: string;
   routeColor?: string;
+  routeLongName?: string;
+  routeShortName?: string;
+  routeType?: string;
 
-  status?: string;
-  reportDate?: string;
   lastUpdated?: number;
+  reportDate?: string;
   seconds?: number;
+  status?: string;
 
-  stopSequence?: number;
-  stopId?: string;
-  vehicleId?: string;
-  tripId?: string;
   blockId?: string;
+  stopId?: string;
+  stopSequence?: number;
+  tripId?: string;
+  vehicleId?: string;
 
+  heading?: number;
   lat?: number;
   lon?: number;
-  heading?: number;
 };
 
 export type OTPTransitVehicle = TransitVehicle & {


### PR DESCRIPTION
RT Vehicle updates have a lastUpdated field that we previously always ignored. This sometimes resulted in a bunch of busses piling up in the yard because they hadn't sent an update in forever. This PR introduces a new prop that can be used to hide vehicles that haven't updated their location in a certain amount of time

cc @fpurcell 