### PR TITLE
deps: update react-dom

### DIFF
--- a/packages/endpoints-overlay/package.json
+++ b/packages/endpoints-overlay/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "react": "^18.2.0",
-    "react-dom": "^16.8.6",
+    "react-dom": "^18.2.0",
     "react-intl": "^5.24.6",
     "react-map-gl": "^7.0.15",
     "styled-components": "^5.3.0"

--- a/packages/park-and-ride-overlay/package.json
+++ b/packages/park-and-ride-overlay/package.json
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "react": "^18.2.0",
-    "react-dom": "^16.8.6",
+    "react-dom": "^18.2.0",
     "react-map-gl": "^7.0.15",
     "styled-components": "^5.3.0"
   }

--- a/packages/vehicle-rental-overlay/package.json
+++ b/packages/vehicle-rental-overlay/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "react": "^18.2.0",
-    "react-dom": "^16.8.6",
+    "react-dom": "^18.2.0",
     "react-intl": "^5.24.6",
     "react-map-gl": "^7.0.15",
     "styled-components": "^5.3.0"


### PR DESCRIPTION
Someone noticed that we have some old react-dom versions in our packages. This is bad! We need to get all those in sync with the react version (which is 18).