### PR TITLE
Better Geocoder Failure Handling 

### DIFF
--- a/packages/geocoder/src/apis/here/index.ts
+++ b/packages/geocoder/src/apis/here/index.ts
@@ -81,7 +81,7 @@ async function autocomplete({
       query,
       url: AUTOCOMPLETE_URL
     });
-    if (boundary?.rect) {
+    if (boundary?.rect && res.items) {
       // HERE does not support a boundary when you use a focus point
       // This workaround filters the results internally to the boundary
       res.items = res.items.filter(checkItemInBoundary(boundary))

--- a/packages/geocoder/src/apis/otp/index.ts
+++ b/packages/geocoder/src/apis/otp/index.ts
@@ -26,7 +26,17 @@ type OTPGeocoderResponse = {
 function run({ query, url }: FetchArgs): Promise<OTPGeocoderResponse> {
   return fetch(`${url}/geocode/stopClusters?query=${query}`)
     .then(res => res.text())
-    .then(res => JSON.parse(`{"results": ${res}}`));
+    .then(res => {
+      let parsed = { results: [] }
+
+      try {
+        parsed = JSON.parse(`{"results": ${res}}`)
+      } catch (e) {
+        console.warn("Invalid response from OTP Geocoder!")
+      }
+
+      return parsed
+});
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3246,6 +3246,11 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
+"@opentripplanner/types@6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/types/-/types-6.4.0.tgz#6f7a3475ea982c7b7d8b2f1383a6d775dfabe62a"
+  integrity sha512-PS+CUwETLf0WzAUZg3qiey+SBigaf0CfknKF1XMOM+zJVc2c8nN34hgnwV7sS+RKs030KZFAgIn8p035ErcBuQ==
+
 "@peculiar/asn1-schema@^2.1.6", "@peculiar/asn1-schema@^2.3.0":
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.3.3.tgz#21418e1f3819e0b353ceff0c2dad8ccb61acd777"


### PR DESCRIPTION
Right now there's nearly no error handling for HERE and OTP failures. This PR adds some simple improvements that allow us to return responses in more cases.