### PR TITLE
Support stop filtering

### DIFF
--- a/packages/otp2-tile-overlay/src/index.tsx
+++ b/packages/otp2-tile-overlay/src/index.tsx
@@ -24,6 +24,7 @@ const OTP2TileLayerWithPopup = ({
   onMapClick,
   setLocation,
   setViewedStop,
+  stopsWhitelist,
   type
 }: {
   color?: string;
@@ -56,6 +57,11 @@ const OTP2TileLayerWithPopup = ({
    * not passed, the stop viewer link will not be shown.
    */
   setViewedStop?: StopEventHandler
+  /**
+   * A list of GTFS stop ids (with agency prepended). If specified, all stops that
+   * are NOT in this list will be HIDDEN.
+   */
+  stopsWhitelist?: string[]
   /**
    * Determines which layer of the OTP2 tile data to display. Also determines icon color.
    */
@@ -135,6 +141,9 @@ const OTP2TileLayerWithPopup = ({
   if (type === "stops" || type === "areaStops") {
     filter = ["all", ["!", ["has", "parentStation"]], ["!=", ["get", "routes"], ["literal", "[]"]]]
   }
+  if (stopsWhitelist) {
+    filter = ["in", ["get", "gtfsId"], ["literal", stopsWhitelist]]
+  }
 
   const isArea = AREA_TYPES.includes(type)
   return (
@@ -148,6 +157,7 @@ const OTP2TileLayerWithPopup = ({
         }}
         source-layer={type}
         source={SOURCE_ID}
+        minzoom={stopsWhitelist ? 2 : 14}
         type="fill"
       />}
       {isArea && <Layer
@@ -169,6 +179,7 @@ const OTP2TileLayerWithPopup = ({
         key={id}
         paint={generateLayerPaint(color)[type]}
         source={SOURCE_ID}
+        minzoom={stopsWhitelist ? 2 : 14}
         source-layer={type}
         type="circle"
       />}
@@ -202,6 +213,7 @@ const OTP2TileLayerWithPopup = ({
  * @param endpoint        The OTP endpoint to make the requests to
  * @param setLocation     An optional method to make from/to buttons functional. See component for more detail.
  * @param setViewedStop   An optional method to make stop viewer button functional. See component for more detail. 
+ * @param stopsWhitelist  An optional list of stops to display singularly. See component for more detail. 
  * @param configCompanies An optional list of companies used to prettify network information.
  * @returns               Array of <Source> and <OTP2TileLayerWithPopup> components
  */
@@ -210,6 +222,7 @@ const generateOTP2TileLayers = (
   endpoint: string,
   setLocation?: (location: MapLocationActionArg) => void,
   setViewedStop?: (stop: Stop) => void,
+  stopsWhitelist?: string[],
   configCompanies?: ConfiguredCompany[]
 ): JSX.Element[] => {
   return [
@@ -236,6 +249,7 @@ const generateOTP2TileLayers = (
           network={network}
           setLocation={setLocation}
           setViewedStop={setViewedStop}
+          stopsWhitelist={stopsWhitelist}
           type={type}
           visible={initiallyVisible}
         />

--- a/packages/otp2-tile-overlay/src/index.tsx
+++ b/packages/otp2-tile-overlay/src/index.tsx
@@ -26,12 +26,12 @@ const OTP2TileLayerWithPopup = ({
   setViewedStop,
   type
 }: {
+  color?: string;
   /**
    * Optional configuration item which allows for customizing properties of scooter and
    * bikeshare companies. If this is provided, scooter/bikeshare company names can be rendered in the
    * default scooter/bike popup.
    */
-  color?: string;
   configCompanies?: ConfiguredCompany[]
   id: string
   name?: string


### PR DESCRIPTION
Adds a new prop to the OTP2 tile layer to support a stop whitelist. If this prop is active, only stops with this id will be shown. Zoom level is also overridden. 