### PR TITLE
feat(building-blocks): add focus trap to building blocks

### DIFF
--- a/packages/building-blocks/src/dropdown/index.tsx
+++ b/packages/building-blocks/src/dropdown/index.tsx
@@ -7,7 +7,10 @@ import React, {
   useState
 } from "react";
 
-import { getNextSibling, getPreviousSibling } from "../utils/dom-query";
+import {
+  getNextSibling,
+  getPreviousSibling
+} from "../focus-trap-wrapper/dom-query";
 import { DropdownButton, DropdownMenu, DropdownWrapper } from "./styled";
 
 export interface Props extends HTMLAttributes<HTMLElement> {

--- a/packages/building-blocks/src/focus-trap-wrapper/dom-query.ts
+++ b/packages/building-blocks/src/focus-trap-wrapper/dom-query.ts
@@ -1,4 +1,4 @@
-function getEntries(query: string) {
+export function getEntries(query: string) {
   const entries = Array.from(document.querySelectorAll(query));
   const firstElement = entries[0];
   const lastElement = entries[entries.length - 1];

--- a/packages/building-blocks/src/focus-trap-wrapper/dom-query.ts
+++ b/packages/building-blocks/src/focus-trap-wrapper/dom-query.ts
@@ -1,4 +1,4 @@
-export function getEntries(query: string) {
+function getEntries(query: string) {
   const entries = Array.from(document.querySelectorAll(query));
   const firstElement = entries[0];
   const lastElement = entries[entries.length - 1];

--- a/packages/building-blocks/src/focus-trap-wrapper/index.tsx
+++ b/packages/building-blocks/src/focus-trap-wrapper/index.tsx
@@ -4,8 +4,8 @@ import { getNextSibling, getPreviousSibling } from "./dom-query";
 const FocusTrapWrapper = ({
   children,
   closePopup = null,
-  id,
-  focusElements = ["button", "a", "input", "select"]
+  focusElements = ["button", "a", "input", "select"],
+  id
 }: {
   children: ReactNode | ReactNode[];
   closePopup?: (arg?: boolean) => void;

--- a/packages/building-blocks/src/focus-trap-wrapper/index.tsx
+++ b/packages/building-blocks/src/focus-trap-wrapper/index.tsx
@@ -5,7 +5,7 @@ const FocusTrapWrapper = ({
   children,
   closePopup = null,
   id,
-  focusElements = ["button", "a"]
+  focusElements = ["button", "a", "input", "select"]
 }: {
   children: ReactNode | ReactNode[];
   closePopup?: (arg?: boolean) => void;

--- a/packages/building-blocks/src/focus-trap-wrapper/index.tsx
+++ b/packages/building-blocks/src/focus-trap-wrapper/index.tsx
@@ -1,0 +1,46 @@
+import React, { ReactNode, useCallback } from "react";
+import { getNextSibling, getPreviousSibling } from "./dom-query";
+
+const FocusTrapWrapper = ({
+  children,
+  closePopup = null,
+  id,
+  focusElements = ["button", "a"]
+}: {
+  children: ReactNode | ReactNode[];
+  closePopup?: (arg?: boolean) => void;
+  id: string;
+  focusElements?: string[];
+}): JSX.Element => {
+  const queryId = focusElements
+    .map(el => `#${id}-focus-trap ${el}:not([disabled])`)
+    .join(", ");
+  const handleKeyDown = useCallback(
+    e => {
+      const element = e.target as HTMLElement;
+      switch (e.key) {
+        case "Escape":
+          closePopup();
+          break;
+        case "Tab":
+          e.preventDefault();
+          if (e.shiftKey) {
+            getPreviousSibling(queryId, element)?.focus();
+          } else {
+            getNextSibling(queryId, element)?.focus();
+          }
+          break;
+        default:
+      }
+    },
+    [closePopup]
+  );
+
+  return (
+    <div id={`${id}-focus-trap`} onKeyDown={handleKeyDown} role="presentation">
+      {children}
+    </div>
+  );
+};
+
+export default FocusTrapWrapper;

--- a/packages/building-blocks/src/stories/__snapshots__/focusTrapStory.story.tsx.snap
+++ b/packages/building-blocks/src/stories/__snapshots__/focusTrapStory.story.tsx.snap
@@ -26,23 +26,39 @@ exports[`Building-Blocks/FocusTrapWrapper FocusTrapWithVariousEls smoke-test 1`]
   <button type="button">
     Button 1
   </button>
+  <br>
   <a href="/">
     link
   </a>
+  <br>
   <div tabindex="-1">
     focusable div
   </div>
-  <input disabled
-         type="text"
-  >
-  <input type="text">
-  <select>
-    <option>
-      Option 1
-    </option>
-    <option>
-      Option 2
-    </option>
-  </select>
+  <label for="disabled-input">
+    Input (disabled)
+    <input id="disabled-input"
+           disabled
+           type="text"
+    >
+  </label>
+  <br>
+  <label for="input">
+    Input
+    <input id="input"
+           type="text"
+    >
+  </label>
+  <br>
+  <label for="select">
+    Select
+    <select id="select">
+      <option>
+        Option 1
+      </option>
+      <option>
+        Option 2
+      </option>
+    </select>
+  </label>
 </div>
 `;

--- a/packages/building-blocks/src/stories/focusTrapStory.story.tsx
+++ b/packages/building-blocks/src/stories/focusTrapStory.story.tsx
@@ -18,12 +18,16 @@ export const FocusTrapAroundButtonSet = (): React.ReactElement => (
 export const FocusTrapWithVariousEls = (): React.ReactElement => (
   <FocusTrapWrapper
     id="various-els-story"
-    focusElements={["button", "a", "div", "input"]}
+    focusElements={["button", "a", "div", "input", "select"]}
   >
     <button type="button">Button 1</button>
     <a href="/">link</a>
     <div tabIndex={-1}>focusable div</div>
     <input disabled type="text"></input>
     <input type="text"></input>
+    <select>
+      <option>Option 1</option>
+      <option>Option 2</option>
+    </select>
   </FocusTrapWrapper>
 );

--- a/packages/building-blocks/src/stories/focusTrapStory.story.tsx
+++ b/packages/building-blocks/src/stories/focusTrapStory.story.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import FocusTrapWrapper from "../focus-trap-wrapper";
+
+export default {
+  title: "Building-Blocks/FocusTrapWrapper",
+  component: FocusTrapWrapper
+};
+
+export const FocusTrapAroundButtonSet = (): React.ReactElement => (
+  <FocusTrapWrapper id="button-set-story">
+    <button type="button">Button 1</button>
+    <button type="button">Button 2</button>
+    <button type="button">Button 3</button>
+    <button type="button">Button 4</button>
+  </FocusTrapWrapper>
+);
+
+export const FocusTrapWithVariousEls = (): React.ReactElement => (
+  <FocusTrapWrapper
+    id="various-els-story"
+    focusElements={["button", "a", "div", "input"]}
+  >
+    <button type="button">Button 1</button>
+    <a href="/">link</a>
+    <div tabIndex={-1}>focusable div</div>
+    <input disabled type="text"></input>
+    <input type="text"></input>
+  </FocusTrapWrapper>
+);

--- a/packages/building-blocks/src/stories/focusTrapStory.story.tsx
+++ b/packages/building-blocks/src/stories/focusTrapStory.story.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import FocusTrapWrapper from "../focus-trap-wrapper";
 
 export default {
-  title: "Building-Blocks/FocusTrapWrapper",
-  component: FocusTrapWrapper
+  component: FocusTrapWrapper,
+  title: "Building-Blocks/FocusTrapWrapper"
 };
 
 export const FocusTrapAroundButtonSet = (): React.ReactElement => (
@@ -17,8 +17,8 @@ export const FocusTrapAroundButtonSet = (): React.ReactElement => (
 
 export const FocusTrapWithVariousEls = (): React.ReactElement => (
   <FocusTrapWrapper
-    id="various-els-story"
     focusElements={["button", "a", "div", "input", "select"]}
+    id="various-els-story"
   >
     <button type="button">Button 1</button>
     <a href="/">link</a>

--- a/packages/building-blocks/src/stories/focusTrapStory.story.tsx
+++ b/packages/building-blocks/src/stories/focusTrapStory.story.tsx
@@ -21,13 +21,26 @@ export const FocusTrapWithVariousEls = (): React.ReactElement => (
     id="various-els-story"
   >
     <button type="button">Button 1</button>
+    <br />
     <a href="/">link</a>
+    <br />
     <div tabIndex={-1}>focusable div</div>
-    <input disabled type="text"></input>
-    <input type="text"></input>
-    <select>
-      <option>Option 1</option>
-      <option>Option 2</option>
-    </select>
+    <label htmlFor="disabled-input">
+      Input (disabled) <input id="disabled-input" disabled type="text" />{" "}
+    </label>
+
+    <br />
+    <label htmlFor="input">
+      Input <input id="input" type="text" />
+    </label>
+
+    <br />
+    <label htmlFor="select">
+      Select{" "}
+      <select id="select">
+        <option>Option 1</option>
+        <option>Option 2</option>
+      </select>
+    </label>
   </FocusTrapWrapper>
 );


### PR DESCRIPTION
Housing Focus Trap Wrapper in map popup doesn't make a ton of sense and is causing circular dependencies and duplicated code.

This version of focus trap also allows for some configuration of which elements are focusable within the trap. For example, if you're creating non-standard focusable elements with `tabIndex`, those can be included.