### PR TITLE
fix(itin-body): support duration in walk leg string override

### DIFF
--- a/packages/itinerary-body/src/defaults/access-leg-description.tsx
+++ b/packages/itinerary-body/src/defaults/access-leg-description.tsx
@@ -100,6 +100,13 @@ export default function AccessLegDescription({
           values={{
             // TODO: Implement metric vs imperial (up until now it's just imperial).
             distance: humanizeDistanceString(leg.distance, false, intl),
+            // This is not used by the default string,
+            // but supplying it allows a user who is overriding the string to use it
+            // This relies on `formatDuration` being passed into the itinerary body config.
+            // That method is used to generate the duration string
+            duration:
+              config?.formatDuration &&
+              config.formatDuration(leg.duration, intl, false),
             mode: modeContent,
             place: placeContent
           }}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 import React, { FunctionComponent, ReactElement } from "react";
+import { IntlShape } from "react-intl";
 import { StyledIcon } from "@styled-icons/styled-icon";
 import { ConfiguredModes } from "./deprecated";
 
@@ -148,6 +149,11 @@ export type Config = {
     /** @deprecated */
     longDateFormat?: string;
   };
+  formatDuration?: (
+    duration: number,
+    intl: IntlShape,
+    includeSeconds: boolean
+  ) => string;
   homeTimezone: string;
   /** @deprecated */
   modes?: ConfiguredModes;


### PR DESCRIPTION
The itinerary body walk legs currently show distance. If a user wants to override the string to display duration instead, they'll need that value. Sadly, it's only in seconds. To fix this, we need a formatDuration method. That method needs to be passed in. Therefore this PR is quite large for doing functionally nothing, but it opens the door to exciting features in the future