### PR TITLE
fix: support distance display in metric units

### DIFF
--- a/packages/itinerary-body/src/AccessLegBody/access-leg-steps.tsx
+++ b/packages/itinerary-body/src/AccessLegBody/access-leg-steps.tsx
@@ -12,6 +12,7 @@ interface Props {
   mapillaryCallback?: (id: string) => void;
   mapillaryKey?: string;
   steps: Step[];
+  useMetricUnits?: boolean;
 }
 
 /**
@@ -20,7 +21,8 @@ interface Props {
 export default function AccessLegSteps({
   steps,
   mapillaryCallback,
-  mapillaryKey
+  mapillaryKey,
+  useMetricUnits = false
 }: Props): ReactElement {
   return (
     <S.Steps>
@@ -33,7 +35,7 @@ export default function AccessLegSteps({
             </S.StepIconContainer>
 
             <S.StepDescriptionContainer>
-              <AccessLegStep step={step} />
+              <AccessLegStep step={step} useMetricUnits={useMetricUnits} />
               <MapillaryButton
                 clickCallback={mapillaryCallback}
                 coords={{ lat, lon }}

--- a/packages/itinerary-body/src/AccessLegBody/access-leg-summary.tsx
+++ b/packages/itinerary-body/src/AccessLegBody/access-leg-summary.tsx
@@ -12,6 +12,7 @@ interface Props {
   LegIcon: LegIconComponent;
   onSummaryClick: () => void;
   showLegIcon: boolean;
+  useMetricUnits?: boolean;
 }
 
 export default function AccessLegSummary({
@@ -19,7 +20,8 @@ export default function AccessLegSummary({
   leg,
   LegIcon,
   onSummaryClick,
-  showLegIcon
+  showLegIcon,
+  useMetricUnits = false
 }: Props): ReactElement {
   return (
     <S.LegClickable>
@@ -32,7 +34,11 @@ export default function AccessLegSummary({
           )}
         </S.LegIconAndRouteShortName>
         <S.InvisibleAdditionalDetails> - </S.InvisibleAdditionalDetails>
-        <AccessLegDescription config={config} leg={leg} />
+        <AccessLegDescription
+          config={config}
+          leg={leg}
+          useMetricUnits={useMetricUnits}
+        />
         <S.LegClickableButton onClick={onSummaryClick}>
           <S.InvisibleAdditionalDetails>
             <FormattedMessage

--- a/packages/itinerary-body/src/AccessLegBody/index.tsx
+++ b/packages/itinerary-body/src/AccessLegBody/index.tsx
@@ -38,6 +38,7 @@ interface Props {
   showElevationProfile: boolean;
   showLegIcon: boolean;
   TransitLegSubheader?: FunctionComponent<TransitLegSubheaderProps>;
+  useMetricUnits?: boolean;
 }
 
 interface State {
@@ -77,7 +78,8 @@ class AccessLegBody extends Component<Props, State> {
       setLegDiagram,
       showElevationProfile,
       showLegIcon,
-      TransitLegSubheader
+      TransitLegSubheader,
+      useMetricUnits = false
     } = this.props;
     const { expanded } = this.state;
 
@@ -93,6 +95,7 @@ class AccessLegBody extends Component<Props, State> {
           LegIcon={LegIcon}
           onSummaryClick={this.onSummaryClick}
           showLegIcon={showLegIcon}
+          useMetricUnits={useMetricUnits}
         />
       );
     }
@@ -121,6 +124,7 @@ class AccessLegBody extends Component<Props, State> {
             LegIcon={LegIcon}
             onSummaryClick={this.onSummaryClick}
             showLegIcon={showLegIcon}
+            useMetricUnits={useMetricUnits}
           />
           <S.LegDetails>
             {hideDrivingDirections ? (
@@ -163,6 +167,7 @@ class AccessLegBody extends Component<Props, State> {
                     mapillaryCallback={mapillaryCallback}
                     mapillaryKey={mapillaryKey}
                     steps={leg.steps}
+                    useMetricUnits={useMetricUnits}
                   />
                 </AnimateHeight>
               </>

--- a/packages/itinerary-body/src/AccessLegBody/tnc-leg.tsx
+++ b/packages/itinerary-body/src/AccessLegBody/tnc-leg.tsx
@@ -19,6 +19,7 @@ interface Props {
   onSummaryClick: () => void;
   showLegIcon: boolean;
   UBER_CLIENT_ID?: string;
+  useMetricUnits?: boolean;
 }
 
 export default function TNCLeg({
@@ -29,7 +30,8 @@ export default function TNCLeg({
   LYFT_CLIENT_ID = "",
   onSummaryClick,
   showLegIcon,
-  UBER_CLIENT_ID = ""
+  UBER_CLIENT_ID = "",
+  useMetricUnits = false
 }: Props): ReactElement {
   const universalLinks = {
     uber: `https://m.uber.com/${
@@ -74,6 +76,7 @@ export default function TNCLeg({
           LegIcon={LegIcon}
           onSummaryClick={onSummaryClick}
           showLegIcon={showLegIcon}
+          useMetricUnits={useMetricUnits}
         />
 
         {/* The "Book Ride" button */}

--- a/packages/itinerary-body/src/ItineraryBody/index.tsx
+++ b/packages/itinerary-body/src/ItineraryBody/index.tsx
@@ -41,7 +41,8 @@ const ItineraryBody = ({
   TimeColumnContent,
   toRouteAbbreviation = defaultRouteAbbr,
   TransitLegSubheader,
-  TransitLegSummary
+  TransitLegSummary,
+  useMetricUnits = false
 }: ItineraryBodyProps): ReactElement => {
   /*
     TODO: replace component should update logic? companies is simply used to
@@ -91,6 +92,7 @@ const ItineraryBody = ({
           toRouteAbbreviation={toRouteAbbreviation}
           TransitLegSubheader={TransitLegSubheader}
           TransitLegSummary={TransitLegSummary}
+          useMetricUnits={useMetricUnits}
         />
       );
     }

--- a/packages/itinerary-body/src/ItineraryBody/place-row.tsx
+++ b/packages/itinerary-body/src/ItineraryBody/place-row.tsx
@@ -47,7 +47,8 @@ export default function PlaceRow({
   TimeColumnContent = DefaultTimeColumnContent,
   toRouteAbbreviation,
   TransitLegSubheader,
-  TransitLegSummary
+  TransitLegSummary,
+  useMetricUnits
 }: PlaceRowProps): ReactElement {
   // NOTE: Previously there was a check for itineraries that changed vehicles
   // at a single stop, which would render the stop place the same as the
@@ -175,6 +176,7 @@ export default function PlaceRow({
               showElevationProfile={showElevationProfile}
               showLegIcon={showLegIcon}
               TransitLegSubheader={TransitLegSubheader}
+              useMetricUnits={useMetricUnits}
             />
           ))}
       </S.PlaceDetails>

--- a/packages/itinerary-body/src/defaults/access-leg-description.tsx
+++ b/packages/itinerary-body/src/defaults/access-leg-description.tsx
@@ -9,6 +9,7 @@ import { defaultMessages, getPlaceName } from "../util";
 interface Props extends HTMLAttributes<HTMLSpanElement> {
   config: Config;
   leg: Leg;
+  useMetricUnits?: boolean;
 }
 
 /**
@@ -71,7 +72,8 @@ export default function AccessLegDescription({
   className,
   config,
   leg,
-  style
+  style,
+  useMetricUnits
 }: Props): ReactElement {
   const intl = useIntl();
   // Replace the Vertex Type for BIKESHARE with VEHICLE as we do not know that
@@ -98,8 +100,11 @@ export default function AccessLegDescription({
           description="Summarizes an access leg, including distance"
           id="otpUi.AccessLegBody.summaryAndDistance"
           values={{
-            // TODO: Implement metric vs imperial (up until now it's just imperial).
-            distance: humanizeDistanceString(leg.distance, false, intl),
+            distance: humanizeDistanceString(
+              leg.distance,
+              useMetricUnits,
+              intl
+            ),
             mode: modeContent,
             place: placeContent
           }}

--- a/packages/itinerary-body/src/defaults/access-leg-step.tsx
+++ b/packages/itinerary-body/src/defaults/access-leg-step.tsx
@@ -12,6 +12,7 @@ import StreetName from "./street-name";
 
 interface Props extends HTMLAttributes<HTMLSpanElement> {
   step: Step;
+  useMetricUnits?: boolean;
 }
 
 /**
@@ -20,7 +21,8 @@ interface Props extends HTMLAttributes<HTMLSpanElement> {
 export default function AccessLegStep({
   className,
   step,
-  style
+  style,
+  useMetricUnits = false
 }: Props): ReactElement {
   const { absoluteDirection, relativeDirection, streetName } = step;
   const intl = useIntl();
@@ -104,10 +106,9 @@ export default function AccessLegStep({
     // for styled-components support.
     <span className={className} style={style}>
       {stepContent}
-      {/* TODO: Implement metric vs imperial (up until now it's just imperial). */}
       {step?.distance > 0 && (
         <S.StepLength>
-          {humanizeDistanceString(step.distance, false, intl)}
+          {humanizeDistanceString(step.distance, useMetricUnits, intl)}
         </S.StepLength>
       )}
     </span>

--- a/packages/itinerary-body/src/stories/OtpRrItineraryBody.story.tsx
+++ b/packages/itinerary-body/src/stories/OtpRrItineraryBody.story.tsx
@@ -60,6 +60,7 @@ interface StoryWrapperProps {
   hideDrivingDirections?: boolean;
   itinerary: Itinerary;
   TimeColumnContent?: FunctionComponent<TimeColumnContentProps>;
+  useMetricUnits?: boolean;
 }
 
 function OtpRRItineraryBodyWrapper({
@@ -67,7 +68,8 @@ function OtpRRItineraryBodyWrapper({
   defaultFareSelector,
   hideDrivingDirections = false,
   itinerary,
-  TimeColumnContent
+  TimeColumnContent,
+  useMetricUnits = false
 }: StoryWrapperProps): ReactElement {
   return (
     <ItineraryBodyDefaultsWrapper
@@ -86,6 +88,7 @@ function OtpRRItineraryBodyWrapper({
       styledItinerary="otp-rr"
       TimeColumnContent={TimeColumnContent}
       TransitLegSubheader={WrappedOtpRRTransitLegSubheader}
+      useMetricUnits={useMetricUnits}
     />
   );
 }
@@ -99,9 +102,17 @@ export const WalkOnlyItinerary = (): ReactElement => (
   <OtpRRItineraryBodyWrapper itinerary={walkOnlyItinerary} />
 );
 
+export const WalkOnlyItineraryMetricUnits = (): ReactElement => (
+  <OtpRRItineraryBodyWrapper itinerary={walkOnlyItinerary} useMetricUnits />
+);
+
 // OTP2.4 type data
 export const Otp24Itinerary = (): ReactElement => (
   <OtpRRItineraryBodyWrapper itinerary={otp24Itinerary} />
+);
+
+export const Otp24ItineraryMetricUnits = (): ReactElement => (
+  <OtpRRItineraryBodyWrapper itinerary={otp24Itinerary} useMetricUnits />
 );
 
 export const BikeOnlyItinerary = (): ReactElement => (
@@ -110,6 +121,13 @@ export const BikeOnlyItinerary = (): ReactElement => (
 
 export const WalkTransitWalkItinerary = (): ReactElement => (
   <OtpRRItineraryBodyWrapper itinerary={walkTransitWalkItinerary} />
+);
+
+export const WalkTransitWalkItineraryUseMetricUnits = (): ReactElement => (
+  <OtpRRItineraryBodyWrapper
+    itinerary={walkTransitWalkItinerary}
+    useMetricUnits
+  />
 );
 
 export const BikeTransitBikeItinerary = (): ReactElement => (

--- a/packages/itinerary-body/src/stories/OtpUiItineraryBody.story.tsx
+++ b/packages/itinerary-body/src/stories/OtpUiItineraryBody.story.tsx
@@ -43,8 +43,16 @@ export const WalkOnlyItinerary = (): ReactElement => (
   <ItineraryBodyDefaultsWrapper itinerary={walkOnlyItinerary} />
 );
 
+export const WalkOnlyItineraryMetricUnits = (): ReactElement => (
+  <ItineraryBodyDefaultsWrapper itinerary={walkOnlyItinerary} useMetricUnits />
+);
+
 export const BikeOnlyItinerary = (): ReactElement => (
   <ItineraryBodyDefaultsWrapper itinerary={bikeOnlyItinerary} />
+);
+
+export const BikeOnlyItineraryMetricUnits = (): ReactElement => (
+  <ItineraryBodyDefaultsWrapper itinerary={bikeOnlyItinerary} useMetricUnits />
 );
 
 export const WalkTransitWalkItinerary = (): ReactElement => (
@@ -96,6 +104,15 @@ export const WalkTransitWalkItineraryWithCustomViewTripButtonActivatedAndCustomR
     itinerary={walkTransitWalkItinerary}
     showViewTripButton
     toRouteAbbreviation={customToRouteAbbreviation}
+  />
+);
+
+export const WalkTransitWalkItineraryWithCustomViewTripButtonActivatedAndCustomRouteAbbreviationUseMetricUnits = (): ReactElement => (
+  <ItineraryBodyDefaultsWrapper
+    itinerary={walkTransitWalkItinerary}
+    showViewTripButton
+    toRouteAbbreviation={customToRouteAbbreviation}
+    useMetricUnits
   />
 );
 

--- a/packages/itinerary-body/src/stories/itinerary-body-defaults-wrapper.tsx
+++ b/packages/itinerary-body/src/stories/itinerary-body-defaults-wrapper.tsx
@@ -20,6 +20,7 @@ const config = require("../__mocks__/config.json");
 type Props = ItineraryBodyProps & {
   hideDrivingDirections?: boolean;
   styledItinerary?: string;
+  useMetricUnits?: boolean;
 };
 
 interface State {
@@ -62,7 +63,8 @@ export default class ItineraryBodyDefaultsWrapper extends Component<
       TransitLegSubheader,
       TransitLegSummary,
       AlertToggleIcon,
-      AlertBodyIcon
+      AlertBodyIcon,
+      useMetricUnits = false
     } = this.props;
     const { diagramVisible } = this.state;
     let ItineraryBodyComponent;
@@ -112,6 +114,7 @@ export default class ItineraryBodyDefaultsWrapper extends Component<
         toRouteAbbreviation={toRouteAbbreviation}
         TransitLegSubheader={TransitLegSubheader}
         TransitLegSummary={TransitLegSummary || DefaultTransitLegSummary}
+        useMetricUnits={useMetricUnits}
       />
     );
   }

--- a/packages/itinerary-body/src/types.ts
+++ b/packages/itinerary-body/src/types.ts
@@ -232,6 +232,8 @@ interface ItineraryBodySharedProps {
    * - stopsExpanded: whether the intermediate stop display is currently expanded
    */
   TransitLegSummary: FunctionComponent<TransitLegSummaryProps>;
+  /** If true, metric units (km, m) will be used. By default imperial units (mile, feet) will be used */
+  useMetricUnits?: boolean;
 }
 
 export interface PlaceRowProps

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -185,7 +185,8 @@ const LocationField = ({
   suggestionHeadingType: headingType,
   suppressNearby = false,
   UserLocationIconComponent = UserLocationIcon,
-  userLocationsAndRecentPlaces = []
+  userLocationsAndRecentPlaces = [],
+  useMetricUnits = false
 }: LocationFieldProps): React.ReactElement => {
   /**
    * Gets the initial value to place in the input field.
@@ -724,6 +725,7 @@ const LocationField = ({
             onClick={locationSelected}
             stop={stop}
             stopOptionIcon={stopOptionIcon}
+            useMetricUnits={useMetricUnits}
           />
         );
         itemIndex++;

--- a/packages/location-field/src/options.tsx
+++ b/packages/location-field/src/options.tsx
@@ -1,7 +1,7 @@
-import { humanizeDistanceStringImperial } from "@opentripplanner/humanize-distance";
+import { humanizeDistanceString } from "@opentripplanner/humanize-distance";
 import { Stop, UserLocation } from "@opentripplanner/types";
 import React from "react";
-import { IntlShape } from "react-intl";
+import { IntlShape, useIntl } from "react-intl";
 import { Bus } from "@styled-icons/fa-solid/Bus";
 import { Briefcase } from "@styled-icons/fa-solid/Briefcase";
 import { Home } from "@styled-icons/fa-solid/Home";
@@ -110,20 +110,23 @@ export function TransitStopOption({
   isActive = false,
   onClick,
   stop,
-  stopOptionIcon
+  stopOptionIcon,
+  useMetricUnits = false
 }: {
   id?: string;
   isActive?: boolean;
   onClick: () => void;
   stop: Stop;
   stopOptionIcon: React.ReactNode;
+  useMetricUnits?: boolean;
 }): React.ReactElement {
+  const intl = useIntl();
   return (
     <MenuItem active={isActive} id={id} onClick={onClick}>
       <S.StopIconAndDistanceContainer>
         {stopOptionIcon}
         <S.StopDistance>
-          {humanizeDistanceStringImperial(stop.dist, true)}
+          {humanizeDistanceString(stop.dist, useMetricUnits, intl)}
         </S.StopDistance>
       </S.StopIconAndDistanceContainer>
       <S.StopContentContainer>

--- a/packages/location-field/src/stories/Mobile.story.tsx
+++ b/packages/location-field/src/stories/Mobile.story.tsx
@@ -207,6 +207,21 @@ export const WithNearbyStops = (): JSX.Element => (
   />
 );
 
+export const WithNearbyStopsMetricUnits = (): JSX.Element => (
+  <LocationField
+    currentPosition={currentPosition}
+    geocoderConfig={geocoderConfig}
+    getCurrentPosition={getCurrentPosition}
+    isStatic
+    layerColorMap={layerColorMap}
+    locationType="to"
+    nearbyStops={nearbyStops}
+    onLocationSelected={onLocationSelected}
+    stopsIndex={stopsIndex}
+    useMetricUnits
+  />
+);
+
 export const WithSessionSearches = (): JSX.Element => (
   <LocationField
     currentPosition={currentPosition}

--- a/packages/location-field/src/types.ts
+++ b/packages/location-field/src/types.ts
@@ -273,6 +273,8 @@ export interface LocationFieldProps {
    * An array of recent locations and places a user has searched for.
    */
   userLocationsAndRecentPlaces?: UserLocation[];
+  /** If true, metric units (km, m) will be used. By default imperial units (mile, feet) will be used */
+  useMetricUnits?: boolean;
 }
 
 export interface Properties {

--- a/packages/printable-itinerary/src/PrintableItinerary.story.tsx
+++ b/packages/printable-itinerary/src/PrintableItinerary.story.tsx
@@ -42,6 +42,15 @@ export const WalkOnlyItinerary = () => (
   />
 );
 
+export const WalkOnlyItineraryMetricUnits = () => (
+  <PrintableItinerary
+    config={config}
+    itinerary={walkOnlyItinerary}
+    LegIcon={TriMetLegIcon}
+    useMetricUnits
+  />
+);
+
 // OTP 2.4 type data
 export const OTP24Itinerary = () => (
   <PrintableItinerary
@@ -51,11 +60,29 @@ export const OTP24Itinerary = () => (
   />
 );
 
+export const OTP24ItineraryMetricUnits = () => (
+  <PrintableItinerary
+    config={config}
+    itinerary={otp24Itinerary}
+    LegIcon={TriMetLegIcon}
+    useMetricUnits
+  />
+);
+
 export const BikeOnlyItinerary = () => (
   <PrintableItinerary
     config={config}
     itinerary={bikeOnlyItinerary}
     LegIcon={TriMetLegIcon}
+  />
+);
+
+export const BikeOnlyItineraryUseMetric = () => (
+  <PrintableItinerary
+    config={config}
+    itinerary={bikeOnlyItinerary}
+    LegIcon={TriMetLegIcon}
+    useMetricUnits
   />
 );
 

--- a/packages/printable-itinerary/src/access-leg.tsx
+++ b/packages/printable-itinerary/src/access-leg.tsx
@@ -14,13 +14,15 @@ interface Props {
   config: Config;
   leg: Leg;
   LegIcon: LegIconComponent;
+  useMetricUnits?: boolean;
 }
 
 export default function AccessLeg({
   accessibilityScoreGradationMap,
   config,
   leg,
-  LegIcon
+  LegIcon,
+  useMetricUnits = false
 }: Props): ReactElement {
   return (
     <S.Leg>
@@ -31,12 +33,16 @@ export default function AccessLeg({
         LegIcon={LegIcon}
       />
       <S.LegBody>
-        <S.AccessLegDescription config={config} leg={leg} />
+        <S.AccessLegDescription
+          config={config}
+          leg={leg}
+          useMetricUnits={useMetricUnits}
+        />
         {!leg.rideHailingEstimate && (
           <S.LegDetails>
             {leg.steps.map((step, k) => (
               <S.LegDetail key={k}>
-                <S.AccessLegStep step={step} />
+                <S.AccessLegStep step={step} useMetricUnits={useMetricUnits} />
               </S.LegDetail>
             ))}
           </S.LegDetails>

--- a/packages/printable-itinerary/src/index.tsx
+++ b/packages/printable-itinerary/src/index.tsx
@@ -17,13 +17,16 @@ interface Props {
   itinerary: Itinerary;
   /** A component class that is used to render icons for legs of an itinerary. */
   LegIcon: LegIconComponent;
+  /** If true, metric units (km, m) will be used. By default imperial units (mile, feet) will be used */
+  useMetricUnits?: boolean;
 }
 
 function PrintableItinerary({
   className,
   config,
   itinerary,
-  LegIcon
+  LegIcon,
+  useMetricUnits = false
 }: Props): ReactElement {
   return (
     <S.PrintableItinerary className={className}>
@@ -60,7 +63,13 @@ function PrintableItinerary({
         ) : leg.rideHailingEstimate ? (
           <TNCLeg leg={leg} LegIcon={LegIcon} key={k} />
         ) : (
-          <AccessLeg config={config} key={k} leg={leg} LegIcon={LegIcon} />
+          <AccessLeg
+            config={config}
+            key={k}
+            leg={leg}
+            LegIcon={LegIcon}
+            useMetricUnits={useMetricUnits}
+          />
         )
       )}
     </S.PrintableItinerary>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3246,6 +3246,11 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
+"@opentripplanner/types@6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/types/-/types-6.4.0.tgz#6f7a3475ea982c7b7d8b2f1383a6d775dfabe62a"
+  integrity sha512-PS+CUwETLf0WzAUZg3qiey+SBigaf0CfknKF1XMOM+zJVc2c8nN34hgnwV7sS+RKs030KZFAgIn8p035ErcBuQ==
+
 "@peculiar/asn1-schema@^2.1.6", "@peculiar/asn1-schema@^2.3.0":
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.3.3.tgz#21418e1f3819e0b353ceff0c2dad8ccb61acd777"


### PR DESCRIPTION
Hi there, the following PR deals with issue #116 

I've added a useMetricUnits props to the affected components reported in the issue:

- [X] AccessLegSummary (package itinerary-body)
- [X] AccessLeg (package printable-itinerary)
- [X] TransitStopOption (package location-field)

This prop is optional with default value false which means that imperial units will be used. If useMetricUnits is set, metric units will be used instead.

I've also added some stories to test useMetricUnits in action:

![image](https://github.com/opentripplanner/otp-ui/assets/30386061/5a2470ab-a56d-43d1-8a62-7ac6439b55b9)

As this is my first ever contribution to this project so I hope this first contribution is useful. Please don't hesitate to tell me what I should improve or change for my future contributions. 

This an awesome project, thank's a lot for your effort and the quality of the code. It's great that you've published it as an open source project, hopefully I'll try to upload more contributions soon.

Cheers!