### PR TITLE
Map Popup show company name in all map popup titles

### DIFF
--- a/packages/map-popup/i18n/en-US.yml
+++ b/packages/map-popup/i18n/en-US.yml
@@ -3,7 +3,8 @@ otpUi:
     availableBikes: "Available bikes: {value}"
     availableDocks: "Available docks: {value}"
     floatingBike: "Free-floating bike: {name}"
-    floatingCar: "{company} {name}"
+    floatingCar: "Car: {name}"
     floatingEScooter: "E-scooter: {name}"
+    popupTitle: "{stationNetwork, select, false {{name}} other {{stationNetwork} {name}}}"
     stopId: "Stop ID: {stopId}"
     stopViewer: Stop Viewer

--- a/packages/map-popup/i18n/es.yml
+++ b/packages/map-popup/i18n/es.yml
@@ -3,7 +3,7 @@ otpUi:
     availableBikes: "Bicicletas disponibles: {value}"
     availableDocks: "Estaciones de carga disponibles: {value}"
     floatingBike: "Bicicleta flotante: {name}"
-    floatingCar: "{company} {name}"
+    floatingCar: "Carro: {name}"
     floatingEScooter: Scooter eléctrico {name}
     popupTitle: "{stationNetwork, select, false {{name}} other {{stationNetwork} {name}}}"
     stopId: Parada n°{stopId}

--- a/packages/map-popup/i18n/es.yml
+++ b/packages/map-popup/i18n/es.yml
@@ -4,7 +4,7 @@ otpUi:
     availableDocks: "Estaciones de carga disponibles: {value}"
     floatingBike: "Bicicleta flotante: {name}"
     floatingCar: "{company} {name}"
-    floatingEScooter: "Scooter eléctrico {name}"
-
+    floatingEScooter: Scooter eléctrico {name}
+    popupTitle: "{stationNetwork, select, false {{name}} other {{stationNetwork} {name}}}"
     stopId: Parada n°{stopId}
     stopViewer: Visor de paradas

--- a/packages/map-popup/i18n/fr.yml
+++ b/packages/map-popup/i18n/fr.yml
@@ -3,7 +3,7 @@ otpUi:
     availableBikes: "Vélos disponibles : {value}"
     availableDocks: "Bornes disponibles : {value}"
     floatingBike: "Vélo flottant : {name}"
-    floatingCar: "{company} {name}"
+    floatingCar: "Voiture : {name}"
     floatingEScooter: Trottinette {name}
     popupTitle: "{stationNetwork, select, false {{name}} other {{stationNetwork} {name}}}"
     stopId: Arrêt n°{stopId}

--- a/packages/map-popup/i18n/fr.yml
+++ b/packages/map-popup/i18n/fr.yml
@@ -5,5 +5,6 @@ otpUi:
     floatingBike: "Vélo flottant : {name}"
     floatingCar: "{company} {name}"
     floatingEScooter: Trottinette {name}
+    popupTitle: "{stationNetwork, select, false {{name}} other {{stationNetwork} {name}}}"
     stopId: Arrêt n°{stopId}
     stopViewer: Info arrêt

--- a/packages/map-popup/i18n/ko.yml
+++ b/packages/map-popup/i18n/ko.yml
@@ -3,7 +3,7 @@ otpUi:
     availableBikes: "사용 가능한 자전거: {value}"
     availableDocks: "사용 가능한 도크: {value}"
     floatingBike: "프리-플로팅 자전거: {name}"
-    floatingCar: "{company} {name}"
+    floatingCar: "자동차: {name}"
     floatingEScooter: "{name} 전동스쿠터"
     popupTitle: "{stationNetwork, select, false {{name}} other {{stationNetwork} {name}}}"
     stopId: "정류장 ID: {stopId}"

--- a/packages/map-popup/i18n/ko.yml
+++ b/packages/map-popup/i18n/ko.yml
@@ -1,10 +1,10 @@
 otpUi:
   MapPopup:
-    floatingEScooter: "{name} 전동스쿠터"
-    availableDocks: "사용 가능한 도크: {value}"
     availableBikes: "사용 가능한 자전거: {value}"
-    floatingCar: "{company} {name}"
+    availableDocks: "사용 가능한 도크: {value}"
     floatingBike: "프리-플로팅 자전거: {name}"
-
-    stopViewer: 정류장 뷰어
+    floatingCar: "{company} {name}"
+    floatingEScooter: "{name} 전동스쿠터"
+    popupTitle: "{stationNetwork, select, false {{name}} other {{stationNetwork} {name}}}"
     stopId: "정류장 ID: {stopId}"
+    stopViewer: 정류장 뷰어

--- a/packages/map-popup/i18n/nb_NO.yml
+++ b/packages/map-popup/i18n/nb_NO.yml
@@ -1,9 +1,10 @@
 otpUi:
   MapPopup:
-    availableBikes: 'Tilgjengelige sykler: {value}'
-    floatingCar: '{company} {name}'
-    stopId: 'Stopp-ID: {stopId}'
+    availableBikes: "Tilgjengelige sykler: {value}"
+    availableDocks: "Tilgjengelige stasjoner: {value}"
+    floatingBike: "Stasjonsløs sykkel: {name}"
+    floatingCar: "{company} {name}"
+    floatingEScooter: "E-scooter: {name}"
+    popupTitle: "{stationNetwork, select, false {{name}} other {{stationNetwork} {name}}}"
+    stopId: "Stopp-ID: {stopId}"
     stopViewer: Stopp-viser
-    availableDocks: 'Tilgjengelige stasjoner: {value}'
-    floatingEScooter: 'E-scooter: {name}'
-    floatingBike: 'Stasjonsløs sykkel: {name}'

--- a/packages/map-popup/i18n/ru.yml
+++ b/packages/map-popup/i18n/ru.yml
@@ -3,7 +3,7 @@ otpUi:
     availableBikes: "Доступные велосипеды: {value}"
     availableDocks: "Доступные станции: {value}"
     floatingBike: "Арендный велосипед не на станции: {name}"
-    floatingCar: "{company} {name}"
+    floatingCar: "Авто: {name}"
     floatingEScooter: "Электросамокат: {name}"
     popupTitle: "{stationNetwork, select, false {{name}} other {{stationNetwork} {name}}}"
     stopId: "Идентификатор остановки: {stopId}"

--- a/packages/map-popup/i18n/ru.yml
+++ b/packages/map-popup/i18n/ru.yml
@@ -1,9 +1,10 @@
 otpUi:
   MapPopup:
-    availableDocks: 'Доступные станции: {value}'
-    floatingBike: 'Арендный велосипед не на станции: {name}'
+    availableBikes: "Доступные велосипеды: {value}"
+    availableDocks: "Доступные станции: {value}"
+    floatingBike: "Арендный велосипед не на станции: {name}"
+    floatingCar: "{company} {name}"
+    floatingEScooter: "Электросамокат: {name}"
+    popupTitle: "{stationNetwork, select, false {{name}} other {{stationNetwork} {name}}}"
+    stopId: "Идентификатор остановки: {stopId}"
     stopViewer: Средство просмотра остановок
-    stopId: 'Идентификатор остановки: {stopId}'
-    floatingCar: '{company} {name}'
-    availableBikes: 'Доступные велосипеды: {value}'
-    floatingEScooter: 'Электросамокат: {name}'

--- a/packages/map-popup/i18n/tl.yml
+++ b/packages/map-popup/i18n/tl.yml
@@ -3,7 +3,7 @@ otpUi:
     availableBikes: "Mga available na bisikleta: {value}"
     availableDocks: "Mga available na dock: {value}"
     floatingBike: "Free-floating na bisikleta: {name}"
-    floatingCar: "{company} {name}"
+    floatingCar: "Sasakyan: {name}"
     floatingEScooter: "E-scooter: {name}"
     popupTitle: "{stationNetwork, select, false {{name}} other {{stationNetwork} {name}}}"
     stopId: "ID ng Hintuan: {stopId}"

--- a/packages/map-popup/i18n/tl.yml
+++ b/packages/map-popup/i18n/tl.yml
@@ -1,9 +1,10 @@
 otpUi:
   MapPopup:
-    availableDocks: 'Mga available na dock: {value}'
-    floatingBike: 'Free-floating na bisikleta: {name}'
+    availableBikes: "Mga available na bisikleta: {value}"
+    availableDocks: "Mga available na dock: {value}"
+    floatingBike: "Free-floating na bisikleta: {name}"
+    floatingCar: "{company} {name}"
+    floatingEScooter: "E-scooter: {name}"
+    popupTitle: "{stationNetwork, select, false {{name}} other {{stationNetwork} {name}}}"
+    stopId: "ID ng Hintuan: {stopId}"
     stopViewer: Ihinto ang Viewer
-    stopId: 'ID ng Hintuan: {stopId}'
-    floatingCar: '{company} {name}'
-    availableBikes: 'Mga available na bisikleta: {value}'
-    floatingEScooter: 'E-scooter: {name}'

--- a/packages/map-popup/i18n/tr.yml
+++ b/packages/map-popup/i18n/tr.yml
@@ -5,5 +5,6 @@ otpUi:
     floatingBike: "Serbest gezen bisiklet: {name}"
     floatingCar: "{company} {name}"
     floatingEScooter: "E-skuter: {name}"
+    popupTitle: "{stationNetwork, select, false {{name}} other {{stationNetwork} {name}}}"
     stopId: "Durak ID: {stopId}"
     stopViewer: Durak Gösterici

--- a/packages/map-popup/i18n/vi.yml
+++ b/packages/map-popup/i18n/vi.yml
@@ -3,7 +3,7 @@ otpUi:
     availableBikes: "Xe đạp có sẵn: {value}"
     availableDocks: "Chỗ dựng xe đạp có sẵn: {value}"
     floatingBike: "Xe đạp để tự do: {name}"
-    floatingCar: "{company} {name}"
+    floatingCar: "Xe hơi: {name}"
     floatingEScooter: Xe tay ga điện {name}
     popupTitle: "{stationNetwork, select, false {{name}} other {{stationNetwork} {name}}}"
     stopId: Điểm dừng số {stopId}

--- a/packages/map-popup/i18n/vi.yml
+++ b/packages/map-popup/i18n/vi.yml
@@ -4,6 +4,7 @@ otpUi:
     availableDocks: "Chỗ dựng xe đạp có sẵn: {value}"
     floatingBike: "Xe đạp để tự do: {name}"
     floatingCar: "{company} {name}"
-    floatingEScooter: "Xe tay ga điện {name}"
+    floatingEScooter: Xe tay ga điện {name}
+    popupTitle: "{stationNetwork, select, false {{name}} other {{stationNetwork} {name}}}"
+    stopId: Điểm dừng số {stopId}
     stopViewer: Xem điểm dừng
-    stopId: "Điểm dừng số {stopId}"

--- a/packages/map-popup/i18n/zh_Hans.yml
+++ b/packages/map-popup/i18n/zh_Hans.yml
@@ -3,8 +3,8 @@ otpUi:
     availableBikes: "可用的自行车: {value}"
     availableDocks: "可用的充电座: {value}"
     floatingBike: "自由浮动的自行车: {name}"
-    floatingCar: "{company} {name}" # as in "CarCompany Veh1234a"
+    floatingCar: "{company} {name}"
     floatingEScooter: "{name} 电动滑板车"
-
-    stopId: '车站 ID: {stopId}'
-    stopViewer: "车站查看器"
+    popupTitle: "{stationNetwork, select, false {{name}} other {{stationNetwork} {name}}}"
+    stopId: "车站 ID: {stopId}"
+    stopViewer: 车站查看器

--- a/packages/map-popup/i18n/zh_Hans.yml
+++ b/packages/map-popup/i18n/zh_Hans.yml
@@ -3,7 +3,7 @@ otpUi:
     availableBikes: "可用的自行车: {value}"
     availableDocks: "可用的充电座: {value}"
     floatingBike: "自由浮动的自行车: {name}"
-    floatingCar: "{company} {name}"
+    floatingCar: "汽车: {name}"
     floatingEScooter: "{name} 电动滑板车"
     popupTitle: "{stationNetwork, select, false {{name}} other {{stationNetwork} {name}}}"
     stopId: "车站 ID: {stopId}"

--- a/packages/map-popup/src/MapPopup.story.tsx
+++ b/packages/map-popup/src/MapPopup.story.tsx
@@ -48,6 +48,22 @@ const FLOATING_VEHICLE = {
   y: 45.525486666666666
 };
 
+const FLOATING_CAR = {
+  "stroke-width": 1,
+  allowDropoff: false,
+  allowPickup: true,
+  color: "#333",
+  id: "car_6861",
+  isCarStation: false,
+  isFloatingCar: true,
+  name: "0541",
+  networks: ["MILES"], // https://miles-mobility.com
+  realTimeData: true,
+  spacesAvailable: 0,
+  x: 13.405,
+  y: 52.52
+};
+
 export const StopEntity = (): JSX.Element => (
   <MapPopupContents
     entity={STOP}
@@ -66,6 +82,10 @@ export const StationEntity = (): JSX.Element => (
     setLocation={action("setLocation")}
     setViewedStop={action("setViewedStop")}
   />
+);
+
+export const FloatingCarEntity = (): JSX.Element => (
+  <MapPopupContents entity={FLOATING_CAR} setLocation={action("setLocation")} />
 );
 
 export const FloatingVehicleEntity = (): JSX.Element => (

--- a/packages/map-popup/src/MapPopup.story.tsx
+++ b/packages/map-popup/src/MapPopup.story.tsx
@@ -40,7 +40,7 @@ const FLOATING_VEHICLE = {
   id: '"bike_6861"',
   isCarStation: false,
   isFloatingBike: true,
-  name: "0541 BIKETOWN",
+  name: "0541",
   networks: ["BIKETOWN"],
   realTimeData: true,
   spacesAvailable: 0,

--- a/packages/map-popup/src/__snapshots__/MapPopup.story.tsx.snap
+++ b/packages/map-popup/src/__snapshots__/MapPopup.story.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Map Popup FloatingVehicleEntity smoke-test 1`] = `
 <div class="styled__MapOverlayPopup-sc-12v7ov3-2 hLIcgt">
   <header class="styled__PopupTitle-sc-12v7ov3-4 jMeCoZ">
-    Free-floating bike: 0541 BIKETOWN
+    BIKETOWN Free-floating bike: 0541
   </header>
   <p class="styled__PopupRow-sc-12v7ov3-3 bGmFCM">
     <strong>
@@ -56,7 +56,7 @@ exports[`Map Popup FloatingVehicleEntity smoke-test 1`] = `
 exports[`Map Popup StationEntity smoke-test 1`] = `
 <div class="styled__MapOverlayPopup-sc-12v7ov3-2 hLIcgt">
   <header class="styled__PopupTitle-sc-12v7ov3-4 jMeCoZ">
-    SW Morrison at 18th
+    BIKETOWN SW Morrison at 18th
   </header>
   <p class="styled__PopupRow-sc-12v7ov3-3 bGmFCM">
     <div>

--- a/packages/map-popup/src/__snapshots__/MapPopup.story.tsx.snap
+++ b/packages/map-popup/src/__snapshots__/MapPopup.story.tsx.snap
@@ -1,5 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Map Popup FloatingCarEntity smoke-test 1`] = `
+<div class="styled__MapOverlayPopup-sc-12v7ov3-2 hLIcgt">
+  <header class="styled__PopupTitle-sc-12v7ov3-4 jMeCoZ">
+    MILES Car: 0541
+  </header>
+  <p class="styled__PopupRow-sc-12v7ov3-3 bGmFCM">
+    <strong>
+      Plan a trip:
+    </strong>
+    <span class="styled__FromToPickerSpan-sc-vb4790-1 hmUShj">
+      <span class="styled__LocationPickerSpan-sc-vb4790-0 gwsIFy">
+        <svg viewbox="0 0 512 512"
+             height="0.9em"
+             width="0.9em"
+             aria-hidden="true"
+             focusable="false"
+             fill="currentColor"
+             xmlns="http://www.w3.org/2000/svg"
+             class="StyledIconBase-ea9ulj-0 hPhvO styled__FromIcon-sc-n5xcvc-0 jTjMOf"
+        >
+          <path fill="currentColor"
+                d="M256 56c110.532 0 200 89.451 200 200 0 110.532-89.451 200-200 200-110.532 0-200-89.451-200-200 0-110.532 89.451-200 200-200m0-48C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm0 168c-44.183 0-80 35.817-80 80s35.817 80 80 80 80-35.817 80-80-35.817-80-80-80z"
+          >
+          </path>
+        </svg>
+        <button class="styled__Button-sc-vb4790-2 hNNoVB">
+          From here
+        </button>
+      </span>
+      <span class="styled__LocationPickerSpan-sc-vb4790-0 gwsIFy">
+        <svg viewbox="0 0 384 512"
+             height="0.9em"
+             width="0.9em"
+             aria-hidden="true"
+             focusable="false"
+             fill="currentColor"
+             xmlns="http://www.w3.org/2000/svg"
+             class="StyledIconBase-ea9ulj-0 hPhvO styled__ToIcon-sc-n5xcvc-2 ipFnZE"
+        >
+          <path fill="currentColor"
+                d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z"
+          >
+          </path>
+        </svg>
+        <button class="styled__Button-sc-vb4790-2 hNNoVB">
+          To here
+        </button>
+      </span>
+    </span>
+  </p>
+</div>
+`;
+
 exports[`Map Popup FloatingVehicleEntity smoke-test 1`] = `
 <div class="styled__MapOverlayPopup-sc-12v7ov3-2 hLIcgt">
   <header class="styled__PopupTitle-sc-12v7ov3-4 jMeCoZ">

--- a/packages/map-popup/src/index.tsx
+++ b/packages/map-popup/src/index.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback } from "react";
 import FromToLocationPicker from "@opentripplanner/from-to-location-picker";
+import coreUtils from "@opentripplanner/core-utils";
+
 // eslint-disable-next-line prettier/prettier
 import type { Company, ConfiguredCompany, Location, Station, Stop, StopEventHandler } from "@opentripplanner/types";
 
@@ -103,6 +105,7 @@ export function MapPopup({ configCompanies, entity, getEntityName, setLocation, 
   const getNameFunc = getEntityName || makeDefaultGetEntityName(intl, defaultMessages);
   const name = getNameFunc(entity, configCompanies);
 
+  const stationNetwork = "networks" in entity && (coreUtils.itinerary.getCompaniesLabelFromNetworks(entity?.networks || [], configCompanies) || entity?.networks?.[0]);
 
   const bikesAvailablePresent = entityIsStation(entity)
   const entityIsStationHub = bikesAvailablePresent && entity?.bikesAvailable !== undefined && !entity?.isFloatingBike;
@@ -110,7 +113,14 @@ export function MapPopup({ configCompanies, entity, getEntityName, setLocation, 
 
   return (
     <S.MapOverlayPopup>
-      <S.PopupTitle>{name}</S.PopupTitle>
+      <S.PopupTitle>
+        <FormattedMessage
+          defaultMessage={defaultMessages["otpUi.MapPopup.popupTitle"]}
+          description="Text for title of the popup, contains an optional company name"
+          id="otpUi.MapPopup.popupTitle"
+          values={{ name, stationNetwork }}
+        />
+      </S.PopupTitle>
       {/* render dock info if it is available */}
       {entityIsStationHub && <StationHubDetails station={entity} />}
 

--- a/packages/map-popup/src/util.ts
+++ b/packages/map-popup/src/util.ts
@@ -11,6 +11,8 @@ export function makeDefaultGetEntityName(
     entity: Station | Stop,
     configCompanies: Company[]
   ): string | null {
+    // TODO: Stop generating this / passing it to the car string? Is it needed?
+    // In English we say "Car: " instead
     const stationNetworks =
       "networks" in entity &&
       (coreUtils.itinerary.getCompaniesLabelFromNetworks(
@@ -36,7 +38,7 @@ export function makeDefaultGetEntityName(
           description: "Popup title for a free-floating bike",
           id: "otpUi.MapPopup.floatingBike"
         },
-        { name: stationName || stationNetworks }
+        { name: stationName }
       );
     } else if ("isFloatingCar" in entity && entity.isFloatingCar) {
       stationName = intl.formatMessage(
@@ -59,7 +61,7 @@ export function makeDefaultGetEntityName(
           description: "Popup title for a free-floating e-scooter",
           id: "otpUi.MapPopup.floatingEScooter"
         },
-        { name: stationName || stationNetworks }
+        { name: stationName }
       );
     }
     return stationName;


### PR DESCRIPTION
It was a little confusing that there was no title in the station names. Especially when feeds had terrible station names. We resolve this. As a result we remove company name from the other strings. However, the car isn't localized, so it's kept for now. In the future we might want to get rid of that