### PR TITLE
OTP2 route support in Transitive

### DIFF
--- a/packages/itinerary-body/src/__mocks__/itineraries/otp2-transit-leg.json
+++ b/packages/itinerary-body/src/__mocks__/itineraries/otp2-transit-leg.json
@@ -1,0 +1,462 @@
+{
+  "accessibilityScore": null,
+  "duration": 545,
+  "endTime": 1729868831000,
+  "legs": [
+    {
+      "accessibilityScore": null,
+      "agency": {
+        "alerts": [
+          {
+            "alertDescriptionText": "Attention Route 70 Riders - Effective October 7, 2024, Route 70 will relocate bus stop # 7000 from Wisteria Drive @ Main Street to Wisteria Drive and Highway 78.  ",
+            "alertHeaderText": "Attention Route 70 Riders - Effective October 7, 2024, Route 70 will relocate bus stop # 7000 from Wisteria Drive @ Main Street to Wisteria Drive and Highway 78.  ",
+            "alertUrl": null,
+            "effectiveStartDate": 1727222400,
+            "id": "QWxlcnQ6R3dpbm5ldHRDb3VudHlUcmFuc2l0OjMzMTQ"
+          },
+          {
+            "alertDescriptionText": "AM Service Alert- Route 103 at 6:30am from Sugarloaf Mills Park and Ride will be a missed trip.  We apologize for the inconvenience",
+            "alertHeaderText": "AM Service Alert- Route 103 at 6:30am from Sugarloaf Mills Park and Ride will be a missed trip.  We apologize for the inconvenience",
+            "alertUrl": null,
+            "effectiveStartDate": 1729814400,
+            "id": "QWxlcnQ6R3dpbm5ldHRDb3VudHlUcmFuc2l0OjM0ODI"
+          },
+          {
+            "alertDescriptionText": "Attention Route 50 Riders: The following outbound bus stops are not active on Route 50.  \n-\tWoodward Crossing Blvd & The Complex – Stop 5051\n-\tMall of GA Blvd & Nature Pkwy OB – Stop 5054",
+            "alertHeaderText": "Attention Route 50 Riders: The following outbound bus stops are not active on Route 50.  \n-\tWoodward Crossing Blvd & The Complex – Stop 5051\n-\tMall of GA Blvd & Nature Pkwy OB – Stop 5054",
+            "alertUrl": null,
+            "effectiveStartDate": 1707350400,
+            "id": "QWxlcnQ6R3dpbm5ldHRDb3VudHlUcmFuc2l0OjI1ODk"
+          },
+          {
+            "alertDescriptionText": "AM Service Alert- Route 101 at 7:00am from I-985 Park and Ride will be a missed trip.  We apologize for the inconvenience",
+            "alertHeaderText": "AM Service Alert- Route 101 at 7:00am from I-985 Park and Ride will be a missed trip.  We apologize for the inconvenience",
+            "alertUrl": null,
+            "effectiveStartDate": 1729814400,
+            "id": "QWxlcnQ6R3dpbm5ldHRDb3VudHlUcmFuc2l0OjM0ODM"
+          },
+          {
+            "alertDescriptionText": "AM Service Alert - Route 110 outbound from Sugarloaf Mills Park and Ride at 8:10am will be a missed trip.  We apologize for the inconvenience.\n",
+            "alertHeaderText": "AM Service Alert - Route 110 outbound from Sugarloaf Mills Park and Ride at 8:10am will be a missed trip.  We apologize for the inconvenience.\n",
+            "alertUrl": null,
+            "effectiveStartDate": 1729814400,
+            "id": "QWxlcnQ6R3dpbm5ldHRDb3VudHlUcmFuc2l0OjM0ODQ"
+          },
+          {
+            "alertDescriptionText": "Attention Route 40 Riders – Effective October 9, 2024 Stop # 4058 on Stone Mountain St. & Piedmont Bank (OB) has temporarily relocated to a location about 250 feet away due to construction in the area.  We apologize for any inconvenience.",
+            "alertHeaderText": "Attention Route 40 Riders – Effective October 9, 2024 Stop # 4058 on Stone Mountain St. & Piedmont Bank (OB) has temporarily relocated to a location about 250 feet away due to construction in the area.  We apologize for any inconvenience.",
+            "alertUrl": null,
+            "effectiveStartDate": 1728432000,
+            "id": "QWxlcnQ6R3dpbm5ldHRDb3VudHlUcmFuc2l0OjMzOTA"
+          }
+        ],
+        "gtfsId": "GwinnettCountyTransit:GCT",
+        "id": "GwinnettCountyTransit:GCT",
+        "name": "Gwinnett County Transit",
+        "timezone": "America/New_York",
+        "url": "https://www.ridegwinnett.com/"
+      },
+      "alerts": [
+        {
+          "alertDescriptionText": "Attention Route 70 Riders - Effective October 7, 2024, Route 70 will relocate bus stop # 7000 from Wisteria Drive @ Main Street to Wisteria Drive and Highway 78.  ",
+          "alertHeaderText": "Attention Route 70 Riders - Effective October 7, 2024, Route 70 will relocate bus stop # 7000 from Wisteria Drive @ Main Street to Wisteria Drive and Highway 78.  ",
+          "alertUrl": null,
+          "effectiveStartDate": 1727222400,
+          "id": "QWxlcnQ6R3dpbm5ldHRDb3VudHlUcmFuc2l0OjMzMTQ"
+        },
+        {
+          "alertDescriptionText": "Attention Route 50 Riders: The following outbound bus stops are not active on Route 50.  \n-\tWoodward Crossing Blvd & The Complex – Stop 5051\n-\tMall of GA Blvd & Nature Pkwy OB – Stop 5054",
+          "alertHeaderText": "Attention Route 50 Riders: The following outbound bus stops are not active on Route 50.  \n-\tWoodward Crossing Blvd & The Complex – Stop 5051\n-\tMall of GA Blvd & Nature Pkwy OB – Stop 5054",
+          "alertUrl": null,
+          "effectiveStartDate": 1707350400,
+          "id": "QWxlcnQ6R3dpbm5ldHRDb3VudHlUcmFuc2l0OjI1ODk"
+        },
+        {
+          "alertDescriptionText": "Attention Route 40 Riders – Effective October 9, 2024 Stop # 4058 on Stone Mountain St. & Piedmont Bank (OB) has temporarily relocated to a location about 250 feet away due to construction in the area.  We apologize for any inconvenience.",
+          "alertHeaderText": "Attention Route 40 Riders – Effective October 9, 2024 Stop # 4058 on Stone Mountain St. & Piedmont Bank (OB) has temporarily relocated to a location about 250 feet away due to construction in the area.  We apologize for any inconvenience.",
+          "alertUrl": null,
+          "effectiveStartDate": 1728432000,
+          "id": "QWxlcnQ6R3dpbm5ldHRDb3VudHlUcmFuc2l0OjMzOTA"
+        }
+      ],
+      "arrivalDelay": 0,
+      "departureDelay": 0,
+      "distance": 4716.45,
+      "dropoffType": "SCHEDULED",
+      "duration": 522,
+      "endTime": 1729868808000,
+      "fareProducts": [
+        {
+          "id": "55a84984-7687-39e8-9a41-ee6e6dbc23ed",
+          "product": {
+            "__typename": "DefaultFareProduct",
+            "id": "atlanta:electronicRegular",
+            "medium": null,
+            "name": "electronicRegular",
+            "riderCategory": null,
+            "price": {
+              "amount": 0,
+              "currency": {
+                "code": "USD",
+                "digits": 2
+              }
+            }
+          }
+        },
+        {
+          "id": "01689082-2707-31ee-8d91-203eda3a29be",
+          "product": {
+            "__typename": "DefaultFareProduct",
+            "id": "atlanta:electronicYouth",
+            "medium": null,
+            "name": "electronicYouth",
+            "riderCategory": null,
+            "price": {
+              "amount": 0,
+              "currency": {
+                "code": "USD",
+                "digits": 2
+              }
+            }
+          }
+        },
+        {
+          "id": "02bf6764-589e-38fe-8b89-e07d7203237d",
+          "product": {
+            "__typename": "DefaultFareProduct",
+            "id": "atlanta:regular",
+            "medium": null,
+            "name": "regular",
+            "riderCategory": null,
+            "price": {
+              "amount": 0,
+              "currency": {
+                "code": "USD",
+                "digits": 2
+              }
+            }
+          }
+        },
+        {
+          "id": "9002d499-a1f7-3696-88de-3854ed39b883",
+          "product": {
+            "__typename": "DefaultFareProduct",
+            "id": "atlanta:electronicSenior",
+            "medium": null,
+            "name": "electronicSenior",
+            "riderCategory": null,
+            "price": {
+              "amount": 0,
+              "currency": {
+                "code": "USD",
+                "digits": 2
+              }
+            }
+          }
+        },
+        {
+          "id": "c25f4197-3483-3364-b447-f5f9adf421da",
+          "product": {
+            "__typename": "DefaultFareProduct",
+            "id": "atlanta:youth",
+            "medium": null,
+            "name": "youth",
+            "riderCategory": null,
+            "price": {
+              "amount": 0,
+              "currency": {
+                "code": "USD",
+                "digits": 2
+              }
+            }
+          }
+        },
+        {
+          "id": "889ffb31-2e8f-3c4d-bda4-df7c6add1026",
+          "product": {
+            "__typename": "DefaultFareProduct",
+            "id": "atlanta:senior",
+            "medium": null,
+            "name": "senior",
+            "riderCategory": null,
+            "price": {
+              "amount": 0,
+              "currency": {
+                "code": "USD",
+                "digits": 2
+              }
+            }
+          }
+        },
+        {
+          "id": "bb9d929b-5ce6-3bcf-8b38-6eaf4eaa2c22",
+          "product": {
+            "__typename": "DefaultFareProduct",
+            "id": "atlanta:electronicSpecial",
+            "medium": null,
+            "name": "electronicSpecial",
+            "riderCategory": null,
+            "price": {
+              "amount": 0,
+              "currency": {
+                "code": "USD",
+                "digits": 2
+              }
+            }
+          }
+        }
+      ],
+      "from": {
+        "lat": 33.916913,
+        "lon": -84.22609,
+        "name": "Best Friend Rd & Nancy Hanks Dr OB",
+        "rentalVehicle": null,
+        "stop": {
+          "alerts": [],
+          "code": "115",
+          "gtfsId": "GwinnettCountyTransit:115",
+          "id": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTE1",
+          "lat": 33.916913,
+          "lon": -84.22609
+        },
+        "vertexType": "TRANSIT"
+      },
+      "headsign": "Doraville MARTA",
+      "interlineWithPreviousLeg": false,
+      "intermediateStops": [
+        {
+          "lat": 33.916055,
+          "locationType": "STOP",
+          "lon": -84.229996,
+          "name": "Best Friend Rd & Skyland Ct OB",
+          "stopCode": "119",
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTE5"
+        },
+        {
+          "lat": 33.915618,
+          "locationType": "STOP",
+          "lon": -84.233462,
+          "name": "Best Friend Rd & Royal Palm Ct OB",
+          "stopCode": "117",
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTE3"
+        },
+        {
+          "lat": 33.913848,
+          "locationType": "STOP",
+          "lon": -84.236614,
+          "name": "Best Friend Rd & Button Gwinnett Dr OB",
+          "stopCode": "318",
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MzE4"
+        },
+        {
+          "lat": 33.914705,
+          "locationType": "STOP",
+          "lon": -84.238103,
+          "name": "Button Gwinnett & TOPSA",
+          "stopCode": "880",
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6ODgw"
+        },
+        {
+          "lat": 33.917448,
+          "locationType": "STOP",
+          "lon": -84.240083,
+          "name": "Button Gwinnett Dr & Mimms Dr",
+          "stopCode": "122",
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTIy"
+        },
+        {
+          "lat": 33.919495,
+          "locationType": "STOP",
+          "lon": -84.241523,
+          "name": "Button Gwinnett Dr & RUSH Truck Ctr",
+          "stopCode": "278",
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6Mjc4"
+        },
+        {
+          "lat": 33.924089,
+          "locationType": "STOP",
+          "lon": -84.244794,
+          "name": "Button Gwinnett Rd & Ryder",
+          "stopCode": "280",
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6Mjgw"
+        },
+        {
+          "lat": 33.925893,
+          "locationType": "STOP",
+          "lon": -84.247838,
+          "name": "Buford Hwy & Jones Mills Rd",
+          "stopCode": "191",
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTkx"
+        },
+        {
+          "lat": 33.923945,
+          "locationType": "STOP",
+          "lon": -84.250991,
+          "name": "Buford Hwy & Amwiler OB",
+          "stopCode": "180",
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTgw"
+        },
+        {
+          "lat": 33.922996,
+          "locationType": "STOP",
+          "lon": -84.25242,
+          "name": "Buford Hwy & East Lake Dr (across) OB",
+          "stopCode": "186",
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTg2"
+        },
+        {
+          "lat": 33.920743,
+          "locationType": "STOP",
+          "lon": -84.255512,
+          "name": "Buford Hwy & Steve Dr OB",
+          "stopCode": "202",
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MjAy"
+        },
+        {
+          "lat": 33.919256,
+          "locationType": "STOP",
+          "lon": -84.257175,
+          "name": "Buford Hwy at Global Forum OB",
+          "stopCode": "215",
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MjE1"
+        },
+        {
+          "lat": 33.917962,
+          "locationType": "STOP",
+          "lon": -84.258413,
+          "name": "Buford Hwy & Reyes Auto OB",
+          "stopCode": "225",
+          "stopId": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MjI1"
+        }
+      ],
+      "legGeometry": {
+        "length": 54,
+        "points": "kk_nEzkaaO?@hDnW????pAnKDdH??DlBt@jChHlJ??@@FH|ArBwGbEA@??a@V_OnJC@??w@f@_JtFA@??uVjOwC~B?B??oDvGkFvDx@lB@B??fCrFxFbK??@@h@|@rCzE??LP`FhIpEhG??@@dHjI??@@zFxF????jTlS"
+      },
+      "mode": "BUS",
+      "pickupBookingInfo": null,
+      "pickupType": "SCHEDULED",
+      "realTime": false,
+      "realtimeState": null,
+      "rentedBike": null,
+      "rideHailingEstimate": null,
+      "route": {
+        "alerts": [],
+        "color": "00BCF2",
+        "gtfsId": "GwinnettCountyTransit:20",
+        "id": "GwinnettCountyTransit:20",
+        "longName": "Beaver Ruin - Doraville",
+        "shortName": "20",
+        "textColor": "000000",
+        "type": 3
+      },
+      "startTime": 1729868286000,
+      "steps": [],
+      "to": {
+        "lat": 33.914541,
+        "lon": -84.261696,
+        "name": "Buford Hwy & Andy Glass OB",
+        "rentalVehicle": null,
+        "stop": {
+          "alerts": [],
+          "code": "184",
+          "gtfsId": "GwinnettCountyTransit:184",
+          "id": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTg0",
+          "lat": 33.914541,
+          "lon": -84.261696
+        },
+        "vertexType": "TRANSIT"
+      },
+      "transitLeg": true,
+      "trip": {
+        "arrivalStoptime": {
+          "stop": {
+            "gtfsId": "GwinnettCountyTransit:6",
+            "id": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6Ng"
+          },
+          "stopPosition": 3060
+        },
+        "departureStoptime": {
+          "stop": {
+            "gtfsId": "GwinnettCountyTransit:7",
+            "id": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6Nw"
+          },
+          "stopPosition": 0
+        },
+        "gtfsId": "GwinnettCountyTransit:t3FC-bCB-sl6",
+        "id": "VHJpcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6dDNGQy1iQ0Itc2w2"
+      }
+    },
+    {
+      "accessibilityScore": null,
+      "agency": null,
+      "alerts": [],
+      "arrivalDelay": 0,
+      "departureDelay": 0,
+      "distance": 25.22,
+      "dropoffType": "SCHEDULED",
+      "duration": 23,
+      "endTime": 1729868831000,
+      "fareProducts": [],
+      "from": {
+        "lat": 33.914541,
+        "lon": -84.261696,
+        "name": "Buford Hwy & Andy Glass OB",
+        "rentalVehicle": null,
+        "stop": {
+          "alerts": [],
+          "code": "184",
+          "gtfsId": "GwinnettCountyTransit:184",
+          "id": "U3RvcDpHd2lubmV0dENvdW50eVRyYW5zaXQ6MTg0",
+          "lat": 33.914541,
+          "lon": -84.261696
+        },
+        "vertexType": "TRANSIT"
+      },
+      "headsign": null,
+      "interlineWithPreviousLeg": false,
+      "intermediateStops": null,
+      "legGeometry": {
+        "length": 3,
+        "points": "{|~mErjhaO@Ac@a@"
+      },
+      "mode": "WALK",
+      "pickupBookingInfo": null,
+      "pickupType": "SCHEDULED",
+      "realTime": false,
+      "realtimeState": null,
+      "rentedBike": false,
+      "rideHailingEstimate": null,
+      "route": null,
+      "startTime": 1729868808000,
+      "steps": [
+        {
+          "absoluteDirection": "NORTHEAST",
+          "alerts": [],
+          "area": false,
+          "distance": 25.22,
+          "elevationProfile": [],
+          "lat": 33.9145331,
+          "lon": -84.2616838,
+          "relativeDirection": "DEPART",
+          "stayOn": false,
+          "streetName": "Buford Highway☆☆☆ tmp r0.384 l25.221"
+        }
+      ],
+      "to": {
+        "lat": 33.9150078,
+        "lon": -84.2619698,
+        "name": "6020 Buford Highway, Doraville, GA, USA",
+        "rentalVehicle": null,
+        "stop": null,
+        "vertexType": "NORMAL"
+      },
+      "transitLeg": false,
+      "trip": null
+    }
+  ],
+  "startTime": 1729868286000,
+  "transfers": 0,
+  "waitingTime": 0,
+  "walkTime": 23
+}

--- a/packages/transitive-overlay/src/TransitiveOverlay.story.tsx
+++ b/packages/transitive-overlay/src/TransitiveOverlay.story.tsx
@@ -70,133 +70,99 @@ export default {
   }
 };
 
-const Template = injectIntl(
-  ({ itinerary, mapCoords, mapZoom, intl, ...args }) => (
-    <>
-      <EndpointsOverlay
-        fromLocation={getFromLocation(itinerary)}
-        setLocation={setLocation}
-        toLocation={getToLocation(itinerary)}
-        visible
-      />
-      <TransitiveOverlay
-        transitiveData={itineraryToTransitive(itinerary, { companies, intl })}
-        {...args}
-      />
-    </>
-  )
-);
+const Template = injectIntl(({ itinerary, intl, ...args }) => (
+  <>
+    <EndpointsOverlay
+      fromLocation={getFromLocation(itinerary)}
+      setLocation={setLocation}
+      toLocation={getToLocation(itinerary)}
+      visible
+    />
+    <TransitiveOverlay
+      transitiveData={itineraryToTransitive(itinerary, { companies, intl })}
+      {...args}
+    />
+  </>
+));
 
 export const WalkingItinerary = Template.bind({});
 WalkingItinerary.args = {
-  itinerary: walkOnlyItinerary,
-  mapCoords: [45.518841, -122.679302],
-  mapZoom: 19
+  itinerary: walkOnlyItinerary
 };
 
 export const BikeOnlyItinerary = Template.bind({});
 BikeOnlyItinerary.args = {
-  itinerary: bikeOnlyItinerary,
-  mapCoords: [45.520441, -122.68302],
-  mapZoom: 16
+  itinerary: bikeOnlyItinerary
 };
 
 export const WalkTransitWalkItinerary = Template.bind({});
 WalkTransitWalkItinerary.args = {
-  itinerary: walkTransitWalkItinerary,
-  mapCoords: [45.520441, -122.68302],
-  mapZoom: 16
+  itinerary: walkTransitWalkItinerary
 };
 
 export const WalkTransitWalkItineraryWithNoIntermediateStops = Template.bind(
   {}
 );
 WalkTransitWalkItineraryWithNoIntermediateStops.args = {
-  itinerary: walkTransitWalkItineraryNoIntermediateStops,
-  mapCoords: [45.525841, -122.649302],
-  mapZoom: 13
+  itinerary: walkTransitWalkItineraryNoIntermediateStops
 };
 
 export const BikeTransitBikeItinerary = Template.bind({});
 BikeTransitBikeItinerary.args = {
-  itinerary: bikeTransitBikeItinerary,
-  mapCoords: [45.520441, -122.68302],
-  mapZoom: 16
+  itinerary: bikeTransitBikeItinerary
 };
 
 export const WalkInterlinedTransitItinerary = Template.bind({});
 WalkInterlinedTransitItinerary.args = {
-  itinerary: walkInterlinedTransitItinerary,
-  mapCoords: [47.703022, -122.328041],
-  mapZoom: 12.5
+  itinerary: walkInterlinedTransitItinerary
 };
 
 export const WalkTransitTransferItinerary = Template.bind({});
 WalkTransitTransferItinerary.args = {
-  itinerary: walkTransitWalkTransitWalkItinerary,
-  mapCoords: [45.505841, -122.631302],
-  mapZoom: 14
+  itinerary: walkTransitWalkTransitWalkItinerary
 };
 
 export const BikeRentalItinerary = Template.bind({});
 BikeRentalItinerary.args = {
-  itinerary: bikeRentalItinerary,
-  mapCoords: [45.508841, -122.631302],
-  mapZoom: 14
+  itinerary: bikeRentalItinerary
 };
 
 export const EScooterRentalItinerary = Template.bind({});
 EScooterRentalItinerary.args = {
-  itinerary: eScooterRentalItinerary,
-  mapCoords: [45.52041, -122.675302],
-  mapZoom: 16
+  itinerary: eScooterRentalItinerary
 };
 
 export const ParkAndRideItinerary = Template.bind({});
 ParkAndRideItinerary.args = {
-  itinerary: parkAndRideItinerary,
-  mapCoords: [45.515841, -122.75302],
-  mapZoom: 13
+  itinerary: parkAndRideItinerary
 };
 
 export const BikeRentalTransitItinerary = Template.bind({});
 BikeRentalTransitItinerary.args = {
-  itinerary: bikeRentalTransitBikeRentalItinerary,
-  mapCoords: [45.538841, -122.6302],
-  mapZoom: 12
+  itinerary: bikeRentalTransitBikeRentalItinerary
 };
 
 export const EScooterRentalTransitItinerary = Template.bind({});
 EScooterRentalTransitItinerary.args = {
-  itinerary: eScooterRentalTransiteScooterRentalItinerary,
-  mapCoords: [45.538841, -122.6302],
-  mapZoom: 12
+  itinerary: eScooterRentalTransiteScooterRentalItinerary
 };
 
 export const TncTransitItinerary = Template.bind({});
 TncTransitItinerary.args = {
-  itinerary: tncTransitTncItinerary,
-  mapCoords: [45.538841, -122.6302],
-  mapZoom: 12
+  itinerary: tncTransitTncItinerary
 };
 
 export const FlexItinerary = Template.bind({});
 FlexItinerary.args = {
-  itinerary: flexItinerary,
-  mapCoords: [40.038487, -105.0529011],
-  mapZoom: 11
+  itinerary: flexItinerary
 };
 
 export const OTP2ScooterItinerary = Template.bind({});
 OTP2ScooterItinerary.args = {
-  itinerary: otp2ScooterItinerary,
-  mapCoords: [33.749, -84.388],
-  mapZoom: 11
+  itinerary: otp2ScooterItinerary
 };
 
 export const OTP2TransitItinerary = Template.bind({});
 OTP2TransitItinerary.args = {
-  itinerary: otp2TransitItinerary,
-  mapCoords: [33.749, -84.388],
-  mapZoom: 11
+  itinerary: otp2TransitItinerary
 };

--- a/packages/transitive-overlay/src/TransitiveOverlay.story.tsx
+++ b/packages/transitive-overlay/src/TransitiveOverlay.story.tsx
@@ -23,6 +23,7 @@ const walkTransitWalkItineraryNoIntermediateStops = require("@opentripplanner/it
 const walkTransitWalkTransitWalkItinerary = require("@opentripplanner/itinerary-body/src/__mocks__/itineraries/walk-transit-walk-transit-walk.json");
 const flexItinerary = require("@opentripplanner/itinerary-body/src/__mocks__/itineraries/flex-itinerary.json");
 const otp2ScooterItinerary = require("@opentripplanner/itinerary-body/src/__mocks__/itineraries/otp2-scooter.json");
+const otp2TransitItinerary = require("@opentripplanner/itinerary-body/src/__mocks__/itineraries/otp2-transit-leg.json");
 
 const companies = [
   {
@@ -189,6 +190,13 @@ FlexItinerary.args = {
 export const OTP2ScooterItinerary = Template.bind({});
 OTP2ScooterItinerary.args = {
   itinerary: otp2ScooterItinerary,
+  mapCoords: [33.749, -84.388],
+  mapZoom: 11
+};
+
+export const OTP2TransitItinerary = Template.bind({});
+OTP2TransitItinerary.args = {
+  itinerary: otp2TransitItinerary,
   mapCoords: [33.749, -84.388],
   mapZoom: 11
 };

--- a/packages/transitive-overlay/src/util.ts
+++ b/packages/transitive-overlay/src/util.ts
@@ -402,11 +402,15 @@ export function itineraryToTransitive(
           ? getRouteLabel(leg)
           : getLegRouteShortName(leg)) || "";
 
+      const basicRouteAttributes = {
+        agency_id: leg.agencyId,
+        route_id: routeId,
+        route_short_name: routeLabel
+      };
+
       if (typeof leg.route === "object") {
         routes[routeId] = {
-          agency_id: leg.agencyId,
-          route_id: routeId,
-          route_short_name: routeLabel,
+          ...basicRouteAttributes,
           route_long_name: leg.route.longName || "",
           route_type: leg.route.type,
           route_color: leg.route.color,
@@ -414,9 +418,7 @@ export function itineraryToTransitive(
         };
       } else {
         routes[routeId] = {
-          agency_id: leg.agencyId,
-          route_id: routeId,
-          route_short_name: routeLabel,
+          ...basicRouteAttributes,
           route_long_name: leg.routeLongName || "",
           route_type: leg.routeType,
           route_color: leg.routeColor,


### PR DESCRIPTION
This PR adds support for OTP2 leg routes, so that route colors and names from OTP2-returned itineraries render correctly. A new mock is added to itinerary-body but that's only for Storybook for transitive-overlay (i.e. dev and test time), so no new package release for itinerary-body will be created.

I have removed map coordinates and zoom from transitive-overlay stories as these story parameters don't seem to affect rendering - the map is autofitted when a new itinerary is rendered.

