### PR TITLE
fix: add missing `minzoom` to area border

### DIFF
--- a/packages/otp2-tile-overlay/src/index.tsx
+++ b/packages/otp2-tile-overlay/src/index.tsx
@@ -164,6 +164,7 @@ const OTP2TileLayerWithPopup = ({
         filter={filter}
         id={`${id}-outline`}
         layout={{ "line-join": "round", "line-cap": "round" }}
+        minzoom={stopsWhitelist ? 2 : 14}
         paint={{
           "line-color": ROUTE_COLOR_EXPRESSION,
           "line-opacity": 0.8,


### PR DESCRIPTION
The line around areas wasn't being filtered! oh no!