### PR TITLE
Add 'boundsFitting' prop to manage camera manipulation via zoomToGeoJSON method

### DIFF
--- a/package.json
+++ b/package.json
@@ -284,5 +284,6 @@
   },
   "dependencies": {
     "@storybook/icons": "^1.2.9"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -284,6 +284,5 @@
   },
   "dependencies": {
     "@storybook/icons": "^1.2.9"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/packages/transitive-overlay/src/index.tsx
+++ b/packages/transitive-overlay/src/index.tsx
@@ -117,7 +117,7 @@ const loadImages = (map: MapRef, images: MapImage[]) => {
 const TransitiveCanvasOverlay = ({
   activeLeg,
   accessLegColorOverride,
-  boundsFitting,
+  boundsFitting = true,
   showRouteArrows,
   transitiveData
 }: Props): JSX.Element => {

--- a/packages/transitive-overlay/src/index.tsx
+++ b/packages/transitive-overlay/src/index.tsx
@@ -89,6 +89,7 @@ const accessLegFilter = [
 type Props = {
   activeLeg?: Leg;
   accessLegColorOverride?: string;
+  boundsFitting?: boolean;
   showRouteArrows?: boolean;
   transitiveData?: TransitiveData;
 };
@@ -116,6 +117,7 @@ const loadImages = (map: MapRef, images: MapImage[]) => {
 const TransitiveCanvasOverlay = ({
   activeLeg,
   accessLegColorOverride,
+  boundsFitting,
   showRouteArrows,
   transitiveData
 }: Props): JSX.Element => {
@@ -227,6 +229,7 @@ const TransitiveCanvasOverlay = ({
   };
 
   const zoomToGeoJSON = geoJson => {
+    if (!boundsFitting) return;
     const b = bbox(geoJson);
     const bounds: [number, number, number, number] = [b[0], b[1], b[2], b[3]];
 


### PR DESCRIPTION
This pull request addresses a need for Trimet's instance of the maplibre map to not get the camera's placement hijacked by the _zoomToGeoJSON_ method which is causing some issues with how we want to frame the transitive-overlay with respect to the side-panel we house much of our tools in.

Essentially, we pass in _boundsFitting_ from the client and into packages/transitive-overlay/src/index.tsx. If it happens to be **false** then when _zoomToGeoJSON_ is called then it returns immediately with no effect on the map. Since this was set up to be active by default, I made the _boundsFitting_ prop be defaultly **true**.