### PR TITLE
feat(itinerary-body): Fix alerts a11y

### DIFF
--- a/packages/itinerary-body/i18n/en-US.yml
+++ b/packages/itinerary-body/i18n/en-US.yml
@@ -90,8 +90,10 @@ otpUi:
     viewOnMap: View on map
   TransitLegBody:
     AlertsBody:
+      alertLinkText: See alert on agency website
       effectiveDate: Effective as of {dateTime, date, long}
       effectiveTimeAndDate: Effective as of {dateTime, time, short}, {day}
+      externalLink: (External link)
       today: Today
       tomorrow: Tomorrow
       yesterday: Yesterday

--- a/packages/itinerary-body/i18n/en-US.yml
+++ b/packages/itinerary-body/i18n/en-US.yml
@@ -90,11 +90,12 @@ otpUi:
     viewOnMap: View on map
   TransitLegBody:
     AlertsBody:
-      agency: agency
       alertLinkText: See alert on {agency} website
       effectiveDate: Effective as of {dateTime, date, long}
       effectiveTimeAndDate: Effective as of {dateTime, time, short}, {day}
       externalLink: (External link)
+      linkOpensNewWindow: (Opens new window)
+      noAgencyAlertLinkText: See alert on agency website
       today: Today
       tomorrow: Tomorrow
       yesterday: Yesterday

--- a/packages/itinerary-body/i18n/en-US.yml
+++ b/packages/itinerary-body/i18n/en-US.yml
@@ -90,6 +90,7 @@ otpUi:
     viewOnMap: View on map
   TransitLegBody:
     AlertsBody:
+      agency: agency
       alertLinkText: See alert on {agency} website
       effectiveDate: Effective as of {dateTime, date, long}
       effectiveTimeAndDate: Effective as of {dateTime, time, short}, {day}

--- a/packages/itinerary-body/i18n/en-US.yml
+++ b/packages/itinerary-body/i18n/en-US.yml
@@ -90,7 +90,7 @@ otpUi:
     viewOnMap: View on map
   TransitLegBody:
     AlertsBody:
-      alertLinkText: See alert on agency website
+      alertLinkText: See alert on {agency} website
       effectiveDate: Effective as of {dateTime, date, long}
       effectiveTimeAndDate: Effective as of {dateTime, time, short}, {day}
       externalLink: (External link)

--- a/packages/itinerary-body/i18n/en-US.yml
+++ b/packages/itinerary-body/i18n/en-US.yml
@@ -93,7 +93,6 @@ otpUi:
       alertLinkText: See alert on {agency} website
       effectiveDate: Effective as of {dateTime, date, long}
       effectiveTimeAndDate: Effective as of {dateTime, time, short}, {day}
-      externalLink: (External link)
       linkOpensNewWindow: (Opens new window)
       noAgencyAlertLinkText: See alert on agency website
       today: Today

--- a/packages/itinerary-body/i18n/fr.yml
+++ b/packages/itinerary-body/i18n/fr.yml
@@ -94,8 +94,11 @@ otpUi:
     viewOnMap: Afficher sur le plan
   TransitLegBody:
     AlertsBody:
+      alertLinkText: Voir l'alerte sur le site de {agency}
       effectiveDate: À partir du {dateTime, date, long}
       effectiveTimeAndDate: À partir de {dateTime, time, short}, {day}
+      linkOpensNewWindow: (Ouvre une nouvelle fenêtre)
+      noAgencyAlertLinkText: Voir l'alerte sur le site du transporteur
       today: aujourd'hui
       tomorrow: demain
       yesterday: hier

--- a/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
@@ -3,7 +3,7 @@ import { toDate, utcToZonedTime } from "date-fns-tz";
 import coreUtils from "@opentripplanner/core-utils";
 import { Alert } from "@opentripplanner/types";
 import React, { FunctionComponent, ReactElement } from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { FormattedMessage } from "react-intl";
 
 import { ExternalLinkAlt } from "@styled-icons/fa-solid";
 import * as S from "../styled";
@@ -70,10 +70,6 @@ export default function AlertsBody({
   timeZone = getUserTimezone()
 }: Props): ReactElement {
   if (typeof alerts !== "object") return null;
-  const intl = useIntl();
-  const defaultAgencyName = intl.formatMessage({
-    id: "otpUi.TransitLegBody.AlertsBody.agency"
-  });
   return (
     <S.TransitAlerts>
       {alerts
@@ -138,22 +134,35 @@ export default function AlertsBody({
                       }}
                     />
                   )}
-                  {alertUrl.trim() && (
+                  {alertUrl?.trim() && (
                     <S.TransitAlertExternalLink href={alertUrl} target="_blank">
                       <ExternalLinkAlt height={10} />
-                      <FormattedMessage
-                        defaultMessage={
-                          defaultMessages[
-                            "otpUi.TransitLegBody.AlertsBody.alertLinkText"
-                          ]
-                        }
-                        description="Text with the date an alert takes effect"
-                        id="otpUi.TransitLegBody.AlertsBody.alertLinkText"
-                        values={{ agency: agencyName || defaultAgencyName }}
-                      />
+                      {agencyName ? (
+                        <FormattedMessage
+                          defaultMessage={
+                            defaultMessages[
+                              "otpUi.TransitLegBody.AlertsBody.alertLinkText"
+                            ]
+                          }
+                          description="Describes how link directs to agency website"
+                          id="otpUi.TransitLegBody.AlertsBody.alertLinkText"
+                          values={{ agency: agencyName }}
+                        />
+                      ) : (
+                        <FormattedMessage
+                          defaultMessage={
+                            defaultMessages[
+                              "otpUi.TransitLegBody.AlertsBody.noAgencyAlertLinkText"
+                            ]
+                          }
+                          description="Describes how link directs to agency website, but does not name agency"
+                          id="otpUi.TransitLegBody.AlertsBody.noAgencyAlertLinkText"
+                        />
+                      )}
+
                       <S.InvisibleAdditionalDetails>
                         {" "}
-                        <FormattedMessage id="otpUi.TransitLegBody.AlertsBody.externalLink" />
+                        <FormattedMessage id="otpUi.TransitLegBody.AlertsBody.linkOpensNewWindow" />
                       </S.InvisibleAdditionalDetails>
                     </S.TransitAlertExternalLink>
                   )}

--- a/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
@@ -134,7 +134,6 @@ export default function AlertsBody({
                       }}
                     />
                   )}
-                  <br />
                   {alertUrl.trim() && (
                     <S.TransitAlertExternalLink href={alertUrl} target="_blank">
                       <ExternalLinkAlt height={10} />

--- a/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
@@ -12,6 +12,7 @@ import { defaultMessages } from "../util";
 const { getUserTimezone, getCurrentDate } = coreUtils.time;
 
 interface Props {
+  agencyName: string;
   alerts: Alert[];
   AlertIcon?: FunctionComponent;
   timeZone?: string;
@@ -63,6 +64,7 @@ function AlertDay({ dayDiff }: AlertDayProps) {
 }
 
 export default function AlertsBody({
+  agencyName,
   alerts,
   AlertIcon = S.DefaultAlertBodyIcon,
   timeZone = getUserTimezone()
@@ -144,6 +146,7 @@ export default function AlertsBody({
                         }
                         description="Text with the date an alert takes effect"
                         id="otpUi.TransitLegBody.AlertsBody.alertLinkText"
+                        values={{ agency: agencyName }}
                       />{" "}
                       <S.InvisibleAdditionalDetails>
                         <FormattedMessage id="otpUi.TransitLegBody.AlertsBody.externalLink" />

--- a/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
@@ -3,7 +3,7 @@ import { toDate, utcToZonedTime } from "date-fns-tz";
 import coreUtils from "@opentripplanner/core-utils";
 import { Alert } from "@opentripplanner/types";
 import React, { FunctionComponent, ReactElement } from "react";
-import { FormattedMessage } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { ExternalLinkAlt } from "@styled-icons/fa-solid";
 import * as S from "../styled";
@@ -12,7 +12,7 @@ import { defaultMessages } from "../util";
 const { getUserTimezone, getCurrentDate } = coreUtils.time;
 
 interface Props {
-  agencyName: string;
+  agencyName?: string;
   alerts: Alert[];
   AlertIcon?: FunctionComponent;
   timeZone?: string;
@@ -70,6 +70,10 @@ export default function AlertsBody({
   timeZone = getUserTimezone()
 }: Props): ReactElement {
   if (typeof alerts !== "object") return null;
+  const intl = useIntl();
+  const defaultAgencyName = intl.formatMessage({
+    id: "otpUi.TransitLegBody.AlertsBody.agency"
+  });
   return (
     <S.TransitAlerts>
       {alerts
@@ -145,9 +149,10 @@ export default function AlertsBody({
                         }
                         description="Text with the date an alert takes effect"
                         id="otpUi.TransitLegBody.AlertsBody.alertLinkText"
-                        values={{ agency: agencyName }}
-                      />{" "}
+                        values={{ agency: agencyName || defaultAgencyName }}
+                      />
                       <S.InvisibleAdditionalDetails>
+                        {" "}
                         <FormattedMessage id="otpUi.TransitLegBody.AlertsBody.externalLink" />
                       </S.InvisibleAdditionalDetails>
                     </S.TransitAlertExternalLink>

--- a/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
@@ -5,6 +5,7 @@ import { Alert } from "@opentripplanner/types";
 import React, { FunctionComponent, ReactElement } from "react";
 import { FormattedMessage } from "react-intl";
 
+import { ExternalLinkAlt } from "@styled-icons/fa-solid";
 import * as S from "../styled";
 import { defaultMessages } from "../util";
 
@@ -94,7 +95,7 @@ export default function AlertsBody({
             const dayDiff = differenceInCalendarDays(compareDate, today);
 
             return (
-              <S.TransitAlert key={i} href={alertUrl}>
+              <S.TransitAlert key={i}>
                 <S.TransitAlertIconContainer>
                   <AlertIcon />
                 </S.TransitAlertIconContainer>
@@ -130,6 +131,24 @@ export default function AlertsBody({
                         dateTime: effectiveStartDate * 1000
                       }}
                     />
+                  )}
+                  <br />
+                  {alertUrl.trim() && (
+                    <S.TransitAlertExternalLink href={alertUrl} target="_blank">
+                      <ExternalLinkAlt height={10} />
+                      <FormattedMessage
+                        defaultMessage={
+                          defaultMessages[
+                            "otpUi.TransitLegBody.AlertsBody.alertLinkText"
+                          ]
+                        }
+                        description="Text with the date an alert takes effect"
+                        id="otpUi.TransitLegBody.AlertsBody.alertLinkText"
+                      />{" "}
+                      <S.InvisibleAdditionalDetails>
+                        <FormattedMessage id="otpUi.TransitLegBody.AlertsBody.externalLink" />
+                      </S.InvisibleAdditionalDetails>
+                    </S.TransitAlertExternalLink>
                   )}
                 </S.TransitAlertEffectiveDate>
               </S.TransitAlert>

--- a/packages/itinerary-body/src/TransitLegBody/index.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/index.tsx
@@ -288,7 +288,11 @@ class TransitLegBody extends Component<Props, State> {
             )}
             {/* Alerts toggle */}
             {alerts?.length > 0 && (
-              <S.TransitAlertToggle onClick={this.onToggleAlertsClick}>
+              <S.TransitAlertToggle
+                isButton={!shouldOnlyShowAlertsExpanded}
+                as={shouldOnlyShowAlertsExpanded && "div"}
+                onClick={this.onToggleAlertsClick}
+              >
                 <AlertToggleIcon />{" "}
                 <FormattedMessage
                   defaultMessage={
@@ -301,17 +305,19 @@ class TransitLegBody extends Component<Props, State> {
                   }}
                 />
                 {!shouldOnlyShowAlertsExpanded && (
-                  <S.CaretToggle expanded={alertsExpanded} />
+                  <>
+                    <S.CaretToggle expanded={alertsExpanded} />
+                    <S.InvisibleAdditionalDetails>
+                      <FormattedMessage
+                        defaultMessage={
+                          defaultMessages["otpUi.TransitLegBody.expandDetails"]
+                        }
+                        description="Screen reader text added to expand steps"
+                        id="otpUi.TransitLegBody.expandDetails"
+                      />
+                    </S.InvisibleAdditionalDetails>
+                  </>
                 )}
-                <S.InvisibleAdditionalDetails>
-                  <FormattedMessage
-                    defaultMessage={
-                      defaultMessages["otpUi.TransitLegBody.expandDetails"]
-                    }
-                    description="Screen reader text added to expand steps"
-                    id="otpUi.TransitLegBody.expandDetails"
-                  />
-                </S.InvisibleAdditionalDetails>
               </S.TransitAlertToggle>
             )}
 

--- a/packages/itinerary-body/src/TransitLegBody/index.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/index.tsx
@@ -318,6 +318,7 @@ class TransitLegBody extends Component<Props, State> {
             {/* The Alerts body, if visible */}
             <AnimateHeight duration={500} height={expandAlerts ? "auto" : 0}>
               <AlertsBody
+                agencyName={agencyName}
                 alerts={leg.alerts}
                 AlertIcon={AlertBodyIcon}
                 timeZone={timeZone}

--- a/packages/itinerary-body/src/TransitLegBody/index.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/index.tsx
@@ -303,6 +303,15 @@ class TransitLegBody extends Component<Props, State> {
                 {!shouldOnlyShowAlertsExpanded && (
                   <S.CaretToggle expanded={alertsExpanded} />
                 )}
+                <S.InvisibleAdditionalDetails>
+                  <FormattedMessage
+                    defaultMessage={
+                      defaultMessages["otpUi.TransitLegBody.expandDetails"]
+                    }
+                    description="Screen reader text added to expand steps"
+                    id="otpUi.TransitLegBody.expandDetails"
+                  />
+                </S.InvisibleAdditionalDetails>
               </S.TransitAlertToggle>
             )}
 

--- a/packages/itinerary-body/src/styled.tsx
+++ b/packages/itinerary-body/src/styled.tsx
@@ -650,13 +650,20 @@ export const StopRow = styled.li`
   position: relative;
 `;
 
-export const TransitAlert = styled.a`
+export const TransitAlert = styled.li`
   background-color: #eee;
   border-radius: 4px;
   color: #000;
   display: block;
   margin-top: 5px;
   padding: 8px;
+  text-decoration: none;
+`;
+
+export const TransitAlertExternalLink = styled.a`
+  align-items: center;
+  display: flex;
+  gap: 5px;
   text-decoration: none;
 `;
 
@@ -684,7 +691,7 @@ export const TransitAlertIconContainer = styled.div`
   font-size: 18px;
 `;
 
-export const TransitAlerts = styled.div`
+export const TransitAlerts = styled.ul`
   display: block;
   margin-top: 3px;
 `;

--- a/packages/itinerary-body/src/styled.tsx
+++ b/packages/itinerary-body/src/styled.tsx
@@ -664,6 +664,7 @@ export const TransitAlertExternalLink = styled.a`
   align-items: center;
   display: flex;
   gap: 5px;
+  margin-top: 0.5em;
   text-decoration: none;
 
   &:hover {

--- a/packages/itinerary-body/src/styled.tsx
+++ b/packages/itinerary-body/src/styled.tsx
@@ -661,7 +661,7 @@ export const TransitAlert = styled.li`
 `;
 
 export const TransitAlertExternalLink = styled.a`
-  align-items: center;
+  align-items: baseline;
   display: flex;
   gap: 5px;
   margin-top: 0.5em;

--- a/packages/itinerary-body/src/styled.tsx
+++ b/packages/itinerary-body/src/styled.tsx
@@ -665,6 +665,10 @@ export const TransitAlertExternalLink = styled.a`
   display: flex;
   gap: 5px;
   text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
 `;
 
 export const TransitAlertBody = styled.div`

--- a/packages/itinerary-body/src/styled.tsx
+++ b/packages/itinerary-body/src/styled.tsx
@@ -699,11 +699,14 @@ export const TransitAlertIconContainer = styled.div`
 export const TransitAlerts = styled.ul`
   display: block;
   margin-top: 3px;
+  padding: 0;
 `;
 
-export const TransitAlertToggle = styled(TransparentButton)`
+export const TransitAlertToggle = styled(TransparentButton)<{
+  isButton?: boolean;
+}>`
   color: #d14727;
-  cursor: pointer;
+  cursor: ${props => (props.isButton ? "cursor" : "auto")};
   display: inline-block;
   font-weight: 400;
   margin-top: 8px;


### PR DESCRIPTION
- Creates a `ul` and `li` for each transit alert
- Creates a clear alert hyperlink that opens in external window (if url is provided)
- Adds more invisible context for AT 