### PR TITLE
fix(EndPointsOverlay): Make setLocation optional

### DIFF
--- a/packages/endpoints-overlay/src/EndpointsOverlay.story.tsx
+++ b/packages/endpoints-overlay/src/EndpointsOverlay.story.tsx
@@ -46,11 +46,7 @@ export default {
 } as ComponentMeta<typeof EndpointsOverlay>;
 
 export const EndpointsOverlayWithoutUserSettings: ComponentStory<typeof EndpointsOverlay> = () => (
-  <EndpointsOverlay
-    fromLocation={fromLocation}
-    setLocation={setLocation}
-    toLocation={toLocation}
-  />
+  <EndpointsOverlay fromLocation={fromLocation} toLocation={toLocation} />
 );
 
 export const EndpointsOverlayWithUserSettings: ComponentStory<typeof EndpointsOverlay> = () => (

--- a/packages/endpoints-overlay/src/index.tsx
+++ b/packages/endpoints-overlay/src/index.tsx
@@ -63,7 +63,7 @@ interface Props {
    *
    * { location: {...location}, reverseGeocode: true, type: "from/to" }
    */
-  setLocation: (arg: MapLocationActionArg) => void;
+  setLocation?: (arg: MapLocationActionArg) => void;
   /**
    * Whether or not to show the user settings popup when an endpoint is clicked.
    */
@@ -120,7 +120,7 @@ const EndpointsOverlay = ({
   locations = [],
   MapMarkerIcon = DefaultMapMarkerIcon,
   rememberPlace = noop,
-  setLocation,
+  setLocation = noop,
   showUserSettings,
   toLocation
 }: Props): ReactElement => (


### PR DESCRIPTION
In response to https://github.com/opentripplanner/otp-react-redux/pull/1272#discussion_r1779001128 , this PR makes the `setLocation` prop in the `EndpointsOverlay` optional (puts in the default `noop` handler as with other event handlers).