### PR TITLE
downgrade ubuntu until playwright is upgraded

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,6 +1,6 @@
 jobs:
   test-build-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Ubuntu 24.04 is supported by a newer version of Playwright, but not the one we are using