### PR TITLE
Update Date/Time Selector

### DIFF
--- a/packages/trip-form/src/DateTimeSelector/index.tsx
+++ b/packages/trip-form/src/DateTimeSelector/index.tsx
@@ -91,6 +91,8 @@ function isInputTypeSupported(type: string): boolean {
 
 const supportsDateTimeInputs = isInputTypeSupported("date") && isInputTypeSupported("time");
 
+const buttonStyle = { backgroundColor: S.baseColor() || grey[700], border: "0px", borderRadius: "3px 0px 0px 3px", color: "white", height: "45px" }
+
 /**
  * Reference date for parsing.
  */
@@ -216,7 +218,7 @@ export default function DateTimeSelector({
       style={style}
       baseColor={baseColor}
     >
-        <Dropdown alignMenuLeft id="date-time-depart-arrive" text={departureOptions.find(opt => opt.type === departArrive).text} buttonStyle={{ backgroundColor: S.baseColor() || grey[700], borderRadius: "3px 0px 0px 3px", color: "white", height: "45px", border: "0px" }}>
+        <Dropdown alignMenuLeft id="date-time-depart-arrive" text={departureOptions.find(opt => opt.type === departArrive).text} buttonStyle={buttonStyle}>
         {departureOptions.map(opt => (
           <button
             aria-pressed={opt.type === departArrive}

--- a/packages/trip-form/src/DateTimeSelector/index.tsx
+++ b/packages/trip-form/src/DateTimeSelector/index.tsx
@@ -70,7 +70,6 @@ interface DateTimeSelectorProps {
 }
 
 interface DepartArriveOption {
-  isSelected?: boolean;
   text: string;
   type: DepartArriveValue;
 }
@@ -147,9 +146,6 @@ export default function DateTimeSelector({
       text: intl.formatMessage({ id: "otpUi.DateTimeSelector.arrive" })
     }
   ];
-  departureOptions.forEach(opt => {
-    opt.isSelected = departArrive === opt.type;
-  });
 
   const handleQueryParamChange = useCallback(
     (queryParam: QueryParamChangeEvent): void => {
@@ -199,13 +195,13 @@ export default function DateTimeSelector({
           departArrive: "NOW",
           time: getCurrentTime(timeZone)
         });
-      } else if (!option.isSelected) {
+      } else if (!(option.type === departArrive)) {
         handleQueryParamChange({
           departArrive: option.type
         });
       }
     },
-    [onQueryParamChange, option.type, option.isSelected, timeZone]
+    [onQueryParamChange, option.type, timeZone]
   );
 
 
@@ -220,10 +216,10 @@ export default function DateTimeSelector({
       style={style}
       baseColor={baseColor}
     >
-        <Dropdown alignMenuLeft id="date-time-depart-arrive" text={departureOptions.find(opt => opt.isSelected).text} buttonStyle={{ backgroundColor: S.baseColor() || blue[900], borderRadius: "3px 0px 0px 3px", color: "white", height: "45px", border: "0px", padding:"5px 7px" }}>
+        <Dropdown alignMenuLeft id="date-time-depart-arrive" text={departureOptions.find(opt => opt.type === departArrive).text} buttonStyle={{ backgroundColor: S.baseColor() || blue[900], borderRadius: "3px 0px 0px 3px", color: "white", height: "45px", border: "0px" }}>
         {departureOptions.map(opt => (
           <button
-            aria-pressed={opt.isSelected}
+            aria-pressed={opt.type === departArrive}
             key={opt.type}
             onClick={setDepartArrive(opt)}
             type="button"

--- a/packages/trip-form/src/DateTimeSelector/index.tsx
+++ b/packages/trip-form/src/DateTimeSelector/index.tsx
@@ -19,7 +19,7 @@ const {
   OTP_API_TIME_FORMAT
 } = coreUtils.time;
 
-const { blue } = colors;
+const { grey } = colors;
 
 type DepartArriveValue = "NOW" | "DEPART" | "ARRIVE";
 
@@ -216,7 +216,7 @@ export default function DateTimeSelector({
       style={style}
       baseColor={baseColor}
     >
-        <Dropdown alignMenuLeft id="date-time-depart-arrive" text={departureOptions.find(opt => opt.type === departArrive).text} buttonStyle={{ backgroundColor: S.baseColor() || blue[900], borderRadius: "3px 0px 0px 3px", color: "white", height: "45px", border: "0px" }}>
+        <Dropdown alignMenuLeft id="date-time-depart-arrive" text={departureOptions.find(opt => opt.type === departArrive).text} buttonStyle={{ backgroundColor: S.baseColor() || grey[700], borderRadius: "3px 0px 0px 3px", color: "white", height: "45px", border: "0px" }}>
         {departureOptions.map(opt => (
           <button
             aria-pressed={opt.type === departArrive}

--- a/packages/trip-form/src/MetroModeSelector/__snapshots__/AdvancedModeSettingsButton.story.tsx.snap
+++ b/packages/trip-form/src/MetroModeSelector/__snapshots__/AdvancedModeSettingsButton.story.tsx.snap
@@ -159,7 +159,7 @@ exports[`Trip Form Components/Advanced Mode Settings Buttons AdvancedModeSetting
                   </label>
                 </div>
               </div>
-              <div class="styled__DropdownSelector-sc-122ziys-17 kiQdDP">
+              <div class="styled__DropdownSelector-sc-122ziys-16 jBvmxW">
                 <div>
                   <label for="id-query-param-busColor"
                          class="styled__SettingLabel-sc-122ziys-2 hlSjLd"

--- a/packages/trip-form/src/__mocks__/trimet-styled.tsx
+++ b/packages/trip-form/src/__mocks__/trimet-styled.tsx
@@ -58,10 +58,11 @@ const TriMetStyled = styled.div`
       text-decoration: underline;
     }
   }
+  ${TripFormClasses.DateTimeSelector} {
+    max-width: 550px;
+  }
   ${TripFormClasses.DateTimeSelector.DateTimeRow} {
-    margin: 15px 0px;
     input {
-      padding: 6px 12px;
       text-align: center;
       font-size: inherit;
       font-family: inherit;

--- a/packages/trip-form/src/__snapshots__/SettingsSelectorPanel.story.tsx.snap
+++ b/packages/trip-form/src/__snapshots__/SettingsSelectorPanel.story.tsx.snap
@@ -3,16 +3,16 @@
 exports[`SeṯtingsSelectorPanel settingsSelectorPanel smoke-test 1`] = `
 <div>
   <div aria-label="Travel Preferences"
-       class="styled__SettingsSelectorPanel-sc-122ziys-20 cHOFdL"
+       class="styled__SettingsSelectorPanel-sc-122ziys-19 gFYycZ"
        role="group"
   >
-    <div class="styled__ModeSelector-sc-122ziys-7 kUleUC"
+    <div class="styled__ModeSelector-sc-122ziys-6 dNdlwn"
          style="margin: 0px -5px; padding-bottom: 8px;"
     >
-      <div class="styled__MainRow-sc-122ziys-8 kIuztG">
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+      <div class="styled__MainRow-sc-122ziys-7 gfBfQl">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="true"
-                  class="styled__Button-sc-122ziys-16 dxnCjq active "
+                  class="styled__Button-sc-122ziys-15 liaabt active "
                   title="Take Transit"
           >
             <span>
@@ -46,132 +46,132 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanel smoke-test 1`] = `
           </button>
         </div>
       </div>
-      <div class="styled__SecondaryRow-sc-122ziys-9 hBmEla">
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+      <div class="styled__SecondaryRow-sc-122ziys-8 dShQYv">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="true"
-                  class="styled__Button-sc-122ziys-16 dxnCjq active "
+                  class="styled__Button-sc-122ziys-15 liaabt active "
                   title="Saunter"
           >
             <span>
               Loading...
             </span>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv active "
+          <div class="styled__Title-sc-122ziys-14 iasiNe active "
                title="Saunter"
           >
             Saunter
           </div>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Transit + Personal Bike"
           >
             <span>
               Loading...
             </span>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv  "
+          <div class="styled__Title-sc-122ziys-14 iasiNe  "
                title="Transit + Personal Bike"
           >
             Transit + Personal Bike
           </div>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Transit + Biketown"
           >
             <span>
               Loading...
             </span>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv  "
+          <div class="styled__Title-sc-122ziys-14 iasiNe  "
                title="Transit + Biketown"
           >
             Transit + Biketown
           </div>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Transit + E-scooter"
           >
             <span>
               Loading...
             </span>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv  "
+          <div class="styled__Title-sc-122ziys-14 iasiNe  "
                title="Transit + E-scooter"
           >
             Transit + E-scooter
           </div>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Park &amp; Ride"
           >
             <span>
               Loading...
             </span>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv  "
+          <div class="styled__Title-sc-122ziys-14 iasiNe  "
                title="Park &amp; Ride"
           >
             Park &amp; Ride
           </div>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Transit + Uber"
           >
             <span>
               +Uber
             </span>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv  "
+          <div class="styled__Title-sc-122ziys-14 iasiNe  "
                title="Transit + Uber"
           >
             Transit + Uber
           </div>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Transit + ReachNow"
           >
             <span>
               +ReachNow
             </span>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv  "
+          <div class="styled__Title-sc-122ziys-14 iasiNe  "
                title="Transit + ReachNow"
           >
             Transit + ReachNow
           </div>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Transit + Car2Go"
           >
             <span>
               +Car2Go
             </span>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv  "
+          <div class="styled__Title-sc-122ziys-14 iasiNe  "
                title="Transit + Car2Go"
           >
             Transit + Car2Go
           </div>
         </div>
       </div>
-      <div class="styled__TertiaryRow-sc-122ziys-10 enlXGA">
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+      <div class="styled__TertiaryRow-sc-122ziys-9 gsiqpM">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Walk Only"
           >
             <span>
@@ -183,9 +183,9 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanel smoke-test 1`] = `
             </span>
           </button>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Bike Only"
           >
             <span>
@@ -199,9 +199,9 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanel smoke-test 1`] = `
             </span>
           </button>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="E-scooter Only"
           >
             <span>
@@ -219,7 +219,7 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanel smoke-test 1`] = `
       Travel Preferences
     </div>
     <div aria-label="Use"
-         class="styled__SettingsSection-sc-122ziys-1 styled__SubmodeSelector-sc-122ziys-11 ilyYai dliLpR"
+         class="styled__SettingsSection-sc-122ziys-1 styled__SubmodeSelector-sc-122ziys-10 ilyYai dhpvjI"
          role="group"
     >
       <span aria-hidden="true"
@@ -227,10 +227,10 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanel smoke-test 1`] = `
       >
         Use
       </span>
-      <div class="styled__submodeRow-sc-122ziys-12 gItmJF">
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+      <div class="styled__submodeRow-sc-122ziys-11 bzwMcq">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Buses"
           >
             <span>
@@ -242,9 +242,9 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanel smoke-test 1`] = `
             </span>
           </button>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="MAX and Portland Streetcar"
           >
             <span>
@@ -256,9 +256,9 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanel smoke-test 1`] = `
             </span>
           </button>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="WES Commuter Rail"
           >
             <span>
@@ -280,9 +280,9 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanel smoke-test 1`] = `
             </span>
           </button>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Aerial Tram"
           >
             <span>
@@ -296,8 +296,8 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanel smoke-test 1`] = `
         </div>
       </div>
     </div>
-    <div class="styled__GeneralSettingsPanel-sc-122ziys-19 hKJhWi">
-      <div class="styled__DropdownSelector-sc-122ziys-17 kiQdDP">
+    <div class="styled__GeneralSettingsPanel-sc-122ziys-18 jcRROj">
+      <div class="styled__DropdownSelector-sc-122ziys-16 jBvmxW">
         <div>
           <label for="id-query-param-maxWalkDistance"
                  class="styled__SettingLabel-sc-122ziys-2 hlSjLd"
@@ -339,16 +339,16 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanel smoke-test 1`] = `
 exports[`SeṯtingsSelectorPanel settingsSelectorPanelWithCustomIcons smoke-test 1`] = `
 <div>
   <div aria-label="Travel Preferences"
-       class="styled__SettingsSelectorPanel-sc-122ziys-20 cHOFdL"
+       class="styled__SettingsSelectorPanel-sc-122ziys-19 gFYycZ"
        role="group"
   >
-    <div class="styled__ModeSelector-sc-122ziys-7 kUleUC"
+    <div class="styled__ModeSelector-sc-122ziys-6 dNdlwn"
          style="margin: 0px -5px; padding-bottom: 8px;"
     >
-      <div class="styled__MainRow-sc-122ziys-8 kIuztG">
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+      <div class="styled__MainRow-sc-122ziys-7 gfBfQl">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="true"
-                  class="styled__Button-sc-122ziys-16 dxnCjq active "
+                  class="styled__Button-sc-122ziys-15 liaabt active "
                   title="Take Transit"
           >
             <span>
@@ -374,132 +374,132 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanelWithCustomIcons smoke-test
           </button>
         </div>
       </div>
-      <div class="styled__SecondaryRow-sc-122ziys-9 hBmEla">
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+      <div class="styled__SecondaryRow-sc-122ziys-8 dShQYv">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="true"
-                  class="styled__Button-sc-122ziys-16 dxnCjq active "
+                  class="styled__Button-sc-122ziys-15 liaabt active "
                   title="Saunter"
           >
             <span>
               Loading...
             </span>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv active "
+          <div class="styled__Title-sc-122ziys-14 iasiNe active "
                title="Saunter"
           >
             Saunter
           </div>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Transit + Personal Bike"
           >
             <span>
               Loading...
             </span>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv  "
+          <div class="styled__Title-sc-122ziys-14 iasiNe  "
                title="Transit + Personal Bike"
           >
             Transit + Personal Bike
           </div>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Transit + Biketown"
           >
             <span>
               Loading...
             </span>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv  "
+          <div class="styled__Title-sc-122ziys-14 iasiNe  "
                title="Transit + Biketown"
           >
             Transit + Biketown
           </div>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Transit + E-scooter"
           >
             <span>
               Loading...
             </span>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv  "
+          <div class="styled__Title-sc-122ziys-14 iasiNe  "
                title="Transit + E-scooter"
           >
             Transit + E-scooter
           </div>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Park &amp; Ride"
           >
             <span>
               Loading...
             </span>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv  "
+          <div class="styled__Title-sc-122ziys-14 iasiNe  "
                title="Park &amp; Ride"
           >
             Park &amp; Ride
           </div>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Transit + Uber"
           >
             <span>
               +Uber
             </span>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv  "
+          <div class="styled__Title-sc-122ziys-14 iasiNe  "
                title="Transit + Uber"
           >
             Transit + Uber
           </div>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Transit + ReachNow"
           >
             <span>
               +ReachNow
             </span>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv  "
+          <div class="styled__Title-sc-122ziys-14 iasiNe  "
                title="Transit + ReachNow"
           >
             Transit + ReachNow
           </div>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Transit + Car2Go"
           >
             <span>
               +Car2Go
             </span>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv  "
+          <div class="styled__Title-sc-122ziys-14 iasiNe  "
                title="Transit + Car2Go"
           >
             Transit + Car2Go
           </div>
         </div>
       </div>
-      <div class="styled__TertiaryRow-sc-122ziys-10 enlXGA">
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+      <div class="styled__TertiaryRow-sc-122ziys-9 gsiqpM">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Walk Only"
           >
             <span>
@@ -520,9 +520,9 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanelWithCustomIcons smoke-test
             </span>
           </button>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Bike Only"
           >
             <span>
@@ -539,9 +539,9 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanelWithCustomIcons smoke-test
             </span>
           </button>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="E-scooter Only"
           >
             <span>
@@ -563,7 +563,7 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanelWithCustomIcons smoke-test
       Travel Preferences
     </div>
     <div aria-label="Use"
-         class="styled__SettingsSection-sc-122ziys-1 styled__SubmodeSelector-sc-122ziys-11 ilyYai dliLpR"
+         class="styled__SettingsSection-sc-122ziys-1 styled__SubmodeSelector-sc-122ziys-10 ilyYai dhpvjI"
          role="group"
     >
       <span aria-hidden="true"
@@ -571,10 +571,10 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanelWithCustomIcons smoke-test
       >
         Use
       </span>
-      <div class="styled__submodeRow-sc-122ziys-12 gItmJF">
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+      <div class="styled__submodeRow-sc-122ziys-11 bzwMcq">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Buses"
           >
             <span>
@@ -599,9 +599,9 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanelWithCustomIcons smoke-test
             </span>
           </button>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="MAX and Portland Streetcar"
           >
             <span>
@@ -622,9 +622,9 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanelWithCustomIcons smoke-test
             </span>
           </button>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="WES Commuter Rail"
           >
             <span>
@@ -645,9 +645,9 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanelWithCustomIcons smoke-test
             </span>
           </button>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Aerial Tram"
           >
             <span>
@@ -672,8 +672,8 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanelWithCustomIcons smoke-test
         </div>
       </div>
     </div>
-    <div class="styled__GeneralSettingsPanel-sc-122ziys-19 hKJhWi">
-      <div class="styled__DropdownSelector-sc-122ziys-17 kiQdDP">
+    <div class="styled__GeneralSettingsPanel-sc-122ziys-18 jcRROj">
+      <div class="styled__DropdownSelector-sc-122ziys-16 jBvmxW">
         <div>
           <label for="id-query-param-maxWalkDistance"
                  class="styled__SettingLabel-sc-122ziys-2 hlSjLd"
@@ -715,16 +715,16 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanelWithCustomIcons smoke-test
 exports[`SeṯtingsSelectorPanel settingsSelectorPanelWithUndefinedParams smoke-test 1`] = `
 <div>
   <div aria-label="Travel Preferences"
-       class="styled__SettingsSelectorPanel-sc-122ziys-20 cHOFdL"
+       class="styled__SettingsSelectorPanel-sc-122ziys-19 gFYycZ"
        role="group"
   >
-    <div class="styled__ModeSelector-sc-122ziys-7 kUleUC"
+    <div class="styled__ModeSelector-sc-122ziys-6 dNdlwn"
          style="margin: 0px -5px; padding-bottom: 8px;"
     >
-      <div class="styled__MainRow-sc-122ziys-8 kIuztG">
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+      <div class="styled__MainRow-sc-122ziys-7 gfBfQl">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="true"
-                  class="styled__Button-sc-122ziys-16 dxnCjq active "
+                  class="styled__Button-sc-122ziys-15 liaabt active "
                   title="Take Transit"
           >
             <span>
@@ -758,14 +758,14 @@ exports[`SeṯtingsSelectorPanel settingsSelectorPanelWithUndefinedParams smoke-
           </button>
         </div>
       </div>
-      <div class="styled__TertiaryRow-sc-122ziys-10 enlXGA">
+      <div class="styled__TertiaryRow-sc-122ziys-9 gsiqpM">
       </div>
     </div>
     <div class="styled__SettingsHeader-sc-122ziys-0 kGehGV">
       Travel Preferences
     </div>
-    <div class="styled__GeneralSettingsPanel-sc-122ziys-19 hKJhWi">
-      <div class="styled__DropdownSelector-sc-122ziys-17 kiQdDP">
+    <div class="styled__GeneralSettingsPanel-sc-122ziys-18 jcRROj">
+      <div class="styled__DropdownSelector-sc-122ziys-16 jBvmxW">
         <div>
           <label for="id-query-param-maxWalkDistance"
                  class="styled__SettingLabel-sc-122ziys-2 hlSjLd"

--- a/packages/trip-form/src/__snapshots__/TripOptions.story.tsx.snap
+++ b/packages/trip-form/src/__snapshots__/TripOptions.story.tsx.snap
@@ -225,8 +225,8 @@ exports[`TripOptions CompanyFirstMixedCategory smoke-test 1`] = `
     </button>
   </div>
   <div class="styled__TripOptionsSubContainer-sc-18bsv9u-1 ddbfLo">
-    <div class="styled__GeneralSettingsPanel-sc-122ziys-19 hKJhWi">
-      <div class="styled__DropdownSelector-sc-122ziys-17 kiQdDP">
+    <div class="styled__GeneralSettingsPanel-sc-122ziys-18 jcRROj">
+      <div class="styled__DropdownSelector-sc-122ziys-16 jBvmxW">
         <div>
           <label for="id-query-param-maxWalkDistance"
                  class="styled__SettingLabel-sc-122ziys-2 hlSjLd"
@@ -564,8 +564,8 @@ exports[`TripOptions Default smoke-test 1`] = `
     </button>
   </div>
   <div class="styled__TripOptionsSubContainer-sc-18bsv9u-1 ddbfLo">
-    <div class="styled__GeneralSettingsPanel-sc-122ziys-19 hKJhWi">
-      <div class="styled__DropdownSelector-sc-122ziys-17 kiQdDP">
+    <div class="styled__GeneralSettingsPanel-sc-122ziys-18 jcRROj">
+      <div class="styled__DropdownSelector-sc-122ziys-16 jBvmxW">
         <div>
           <label for="id-query-param-maxWalkDistance"
                  class="styled__SettingLabel-sc-122ziys-2 hlSjLd"

--- a/packages/trip-form/src/__snapshots__/components.story.tsx.snap
+++ b/packages/trip-form/src/__snapshots__/components.story.tsx.snap
@@ -41,30 +41,41 @@ exports[`Trip Form Components dateTimeSelector smoke-test 1`] = `
 </p>
 <div>
   <div aria-label="Date/Time Selector"
-       class="styled__DateTimeSelector-sc-122ziys-4 fXHZJj"
+       class="styled__DateTimeSelector-sc-122ziys-4 ieeLrJ"
        role="group"
   >
-    <div class="styled__DepartureRow-sc-122ziys-5 iHMVJs">
-      <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
-        <button aria-pressed="true"
-                class="styled__Button-sc-122ziys-16 dxnCjq active "
-        >
+    <span class="styled__DropdownWrapper-sc-kes9ha-2 dgncpu"
+          id="date-time-depart-arrive-wrapper"
+    >
+      <button aria-expanded="false"
+              aria-haspopup="listbox"
+              id="date-time-depart-arrive-label"
+              class="styled__DropdownButton-sc-kes9ha-0 eBZyNH"
+              style="background-color: rgb(102, 102, 102); border: 0px; border-radius: 3px 0px 0px 3px; color: white; height: 45px;"
+      >
+        <span>
           Leave now
-        </button>
-      </div>
-      <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
-        <button aria-pressed="false"
-                class="styled__Button-sc-122ziys-16 dxnCjq  "
+        </span>
+        <span class="caret"
+              role="presentation"
         >
-          Depart at
-        </button>
-      </div>
-      <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
-        <button aria-pressed="false"
-                class="styled__Button-sc-122ziys-16 dxnCjq  "
+        </span>
+      </button>
+    </span>
+    <div class="styled__DateTimeRow-sc-122ziys-5 eSpCdp">
+      <div>
+        <input aria-label="Time"
+               required
+               type="time"
+               value="14:17"
         >
-          Arrive by
-        </button>
+      </div>
+      <div>
+        <input aria-label="Date"
+               required
+               type="date"
+               value="2020-02-15"
+        >
       </div>
     </div>
   </div>
@@ -75,30 +86,41 @@ exports[`Trip Form Components dateTimeSelector smoke-test 1`] = `
 <div>
   <div class="trimet-styled__TriMetStyled-sc-buwk9d-0 eAInfX">
     <div aria-label="Date/Time Selector"
-         class="styled__DateTimeSelector-sc-122ziys-4 fXHZJj"
+         class="styled__DateTimeSelector-sc-122ziys-4 ieeLrJ"
          role="group"
     >
-      <div class="styled__DepartureRow-sc-122ziys-5 iHMVJs">
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
-          <button aria-pressed="true"
-                  class="styled__Button-sc-122ziys-16 dxnCjq active "
-          >
+      <span class="styled__DropdownWrapper-sc-kes9ha-2 dgncpu"
+            id="date-time-depart-arrive-wrapper"
+      >
+        <button aria-expanded="false"
+                aria-haspopup="listbox"
+                id="date-time-depart-arrive-label"
+                class="styled__DropdownButton-sc-kes9ha-0 eBZyNH"
+                style="background-color: rgb(102, 102, 102); border: 0px; border-radius: 3px 0px 0px 3px; color: white; height: 45px;"
+        >
+          <span>
             Leave now
-          </button>
-        </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
-          <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+          </span>
+          <span class="caret"
+                role="presentation"
           >
-            Depart at
-          </button>
-        </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
-          <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+          </span>
+        </button>
+      </span>
+      <div class="styled__DateTimeRow-sc-122ziys-5 eSpCdp">
+        <div>
+          <input aria-label="Time"
+                 required
+                 type="time"
+                 value="14:17"
           >
-            Arrive by
-          </button>
+        </div>
+        <div>
+          <input aria-label="Date"
+                 required
+                 type="date"
+                 value="2020-02-15"
+          >
         </div>
       </div>
     </div>
@@ -111,7 +133,7 @@ exports[`Trip Form Components dropdownSelector smoke-test 1`] = `
   Plain
 </p>
 <div>
-  <div class="styled__DropdownSelector-sc-122ziys-17 kiQdDP"
+  <div class="styled__DropdownSelector-sc-122ziys-16 jBvmxW"
        style="display: inline-block; width: 250px;"
   >
     <div>
@@ -138,7 +160,7 @@ exports[`Trip Form Components dropdownSelector smoke-test 1`] = `
 </p>
 <div>
   <div class="trimet-styled__TriMetStyled-sc-buwk9d-0 eAInfX">
-    <div class="styled__DropdownSelector-sc-122ziys-17 kiQdDP"
+    <div class="styled__DropdownSelector-sc-122ziys-16 jBvmxW"
          style="display: inline-block; width: 250px;"
     >
       <div>
@@ -168,8 +190,8 @@ exports[`Trip Form Components generalSettingsPanel smoke-test 1`] = `
   Plain
 </p>
 <div>
-  <div class="styled__GeneralSettingsPanel-sc-122ziys-19 hKJhWi">
-    <div class="styled__DropdownSelector-sc-122ziys-17 kiQdDP">
+  <div class="styled__GeneralSettingsPanel-sc-122ziys-18 jcRROj">
+    <div class="styled__DropdownSelector-sc-122ziys-16 jBvmxW">
       <div>
         <label for="id-query-param-maxWalkDistance"
                class="styled__SettingLabel-sc-122ziys-2 hlSjLd"
@@ -210,8 +232,8 @@ exports[`Trip Form Components generalSettingsPanel smoke-test 1`] = `
 </p>
 <div>
   <div class="trimet-styled__TriMetStyled-sc-buwk9d-0 eAInfX">
-    <div class="styled__GeneralSettingsPanel-sc-122ziys-19 hKJhWi">
-      <div class="styled__DropdownSelector-sc-122ziys-17 kiQdDP">
+    <div class="styled__GeneralSettingsPanel-sc-122ziys-18 jcRROj">
+      <div class="styled__DropdownSelector-sc-122ziys-16 jBvmxW">
         <div>
           <label for="id-query-param-maxWalkDistance"
                  class="styled__SettingLabel-sc-122ziys-2 hlSjLd"
@@ -255,8 +277,8 @@ exports[`Trip Form Components generalSettingsPanelWithCustomMessages smoke-test 
   Plain
 </p>
 <div>
-  <div class="styled__GeneralSettingsPanel-sc-122ziys-19 hKJhWi">
-    <div class="styled__DropdownSelector-sc-122ziys-17 kiQdDP">
+  <div class="styled__GeneralSettingsPanel-sc-122ziys-18 jcRROj">
+    <div class="styled__DropdownSelector-sc-122ziys-16 jBvmxW">
       <div>
         <label for="id-query-param-maxWalkDistance"
                class="styled__SettingLabel-sc-122ziys-2 hlSjLd"
@@ -282,8 +304,8 @@ exports[`Trip Form Components generalSettingsPanelWithCustomMessages smoke-test 
 </p>
 <div>
   <div class="trimet-styled__TriMetStyled-sc-buwk9d-0 eAInfX">
-    <div class="styled__GeneralSettingsPanel-sc-122ziys-19 hKJhWi">
-      <div class="styled__DropdownSelector-sc-122ziys-17 kiQdDP">
+    <div class="styled__GeneralSettingsPanel-sc-122ziys-18 jcRROj">
+      <div class="styled__DropdownSelector-sc-122ziys-16 jBvmxW">
         <div>
           <label for="id-query-param-maxWalkDistance"
                  class="styled__SettingLabel-sc-122ziys-2 hlSjLd"
@@ -312,9 +334,9 @@ exports[`Trip Form Components generalSettingsPanelWithOtp2 smoke-test 1`] = `
   Plain
 </p>
 <div>
-  <div class="styled__GeneralSettingsPanel-sc-122ziys-19 hKJhWi">
+  <div class="styled__GeneralSettingsPanel-sc-122ziys-18 jcRROj">
     <div aria-label="walk reluctance"
-         class="styled__SliderSelector-sc-122ziys-18 qDJRa"
+         class="styled__SliderSelector-sc-122ziys-17 fDkIgR"
          role="group"
     >
       <div>
@@ -346,9 +368,9 @@ exports[`Trip Form Components generalSettingsPanelWithOtp2 smoke-test 1`] = `
 </p>
 <div>
   <div class="trimet-styled__TriMetStyled-sc-buwk9d-0 eAInfX">
-    <div class="styled__GeneralSettingsPanel-sc-122ziys-19 hKJhWi">
+    <div class="styled__GeneralSettingsPanel-sc-122ziys-18 jcRROj">
       <div aria-label="walk reluctance"
-           class="styled__SliderSelector-sc-122ziys-18 qDJRa"
+           class="styled__SliderSelector-sc-122ziys-17 fDkIgR"
            role="group"
       >
         <div>
@@ -385,9 +407,9 @@ exports[`Trip Form Components modeButtons smoke-test 1`] = `
 <div>
   <div>
     <div>
-      <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+      <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
         <button aria-pressed="false"
-                class="styled__Button-sc-122ziys-16 dxnCjq  "
+                class="styled__Button-sc-122ziys-15 liaabt  "
                 title="Normal"
         >
           <svg viewbox="0 0 390 390">
@@ -409,7 +431,7 @@ exports[`Trip Form Components modeButtons smoke-test 1`] = `
           </span>
           bike
         </button>
-        <div class="styled__Title-sc-122ziys-15 gZuthv  "
+        <div class="styled__Title-sc-122ziys-14 iasiNe  "
              title="Normal"
         >
           Normal
@@ -417,9 +439,9 @@ exports[`Trip Form Components modeButtons smoke-test 1`] = `
       </div>
       <span style="display: inline-block; width: 1em;">
       </span>
-      <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+      <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
         <button aria-pressed="true"
-                class="styled__Button-sc-122ziys-16 dxnCjq active "
+                class="styled__Button-sc-122ziys-15 liaabt active "
                 title="Active"
         >
           <svg viewbox="0 0 390 390">
@@ -428,7 +450,7 @@ exports[`Trip Form Components modeButtons smoke-test 1`] = `
           </svg>
           Train
         </button>
-        <div class="styled__Title-sc-122ziys-15 gZuthv active "
+        <div class="styled__Title-sc-122ziys-14 iasiNe active "
              title="Active"
         >
           Active
@@ -436,9 +458,9 @@ exports[`Trip Form Components modeButtons smoke-test 1`] = `
       </div>
       <span style="display: inline-block; width: 1em;">
       </span>
-      <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+      <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
         <button aria-pressed="false"
-                class="styled__Button-sc-122ziys-16 dxnCjq  disabled"
+                class="styled__Button-sc-122ziys-15 liaabt  disabled"
                 disabled
                 title="Disabled"
         >
@@ -459,7 +481,7 @@ exports[`Trip Form Components modeButtons smoke-test 1`] = `
             </path>
           </svg>
         </button>
-        <div class="styled__Title-sc-122ziys-15 gZuthv  disabled"
+        <div class="styled__Title-sc-122ziys-14 iasiNe  disabled"
              title="Disabled"
         >
           Disabled
@@ -467,9 +489,9 @@ exports[`Trip Form Components modeButtons smoke-test 1`] = `
       </div>
     </div>
     <div>
-      <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+      <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
         <button aria-pressed="false"
-                class="styled__Button-sc-122ziys-16 dxnCjq  "
+                class="styled__Button-sc-122ziys-15 liaabt  "
                 title="Walk Only"
         >
           <svg viewbox="0 0 390 390">
@@ -489,9 +511,9 @@ exports[`Trip Form Components modeButtons smoke-test 1`] = `
   <div class="trimet-styled__TriMetStyled-sc-buwk9d-0 eAInfX">
     <div>
       <div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Normal"
           >
             <svg viewbox="0 0 390 390">
@@ -513,7 +535,7 @@ exports[`Trip Form Components modeButtons smoke-test 1`] = `
             </span>
             bike
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv  "
+          <div class="styled__Title-sc-122ziys-14 iasiNe  "
                title="Normal"
           >
             Normal
@@ -521,9 +543,9 @@ exports[`Trip Form Components modeButtons smoke-test 1`] = `
         </div>
         <span style="display: inline-block; width: 1em;">
         </span>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="true"
-                  class="styled__Button-sc-122ziys-16 dxnCjq active "
+                  class="styled__Button-sc-122ziys-15 liaabt active "
                   title="Active"
           >
             <svg viewbox="0 0 390 390">
@@ -532,7 +554,7 @@ exports[`Trip Form Components modeButtons smoke-test 1`] = `
             </svg>
             Train
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv active "
+          <div class="styled__Title-sc-122ziys-14 iasiNe active "
                title="Active"
           >
             Active
@@ -540,9 +562,9 @@ exports[`Trip Form Components modeButtons smoke-test 1`] = `
         </div>
         <span style="display: inline-block; width: 1em;">
         </span>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  disabled"
+                  class="styled__Button-sc-122ziys-15 liaabt  disabled"
                   disabled
                   title="Disabled"
           >
@@ -563,7 +585,7 @@ exports[`Trip Form Components modeButtons smoke-test 1`] = `
               </path>
             </svg>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv  disabled"
+          <div class="styled__Title-sc-122ziys-14 iasiNe  disabled"
                title="Disabled"
           >
             Disabled
@@ -571,9 +593,9 @@ exports[`Trip Form Components modeButtons smoke-test 1`] = `
         </div>
       </div>
       <div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Walk Only"
           >
             <svg viewbox="0 0 390 390">
@@ -594,11 +616,11 @@ exports[`Trip Form Components modeSelector smoke-test 1`] = `
   Plain
 </p>
 <div>
-  <div class="styled__ModeSelector-sc-122ziys-7 kUleUC">
-    <div class="styled__MainRow-sc-122ziys-8 kIuztG">
-      <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+  <div class="styled__ModeSelector-sc-122ziys-6 dNdlwn">
+    <div class="styled__MainRow-sc-122ziys-7 gfBfQl">
+      <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
         <button aria-pressed="false"
-                class="styled__Button-sc-122ziys-16 dxnCjq  "
+                class="styled__Button-sc-122ziys-15 liaabt  "
                 title="Primary Choice"
         >
           <span>
@@ -613,17 +635,17 @@ exports[`Trip Form Components modeSelector smoke-test 1`] = `
             Primary Choice
           </span>
         </button>
-        <div class="styled__Title-sc-122ziys-15 gZuthv  "
+        <div class="styled__Title-sc-122ziys-14 iasiNe  "
              title="Primary Choice"
         >
           Primary Choice
         </div>
       </div>
     </div>
-    <div class="styled__SecondaryRow-sc-122ziys-9 hBmEla">
-      <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+    <div class="styled__SecondaryRow-sc-122ziys-8 dShQYv">
+      <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
         <button aria-pressed="false"
-                class="styled__Button-sc-122ziys-16 dxnCjq  "
+                class="styled__Button-sc-122ziys-15 liaabt  "
                 title="Secondary 1"
         >
           <span>
@@ -638,15 +660,15 @@ exports[`Trip Form Components modeSelector smoke-test 1`] = `
             Sec. #1
           </span>
         </button>
-        <div class="styled__Title-sc-122ziys-15 gZuthv  "
+        <div class="styled__Title-sc-122ziys-14 iasiNe  "
              title="Secondary 1"
         >
           Secondary 1
         </div>
       </div>
-      <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+      <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
         <button aria-pressed="true"
-                class="styled__Button-sc-122ziys-16 dxnCjq active "
+                class="styled__Button-sc-122ziys-15 liaabt active "
                 title="Secondary 2"
         >
           <span>
@@ -659,17 +681,17 @@ exports[`Trip Form Components modeSelector smoke-test 1`] = `
         </button>
       </div>
     </div>
-    <div class="styled__TertiaryRow-sc-122ziys-10 enlXGA">
-      <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+    <div class="styled__TertiaryRow-sc-122ziys-9 gsiqpM">
+      <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
         <button aria-pressed="false"
-                class="styled__Button-sc-122ziys-16 dxnCjq  "
+                class="styled__Button-sc-122ziys-15 liaabt  "
                 title="Other Mode"
         >
           <span>
             Tertiary Mode
           </span>
         </button>
-        <div class="styled__Title-sc-122ziys-15 gZuthv  "
+        <div class="styled__Title-sc-122ziys-14 iasiNe  "
              title="Other Mode"
         >
           Other Mode
@@ -683,11 +705,11 @@ exports[`Trip Form Components modeSelector smoke-test 1`] = `
 </p>
 <div>
   <div class="trimet-styled__TriMetStyled-sc-buwk9d-0 eAInfX">
-    <div class="styled__ModeSelector-sc-122ziys-7 kUleUC">
-      <div class="styled__MainRow-sc-122ziys-8 kIuztG">
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+    <div class="styled__ModeSelector-sc-122ziys-6 dNdlwn">
+      <div class="styled__MainRow-sc-122ziys-7 gfBfQl">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Primary Choice"
           >
             <span>
@@ -702,17 +724,17 @@ exports[`Trip Form Components modeSelector smoke-test 1`] = `
               Primary Choice
             </span>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv  "
+          <div class="styled__Title-sc-122ziys-14 iasiNe  "
                title="Primary Choice"
           >
             Primary Choice
           </div>
         </div>
       </div>
-      <div class="styled__SecondaryRow-sc-122ziys-9 hBmEla">
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+      <div class="styled__SecondaryRow-sc-122ziys-8 dShQYv">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Secondary 1"
           >
             <span>
@@ -727,15 +749,15 @@ exports[`Trip Form Components modeSelector smoke-test 1`] = `
               Sec. #1
             </span>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv  "
+          <div class="styled__Title-sc-122ziys-14 iasiNe  "
                title="Secondary 1"
           >
             Secondary 1
           </div>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="true"
-                  class="styled__Button-sc-122ziys-16 dxnCjq active "
+                  class="styled__Button-sc-122ziys-15 liaabt active "
                   title="Secondary 2"
           >
             <span>
@@ -748,17 +770,17 @@ exports[`Trip Form Components modeSelector smoke-test 1`] = `
           </button>
         </div>
       </div>
-      <div class="styled__TertiaryRow-sc-122ziys-10 enlXGA">
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+      <div class="styled__TertiaryRow-sc-122ziys-9 gsiqpM">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Other Mode"
           >
             <span>
               Tertiary Mode
             </span>
           </button>
-          <div class="styled__Title-sc-122ziys-15 gZuthv  "
+          <div class="styled__Title-sc-122ziys-14 iasiNe  "
                title="Other Mode"
           >
             Other Mode
@@ -776,7 +798,7 @@ exports[`Trip Form Components sliderSelector smoke-test 1`] = `
 </p>
 <div>
   <div aria-label="Drag me."
-       class="styled__SliderSelector-sc-122ziys-18 qDJRa"
+       class="styled__SliderSelector-sc-122ziys-17 fDkIgR"
        role="group"
        style="display: inline-block; width: 250px;"
   >
@@ -809,7 +831,7 @@ exports[`Trip Form Components sliderSelector smoke-test 1`] = `
 <div>
   <div class="trimet-styled__TriMetStyled-sc-buwk9d-0 eAInfX">
     <div aria-label="Drag me."
-         class="styled__SliderSelector-sc-122ziys-18 qDJRa"
+         class="styled__SliderSelector-sc-122ziys-17 fDkIgR"
          role="group"
          style="display: inline-block; width: 250px;"
     >
@@ -845,7 +867,7 @@ exports[`Trip Form Components submodeSelector smoke-test 1`] = `
 </p>
 <div>
   <div aria-label="Submodes:"
-       class="styled__SettingsSection-sc-122ziys-1 styled__SubmodeSelector-sc-122ziys-11 ilyYai dliLpR"
+       class="styled__SettingsSection-sc-122ziys-1 styled__SubmodeSelector-sc-122ziys-10 ilyYai dhpvjI"
        role="group"
   >
     <span aria-hidden="true"
@@ -853,10 +875,10 @@ exports[`Trip Form Components submodeSelector smoke-test 1`] = `
     >
       Submodes:
     </span>
-    <div class="styled__submodeRow-sc-122ziys-12 gItmJF">
-      <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+    <div class="styled__submodeRow-sc-122ziys-11 bzwMcq">
+      <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
         <button aria-pressed="false"
-                class="styled__Button-sc-122ziys-16 dxnCjq  "
+                class="styled__Button-sc-122ziys-15 liaabt  "
                 title="Use the bus"
         >
           <span>
@@ -868,9 +890,9 @@ exports[`Trip Form Components submodeSelector smoke-test 1`] = `
           </span>
         </button>
       </div>
-      <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+      <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
         <button aria-pressed="true"
-                class="styled__Button-sc-122ziys-16 dxnCjq active "
+                class="styled__Button-sc-122ziys-15 liaabt active "
                 title="Use the streetcar"
         >
           <span>
@@ -882,9 +904,9 @@ exports[`Trip Form Components submodeSelector smoke-test 1`] = `
           </span>
         </button>
       </div>
-      <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+      <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
         <button aria-pressed="true"
-                class="styled__Button-sc-122ziys-16 dxnCjq active "
+                class="styled__Button-sc-122ziys-15 liaabt active "
                 title="Uber"
         >
           <span>
@@ -915,7 +937,7 @@ exports[`Trip Form Components submodeSelector smoke-test 1`] = `
 <div>
   <div class="trimet-styled__TriMetStyled-sc-buwk9d-0 eAInfX">
     <div aria-label="Submodes:"
-         class="styled__SettingsSection-sc-122ziys-1 styled__SubmodeSelector-sc-122ziys-11 ilyYai dliLpR"
+         class="styled__SettingsSection-sc-122ziys-1 styled__SubmodeSelector-sc-122ziys-10 ilyYai dhpvjI"
          role="group"
     >
       <span aria-hidden="true"
@@ -923,10 +945,10 @@ exports[`Trip Form Components submodeSelector smoke-test 1`] = `
       >
         Submodes:
       </span>
-      <div class="styled__submodeRow-sc-122ziys-12 gItmJF">
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+      <div class="styled__submodeRow-sc-122ziys-11 bzwMcq">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="false"
-                  class="styled__Button-sc-122ziys-16 dxnCjq  "
+                  class="styled__Button-sc-122ziys-15 liaabt  "
                   title="Use the bus"
           >
             <span>
@@ -938,9 +960,9 @@ exports[`Trip Form Components submodeSelector smoke-test 1`] = `
             </span>
           </button>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="true"
-                  class="styled__Button-sc-122ziys-16 dxnCjq active "
+                  class="styled__Button-sc-122ziys-15 liaabt active "
                   title="Use the streetcar"
           >
             <span>
@@ -952,9 +974,9 @@ exports[`Trip Form Components submodeSelector smoke-test 1`] = `
             </span>
           </button>
         </div>
-        <div class="styled__ModeButton-sc-122ziys-14 bNGAA-D">
+        <div class="styled__ModeButton-sc-122ziys-13 ecfMDE">
           <button aria-pressed="true"
-                  class="styled__Button-sc-122ziys-16 dxnCjq active "
+                  class="styled__Button-sc-122ziys-15 liaabt active "
                   title="Uber"
           >
             <span>

--- a/packages/trip-form/src/styled.ts
+++ b/packages/trip-form/src/styled.ts
@@ -39,7 +39,7 @@ display: flex;
 justify-content: space-around;
 align-items: center;
 height: 100%;
-padding: 0 0%;
+padding: 0;
 background-color: white;
 border-radius: 0 3px 3px 0;
 

--- a/packages/trip-form/src/styled.ts
+++ b/packages/trip-form/src/styled.ts
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import colors from "@opentripplanner/building-blocks"
 
 // eslint-disable-next-line prettier/prettier
 import type {
@@ -7,6 +8,12 @@ import type {
   ModeSelectorAndSubComponents,
   SubmodeSelectorAndSubComponents
 } from "./types";
+
+const { blue } = colors;
+
+export const baseColor = () => getComputedStyle(document.documentElement).getPropertyValue(
+  "--main-base-color"
+)
 
 export const SettingsHeader = styled.div``;
 
@@ -21,29 +28,26 @@ export const FloatingSettingLabel = styled(SettingLabel)`
   float: left;
 `;
 
-export const DateTimeSelector: DateTimeSelectorAndSubComponents = styled.div``;
-
-DateTimeSelector.DepartureRow = styled.div`
-  box-sizing: border-box;
-  > * {
-    box-sizing: border-box;
-    width: 33.333333%;
-    padding: 0px 5px;
-  }
+export const DateTimeSelector: DateTimeSelectorAndSubComponents = styled.div<{ baseColor: string | undefined }>`
+border: 2px solid ${(props) => props.baseColor || blue[900]};
+border-radius: 5px;
+height: 45px;
 `;
 
 DateTimeSelector.DateTimeRow = styled.div`
-  box-sizing: border-box;
-  > * {
-    box-sizing: border-box;
-    width: 50%;
-    padding: 0px 5px;
-    display: inline-block;
-  }
-  input {
-    box-sizing: border-box;
-    width: 100%;
-  }
+display: flex;
+justify-content: space-around;
+align-items: center;
+height: 100%;
+padding: 0 0%;
+background-color: white;
+border-radius: 0 3px 3px 0;
+
+input {
+  border: 0px;
+  height: 100%;
+  width: 100%;
+}
 `;
 
 export const ModeSelector: ModeSelectorAndSubComponents = styled.div``;

--- a/packages/trip-form/src/styled.ts
+++ b/packages/trip-form/src/styled.ts
@@ -9,7 +9,7 @@ import type {
   SubmodeSelectorAndSubComponents
 } from "./types";
 
-const { blue } = colors;
+const { grey } = colors;
 
 export const baseColor = () => getComputedStyle(document.documentElement).getPropertyValue(
   "--main-base-color"
@@ -29,7 +29,7 @@ export const FloatingSettingLabel = styled(SettingLabel)`
 `;
 
 export const DateTimeSelector: DateTimeSelectorAndSubComponents = styled.div<{ baseColor: string | undefined }>`
-border: 2px solid ${(props) => props.baseColor || blue[900]};
+border: 2px solid ${(props) => props.baseColor || grey[700]};
 border-radius: 5px;
 height: 45px;
 `;

--- a/packages/trip-form/src/styled.ts
+++ b/packages/trip-form/src/styled.ts
@@ -29,24 +29,24 @@ export const FloatingSettingLabel = styled(SettingLabel)`
 `;
 
 export const DateTimeSelector: DateTimeSelectorAndSubComponents = styled.div<{ baseColor: string | undefined }>`
-border: 2px solid ${(props) => props.baseColor || grey[700]};
-border-radius: 5px;
-height: 45px;
+  border: 2px solid ${(props) => props.baseColor || grey[700]};
+  border-radius: 5px;
+  height: 45px;
 `;
 
 DateTimeSelector.DateTimeRow = styled.div`
-display: flex;
-justify-content: space-around;
-align-items: center;
-height: 100%;
-padding: 0;
-background-color: white;
-border-radius: 0 3px 3px 0;
-
-input {
-  border: 0px;
+  align-items: center;
+  background-color: white;
+  border-radius: 0 3px 3px 0;
+  display: flex;
   height: 100%;
-  width: 100%;
+  justify-content: space-around;
+  padding: 0;
+
+  input {
+    border: 0px;
+    height: 100%;
+    width: 100%;
 }
 `;
 

--- a/packages/trip-form/src/types.ts
+++ b/packages/trip-form/src/types.ts
@@ -107,11 +107,14 @@ export interface ModeSelectorOptionSet {
   tertiary?: ModeSelectorOption[];
 }
 
-type SimpleStyledDiv = StyledComponent<"div", any>;
+type SimpleStyledDiv = StyledComponent<
+  "div",
+  any,
+  { baseColor?: string | undefined }
+>;
 
 export type DateTimeSelectorAndSubComponents = SimpleStyledDiv & {
   DateTimeRow?: SimpleStyledDiv;
-  DepartureRow?: SimpleStyledDiv;
 };
 
 export type ModeSelectorAndSubComponents = SimpleStyledDiv & {

--- a/packages/trip-form/src/types.ts
+++ b/packages/trip-form/src/types.ts
@@ -107,11 +107,7 @@ export interface ModeSelectorOptionSet {
   tertiary?: ModeSelectorOption[];
 }
 
-type SimpleStyledDiv = StyledComponent<
-  "div",
-  any,
-  { baseColor?: string }
->;
+type SimpleStyledDiv = StyledComponent<"div", any, { baseColor?: string }>;
 
 export type DateTimeSelectorAndSubComponents = SimpleStyledDiv & {
   DateTimeRow?: SimpleStyledDiv;


### PR DESCRIPTION
Updates the D/T selector styling so that date time inputs are always visible, and the departure option (leave now, depart at, arrive by) is a dropdown.

If a user updates the date or time input when the option "leave now" is selected, the dropdown will change to "depart at".





| Before | After |
|--------|-------|
|<img width="478" alt="image" src="https://github.com/user-attachments/assets/b039d54f-915f-4ebd-a200-72526a0ddd61">|<img width="473" alt="image" src="https://github.com/user-attachments/assets/49f9c8a6-1ed6-4a67-bdb6-ee85437ee5ac">|
