### PR TITLE
fix(itinerary-body): Optimize icon import in AlertsBody.

### DIFF
--- a/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/alerts-body.tsx
@@ -5,7 +5,7 @@ import { Alert } from "@opentripplanner/types";
 import React, { FunctionComponent, ReactElement } from "react";
 import { FormattedMessage } from "react-intl";
 
-import { ExternalLinkAlt } from "@styled-icons/fa-solid";
+import { ExternalLinkAlt } from "@styled-icons/fa-solid/ExternalLinkAlt";
 import * as S from "../styled";
 import { defaultMessages } from "../util";
 


### PR DESCRIPTION
This PR imports a single icon from fa-solid instead of "requiring" the entire library. This change can help reduce the main OTP-RR production bundle size by as much as 2+MB! (See screenshot before/after)

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/cd2bb88f-d938-462b-a726-efb71d5ac6ec" />
