### PR TITLE
feat(location-field): make location group order configurable

### DIFF
--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -174,6 +174,7 @@ const LocationField = ({
   onTextInputClick = null,
   operatorIconMap = {},
   preferredLayers = [],
+  renderOtherFirst = false,
   sessionOptionIcon = <Search size={ICON_SIZE} />,
   sessionSearches = [],
   showClearButton = true,
@@ -644,8 +645,25 @@ const LocationField = ({
     const transitFeaturesPresent =
       stopFeatures.length > 0 || stationFeatures.length > 0;
 
+    const OtherFeaturesHeader = () => (
+      <S.MenuGroupHeader as={headingType} bgColor="#333" key="other-header">
+        <FormattedMessage
+          description="Text for header above the 'other'"
+          id="otpUi.LocationField.other"
+        />
+      </S.MenuGroupHeader>
+    );
+
+    const otherFeaturesElements = otherFeatures.map(feature =>
+      renderFeature(itemIndex++, feature)
+    );
+
     // Iterate through the geocoder results
     menuItems = menuItems.concat(
+      renderOtherFirst &&
+        transitFeaturesPresent &&
+        otherFeatures.length > 0 && <OtherFeaturesHeader />,
+      renderOtherFirst && otherFeaturesElements,
       stationFeatures.length > 0 && (
         <S.MenuGroupHeader
           as={headingType}
@@ -673,16 +691,10 @@ const LocationField = ({
         </S.MenuGroupHeader>
       ),
       stopFeatures.map(feature => renderFeature(itemIndex++, feature)),
-
-      transitFeaturesPresent && otherFeatures.length > 0 && (
-        <S.MenuGroupHeader as={headingType} bgColor="#333" key="other-header">
-          <FormattedMessage
-            description="Text for header above the 'other'"
-            id="otpUi.LocationField.other"
-          />
-        </S.MenuGroupHeader>
-      ),
-      otherFeatures.map(feature => renderFeature(itemIndex++, feature))
+      !renderOtherFirst &&
+        transitFeaturesPresent &&
+        otherFeatures.length > 0 && <OtherFeaturesHeader />,
+      !renderOtherFirst && otherFeaturesElements
     );
   }
 

--- a/packages/location-field/src/types.ts
+++ b/packages/location-field/src/types.ts
@@ -215,6 +215,10 @@ export interface LocationFieldProps {
    */
   preferredLayers?: string[];
   /**
+   * If true, make "Other" category (addresses, POIs, etc.) first in the results container.
+   */
+  renderOtherFirst?: boolean;
+  /**
    * A slot for the icon to display for an option that was used during the
    * current session.
    */


### PR DESCRIPTION
Allows configuration of the order of the returned location group results, so that if you pass `renderOtherFirst` through the config, it puts the "other" category first in the results, above stops and stations.

| renderOtherFirst | !renderOtherFirst |
|--------|-------|
|![image](https://github.com/user-attachments/assets/e47f3c71-fd1f-4ac3-a841-9e3f8a25887d)|![image](https://github.com/user-attachments/assets/78086079-647b-41ca-9f0f-493598dc7182)|

