### PR TITLE
feat(core-utils): add isTransitLeg function that uses transitLeg prop

### DIFF
--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -42,6 +42,10 @@ export function getTransitModes(config: Config): string[] {
   );
 }
 
+export function isTransitLeg(leg: Leg): boolean {
+  return leg.transitLeg;
+}
+
 export function isTransit(mode: string): boolean {
   return transitModes.includes(mode) || mode === "TRANSIT";
 }


### PR DESCRIPTION
This adds a new function (to avoid a breaking change) that checks for transit legs using the OTP2 `transitLeg` property. We could add extra functionality to this in the future to check for transit legs.

To avoid breaking changes in the future, is there any chance that we would want to support other arguments or return types in the future? 