### PR TITLE
fix(building-blocks): actually export focus trap wrapper

### DIFF
--- a/packages/building-blocks/src/focus-trap-wrapper/index.tsx
+++ b/packages/building-blocks/src/focus-trap-wrapper/index.tsx
@@ -43,4 +43,6 @@ const FocusTrapWrapper = ({
   );
 };
 
+export { getNextSibling, getPreviousSibling };
+
 export default FocusTrapWrapper;

--- a/packages/building-blocks/src/index.ts
+++ b/packages/building-blocks/src/index.ts
@@ -7,5 +7,6 @@ import FocusTrapWrapper, {
   getPreviousSibling
 } from "./focus-trap-wrapper";
 
+// TODO: Fix exports
 export { Dropdown, FocusTrapWrapper, getNextSibling, getPreviousSibling };
 export default { blue, red, grey };

--- a/packages/building-blocks/src/index.ts
+++ b/packages/building-blocks/src/index.ts
@@ -2,6 +2,10 @@ import blue from "./colors/blue";
 import red from "./colors/red";
 import grey from "./colors/grey";
 import Dropdown from "./dropdown";
+import FocusTrapWrapper, {
+  getNextSibling,
+  getPreviousSibling
+} from "./focus-trap-wrapper";
 
-export { Dropdown };
+export { Dropdown, FocusTrapWrapper, getNextSibling, getPreviousSibling };
 export default { blue, red, grey };


### PR DESCRIPTION
Focus trap wrapper is going to be the death of me. Fixes #765 which creates the `FocusTrapWrapper` without actually exporting it!!