### PR TITLE
Support `search` for OTP Geocoder

### DIFF
--- a/packages/geocoder/src/apis/otp/index.ts
+++ b/packages/geocoder/src/apis/otp/index.ts
@@ -1,6 +1,6 @@
 
 // eslint-disable-next-line prettier/prettier
-import type { AutocompleteQuery } from "../../geocoders/types"
+import type { AutocompleteQuery, SearchQuery } from "../../geocoders/types"
 
 type FetchArgs = {
   url: string
@@ -48,8 +48,11 @@ async function autocomplete({
   })
 }
 
-function search(): Promise<unknown> { console.warn("Not implemented"); return null }
-function reverse(): Promise<unknown> { console.warn("Not implemented"); return null }
+async function search(args: SearchQuery): Promise<OTPGeocoderResponse> {
+  return autocomplete(args);
+} 
+
+function reverse(): Promise<OTPGeocoderResponse> { console.warn("Not implemented"); return null }
 
 
 export { autocomplete, reverse, search };

--- a/packages/geocoder/src/geocoders/otp.ts
+++ b/packages/geocoder/src/geocoders/otp.ts
@@ -1,6 +1,6 @@
 // Prettier does not support typescript annotation
 // eslint-disable-next-line prettier/prettier
-import type { AutocompleteQuery, MultiGeocoderResponse } from "./types";
+import type { AutocompleteQuery, MultiGeocoderResponse, SearchQuery } from "./types";
 
 import Geocoder from "./abstract-geocoder";
 import { OTPGeocoderResponse } from "../apis/otp";
@@ -35,6 +35,10 @@ export default class OTPGeocoder extends Geocoder {
       url: baseUrl,
       ...query
     };
+  }
+
+  getSearchQuery(query: SearchQuery): SearchQuery {
+      return this.getAutocompleteQuery(query)
   }
 
 


### PR DESCRIPTION
Right now it causes crashes. We use autocomplete to achieve the same behavior 