### PR TITLE
fix(trip-form): close mode button before setting submode options to default

### DIFF
--- a/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
+++ b/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
@@ -211,7 +211,7 @@ export default function SubSettingsPane({
             evt[s.key] = Object.keys(evt).includes(s.key) || !s.value;
           });
           onAllSubmodesDisabled(modeButton);
-          time = 500;
+          time = 700;
         }
       }
 

--- a/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
+++ b/packages/trip-form/src/MetroModeSelector/SubSettingsPane.tsx
@@ -197,6 +197,7 @@ export default function SubSettingsPane({
 
   const handleSettingChange = useCallback(
     (setting: ModeSetting) => (evt: QueryParamChangeEvent) => {
+      let time = 0;
       // check if setting is a transport mode setting
       if (settingsWithTransportMode.find(s => s.key === setting.key)) {
         // check if all submodes are disabled
@@ -210,10 +211,14 @@ export default function SubSettingsPane({
             evt[s.key] = Object.keys(evt).includes(s.key) || !s.value;
           });
           onAllSubmodesDisabled(modeButton);
+          time = 500;
         }
       }
 
-      onSettingUpdate(evt);
+      setTimeout(() => {
+        // This is a hack to make sure the setting is updated before the next render
+        onSettingUpdate(evt);
+      }, time);
     },
     [onSettingUpdate]
   );


### PR DESCRIPTION
Uses `setTimeout` to wait for the mode button animation to complete before setting submode options to their default values.