### PR TITLE
fix: don’t show stops that are within stations

### DIFF
--- a/packages/otp2-tile-overlay/src/index.tsx
+++ b/packages/otp2-tile-overlay/src/index.tsx
@@ -133,7 +133,7 @@ const OTP2TileLayerWithPopup = ({
     filter = ["all", ["==", "network", network]]
   }
   if (type === "stops" || type === "areaStops") {
-    filter = ["!=", ["get", "routes"], ["literal", "[]"]]
+    filter = ["all", ["!", ["has", "parentStation"]], ["!=", ["get", "routes"], ["literal", "[]"]]]
   }
 
   const isArea = AREA_TYPES.includes(type)


### PR DESCRIPTION
Sometimes stops are a part of stations. OTP now exposes this, so we can filter them out.