### PR TITLE
fix(core-utils): support `unpreferred` query param

### DIFF
--- a/packages/core-utils/src/query-gen.ts
+++ b/packages/core-utils/src/query-gen.ts
@@ -223,9 +223,9 @@ export function generateOtp2Query(
     modeSettings,
     numItineraries,
     preferred,
-    unpreferred,
     time,
-    to
+    to,
+    unpreferred
   }: OTPQueryParams,
   planQuery = DefaultPlanQuery
 ): GraphQLQuery {
@@ -264,9 +264,9 @@ export function generateOtp2Query(
       modes,
       numItineraries,
       preferred,
-      unpreferred,
       time,
       toPlace: `${to.name}::${to.lat},${to.lon}}`,
+      unpreferred,
       walkReluctance,
       walkSpeed,
       wheelchair

--- a/packages/core-utils/src/query-gen.ts
+++ b/packages/core-utils/src/query-gen.ts
@@ -33,6 +33,7 @@ type OTPQueryParams = {
   to: LonLatOutput & { name?: string };
   banned?: InputBanned;
   preferred?: InputPreferred;
+  unpreferred?: InputPreferred;
 };
 
 type GraphQLQuery = {
@@ -222,6 +223,7 @@ export function generateOtp2Query(
     modeSettings,
     numItineraries,
     preferred,
+    unpreferred,
     time,
     to
   }: OTPQueryParams,
@@ -262,6 +264,7 @@ export function generateOtp2Query(
       modes,
       numItineraries,
       preferred,
+      unpreferred,
       time,
       toPlace: `${to.name}::${to.lat},${to.lon}}`,
       walkReluctance,


### PR DESCRIPTION
We even have this in our plan query file! How did we not support setting this!