### PR TITLE
Set viewed stop from endpoint

### DIFF
--- a/packages/endpoints-overlay/i18n/en-US.yml
+++ b/packages/endpoints-overlay/i18n/en-US.yml
@@ -7,3 +7,4 @@ otpUi:
     saveAsHome: Save as home
     saveAsWork: Save as work
     swapLocation: Change to {locationType} location
+    viewStop: View in stop viewer

--- a/packages/endpoints-overlay/i18n/en-US.yml
+++ b/packages/endpoints-overlay/i18n/en-US.yml
@@ -7,4 +7,4 @@ otpUi:
     saveAsHome: Save as home
     saveAsWork: Save as work
     swapLocation: Change to {locationType} location
-    viewStop: View in stop viewer
+    viewNearby: View in nearby viewer

--- a/packages/endpoints-overlay/i18n/en-US.yml
+++ b/packages/endpoints-overlay/i18n/en-US.yml
@@ -7,4 +7,4 @@ otpUi:
     saveAsHome: Save as home
     saveAsWork: Save as work
     swapLocation: Change to {locationType} location
-    viewNearby: View in nearby viewer
+    viewNearby: View nearby

--- a/packages/endpoints-overlay/i18n/fr.yml
+++ b/packages/endpoints-overlay/i18n/fr.yml
@@ -11,3 +11,4 @@ otpUi:
     swapLocation: >-
       En faire {locationType, select, from {le point de départ} to {la
       destination} other {{locationType}}}
+    viewNearby: À proximité

--- a/packages/endpoints-overlay/src/EndpointsOverlay.story.tsx
+++ b/packages/endpoints-overlay/src/EndpointsOverlay.story.tsx
@@ -14,6 +14,7 @@ const clearLocation = action("clearLocation");
 const forgetPlace = action("forgetPlace");
 const rememberPlace = action("rememberPlace");
 const setLocation = action("setLocation");
+const setViewedStop = action("setViewedStop");
 const unnamedFromLocation = {
   lat: 45.522497,
   lon: -122.676029,
@@ -105,7 +106,7 @@ export const EndpointsOverlayWithStopLink: ComponentStory<typeof EndpointsOverla
     locations={locations}
     rememberPlace={rememberPlace}
     setLocation={setLocation}
-    setViewedStop={() => {}}
+    setViewedStop={setViewedStop}
     showUserSettings
     toLocation={toLocation}
   />

--- a/packages/endpoints-overlay/src/EndpointsOverlay.story.tsx
+++ b/packages/endpoints-overlay/src/EndpointsOverlay.story.tsx
@@ -14,7 +14,7 @@ const clearLocation = action("clearLocation");
 const forgetPlace = action("forgetPlace");
 const rememberPlace = action("rememberPlace");
 const setLocation = action("setLocation");
-const setViewedStop = action("setViewedStop");
+const setViewNearby = action("setViewNearby");
 const unnamedFromLocation = {
   lat: 45.522497,
   lon: -122.676029,
@@ -58,6 +58,7 @@ export const EndpointsOverlayWithUserSettings: ComponentStory<typeof EndpointsOv
     locations={locations}
     rememberPlace={rememberPlace}
     setLocation={setLocation}
+    setViewNearby={setViewNearby}
     showUserSettings
     toLocation={toLocation}
   />
@@ -92,21 +93,8 @@ export const EndpointsOverlayWithUnnamedPlace: ComponentStory<typeof EndpointsOv
   <EndpointsOverlay
     fromLocation={unnamedFromLocation}
     setLocation={setLocation}
+    setViewNearby={setViewNearby}
     showUserSettings
     toLocation={unnamedToLocation}
-  />
-);
-
-export const EndpointsOverlayWithStopLink: ComponentStory<typeof EndpointsOverlay> = () => (
-  <EndpointsOverlay
-    clearLocation={clearLocation}
-    forgetPlace={forgetPlace}
-    fromLocation={fromLocation}
-    locations={locations}
-    rememberPlace={rememberPlace}
-    setLocation={setLocation}
-    viewNearbyDestination={setViewedStop}
-    showUserSettings
-    toLocation={toLocation}
   />
 );

--- a/packages/endpoints-overlay/src/EndpointsOverlay.story.tsx
+++ b/packages/endpoints-overlay/src/EndpointsOverlay.story.tsx
@@ -95,3 +95,18 @@ export const EndpointsOverlayWithUnnamedPlace: ComponentStory<typeof EndpointsOv
     toLocation={unnamedToLocation}
   />
 );
+
+export const EndpointsOverlayWithStopLink: ComponentStory<typeof EndpointsOverlay> = () => (
+  <EndpointsOverlay
+    clearLocation={clearLocation}
+    forgetPlace={forgetPlace}
+    fromLocation={fromLocation}
+    fromIsStop
+    locations={locations}
+    rememberPlace={rememberPlace}
+    setLocation={setLocation}
+    setViewedStop={() => {}}
+    showUserSettings
+    toLocation={toLocation}
+  />
+);

--- a/packages/endpoints-overlay/src/EndpointsOverlay.story.tsx
+++ b/packages/endpoints-overlay/src/EndpointsOverlay.story.tsx
@@ -102,11 +102,10 @@ export const EndpointsOverlayWithStopLink: ComponentStory<typeof EndpointsOverla
     clearLocation={clearLocation}
     forgetPlace={forgetPlace}
     fromLocation={fromLocation}
-    fromIsStop
     locations={locations}
     rememberPlace={rememberPlace}
     setLocation={setLocation}
-    setViewedStop={setViewedStop}
+    viewNearbyDestination={setViewedStop}
     showUserSettings
     toLocation={toLocation}
   />

--- a/packages/endpoints-overlay/src/endpoint.tsx
+++ b/packages/endpoints-overlay/src/endpoint.tsx
@@ -31,7 +31,7 @@ interface Props {
   MapMarkerIcon: ComponentType<UserLocationAndType>;
   rememberPlace: (arg: UserLocationAndType) => void;
   setLocation: (arg: MapLocationActionArg) => void;
-  viewNearby?: () => void;
+  viewNearby?: (arg: Location) => void;
   showUserSettings: boolean;
   type: string;
 }
@@ -285,7 +285,7 @@ const Endpoint = (props: Props): JSX.Element => {
               </S.Button>
             </div>
             <div>
-              <S.Button onClick={viewNearby}>
+              <S.Button onClick={() => viewNearby(location)}>
                 <UserLocationIcon type="nearby" />
                 <FormattedMessage
                   defaultMessage={

--- a/packages/endpoints-overlay/src/endpoint.tsx
+++ b/packages/endpoints-overlay/src/endpoint.tsx
@@ -1,6 +1,6 @@
 import { Briefcase } from "@styled-icons/fa-solid/Briefcase";
 import { Popup } from "@opentripplanner/base-map";
-import { Search } from "@styled-icons/fa-solid";
+import { Search } from "@styled-icons/fa-solid/Search";
 import {
   ClearLocationArg,
   Location,

--- a/packages/endpoints-overlay/src/endpoint.tsx
+++ b/packages/endpoints-overlay/src/endpoint.tsx
@@ -26,13 +26,12 @@ import defaultEnglishMessages from "../i18n/en-US.yml";
 interface Props {
   clearLocation: (arg: ClearLocationArg) => void;
   forgetPlace: (type: string) => void;
-  isStop?: boolean;
   location?: Location;
   locations: Location[];
   MapMarkerIcon: ComponentType<UserLocationAndType>;
   rememberPlace: (arg: UserLocationAndType) => void;
   setLocation: (arg: MapLocationActionArg) => void;
-  setViewedStop?: () => void;
+  viewNearby?: () => void;
   showUserSettings: boolean;
   type: string;
 }
@@ -63,7 +62,7 @@ function UserLocationInnerIcon({ type }: IconProps) {
       return <Sync size={12} />;
     case "times":
       return <Times size={12} />;
-    case "stop":
+    case "nearby":
       return <Search size={12} />;
     default:
       return null;
@@ -156,11 +155,10 @@ const Endpoint = (props: Props): JSX.Element => {
 
   const [showPopup, setShowPopup] = useState(false);
   const {
-    isStop,
     location,
     locations,
     MapMarkerIcon,
-    setViewedStop,
+    viewNearby,
     showUserSettings,
     type
   } = props;
@@ -286,20 +284,18 @@ const Endpoint = (props: Props): JSX.Element => {
                 />
               </S.Button>
             </div>
-            {isStop && (
-              <div>
-                <S.Button onClick={() => setViewedStop()}>
-                  <UserLocationIcon type="stop" />
-                  <FormattedMessage
-                    defaultMessage={
-                      defaultMessages["otpUi.EndpointsOverlay.viewStop"]
-                    }
-                    description="Button text to view the stop"
-                    id="otpUi.EndpointsOverlay.viewStop"
-                  />
-                </S.Button>
-              </div>
-            )}
+            <div>
+              <S.Button onClick={viewNearby}>
+                <UserLocationIcon type="nearby" />
+                <FormattedMessage
+                  defaultMessage={
+                    defaultMessages["otpUi.EndpointsOverlay.viewStop"]
+                  }
+                  description="Button text to view the coordinates in the nearby view"
+                  id="otpUi.EndpointsOverlay.viewNearby"
+                />
+              </S.Button>
+            </div>
           </FocusTrapWrapper>
         </Popup>
       )}

--- a/packages/endpoints-overlay/src/endpoint.tsx
+++ b/packages/endpoints-overlay/src/endpoint.tsx
@@ -1,5 +1,6 @@
 import { Briefcase } from "@styled-icons/fa-solid/Briefcase";
 import { Popup } from "@opentripplanner/base-map";
+import { Search } from "@styled-icons/fa-solid";
 import {
   ClearLocationArg,
   Location,
@@ -62,6 +63,8 @@ function UserLocationInnerIcon({ type }: IconProps) {
       return <Sync size={12} />;
     case "times":
       return <Times size={12} />;
+    case "stop":
+      return <Search size={12} />;
     default:
       return null;
   }
@@ -151,17 +154,13 @@ const Endpoint = (props: Props): JSX.Element => {
     setLocation({ locationType: type, location, reverseGeocode: true });
   };
 
-  const viewStop = (): void => {
-    const { setViewedStop } = props;
-    setViewedStop();
-  };
-
   const [showPopup, setShowPopup] = useState(false);
   const {
     isStop,
     location,
     locations,
     MapMarkerIcon,
+    setViewedStop,
     showUserSettings,
     type
   } = props;
@@ -289,7 +288,8 @@ const Endpoint = (props: Props): JSX.Element => {
             </div>
             {isStop && (
               <div>
-                <S.Button onClick={viewStop}>
+                <S.Button onClick={() => setViewedStop()}>
+                  <UserLocationIcon type="stop" />
                   <FormattedMessage
                     defaultMessage={
                       defaultMessages["otpUi.EndpointsOverlay.viewStop"]

--- a/packages/endpoints-overlay/src/endpoint.tsx
+++ b/packages/endpoints-overlay/src/endpoint.tsx
@@ -31,7 +31,7 @@ interface Props {
   MapMarkerIcon: ComponentType<UserLocationAndType>;
   rememberPlace: (arg: UserLocationAndType) => void;
   setLocation: (arg: MapLocationActionArg) => void;
-  viewNearby?: (arg: Location) => void;
+  setViewNearby?: (arg: Location) => void;
   showUserSettings: boolean;
   type: string;
 }
@@ -158,7 +158,7 @@ const Endpoint = (props: Props): JSX.Element => {
     location,
     locations,
     MapMarkerIcon,
-    viewNearby,
+    setViewNearby,
     showUserSettings,
     type
   } = props;
@@ -285,7 +285,7 @@ const Endpoint = (props: Props): JSX.Element => {
               </S.Button>
             </div>
             <div>
-              <S.Button onClick={() => viewNearby(location)}>
+              <S.Button onClick={() => setViewNearby(location)}>
                 <UserLocationIcon type="nearby" />
                 <FormattedMessage
                   defaultMessage={

--- a/packages/endpoints-overlay/src/endpoint.tsx
+++ b/packages/endpoints-overlay/src/endpoint.tsx
@@ -25,11 +25,13 @@ import defaultEnglishMessages from "../i18n/en-US.yml";
 interface Props {
   clearLocation: (arg: ClearLocationArg) => void;
   forgetPlace: (type: string) => void;
+  isStop?: boolean;
   location?: Location;
   locations: Location[];
   MapMarkerIcon: ComponentType<UserLocationAndType>;
   rememberPlace: (arg: UserLocationAndType) => void;
   setLocation: (arg: MapLocationActionArg) => void;
+  setViewedStop?: () => void;
   showUserSettings: boolean;
   type: string;
 }
@@ -149,8 +151,20 @@ const Endpoint = (props: Props): JSX.Element => {
     setLocation({ locationType: type, location, reverseGeocode: true });
   };
 
+  const viewStop = (): void => {
+    const { setViewedStop } = props;
+    setViewedStop();
+  };
+
   const [showPopup, setShowPopup] = useState(false);
-  const { location, locations, MapMarkerIcon, showUserSettings, type } = props;
+  const {
+    isStop,
+    location,
+    locations,
+    MapMarkerIcon,
+    showUserSettings,
+    type
+  } = props;
   if (!(location && location.lat && location.lon)) return null;
   const match = locations.find(l => coreUtils.map.matchLatLon(l, location));
   const isWork = match && match.type === "work";
@@ -273,6 +287,19 @@ const Endpoint = (props: Props): JSX.Element => {
                 />
               </S.Button>
             </div>
+            {isStop && (
+              <div>
+                <S.Button onClick={viewStop}>
+                  <FormattedMessage
+                    defaultMessage={
+                      defaultMessages["otpUi.EndpointsOverlay.viewStop"]
+                    }
+                    description="Button text to view the stop"
+                    id="otpUi.EndpointsOverlay.viewStop"
+                  />
+                </S.Button>
+              </div>
+            )}
           </FocusTrapWrapper>
         </Popup>
       )}

--- a/packages/endpoints-overlay/src/index.tsx
+++ b/packages/endpoints-overlay/src/index.tsx
@@ -24,6 +24,7 @@ interface Props {
    * string argument representing the type of saved location.
    */
   forgetPlace?: (type: string) => void;
+  fromIsStop?: boolean;
   /**
    * The from location.
    */
@@ -67,7 +68,9 @@ interface Props {
   /**
    * Whether or not to show the user settings popup when an endpoint is clicked.
    */
+  setViewedStop?: () => void;
   showUserSettings?: boolean;
+  toIsStop?: boolean;
   /**
    * To to location
    */
@@ -115,24 +118,29 @@ function DefaultMapMarkerIcon({
 const EndpointsOverlay = ({
   clearLocation = noop,
   forgetPlace = noop,
+  fromIsStop = false,
   fromLocation,
   intermediatePlaces = [],
   locations = [],
   MapMarkerIcon = DefaultMapMarkerIcon,
   rememberPlace = noop,
   setLocation = noop,
+  setViewedStop = noop,
   showUserSettings,
+  toIsStop = false,
   toLocation
 }: Props): ReactElement => (
   <div>
     <Endpoint
       clearLocation={clearLocation}
       forgetPlace={forgetPlace}
+      isStop={fromIsStop}
       location={fromLocation}
       locations={locations}
       MapMarkerIcon={MapMarkerIcon}
       rememberPlace={rememberPlace}
       setLocation={setLocation}
+      setViewedStop={setViewedStop}
       showUserSettings={showUserSettings}
       type="from"
     />
@@ -155,6 +163,7 @@ const EndpointsOverlay = ({
     <Endpoint
       clearLocation={clearLocation}
       forgetPlace={forgetPlace}
+      isStop={toIsStop}
       location={toLocation}
       locations={locations}
       MapMarkerIcon={MapMarkerIcon}

--- a/packages/endpoints-overlay/src/index.tsx
+++ b/packages/endpoints-overlay/src/index.tsx
@@ -24,7 +24,6 @@ interface Props {
    * string argument representing the type of saved location.
    */
   forgetPlace?: (type: string) => void;
-  fromIsStop?: boolean;
   /**
    * The from location.
    */
@@ -68,13 +67,11 @@ interface Props {
   /**
    * Opens the nearby view from the location coordinates
    */
-  viewNearbyOrigin?: () => void;
-  viewNearbyDestination?: () => void;
+  setViewNearby?: (arg: Location) => void;
   /**
    * Whether or not to show the user settings popup when an endpoint is clicked.
    */
   showUserSettings?: boolean;
-  toIsStop?: boolean;
   /**
    * To to location
    */
@@ -128,8 +125,7 @@ const EndpointsOverlay = ({
   MapMarkerIcon = DefaultMapMarkerIcon,
   rememberPlace = noop,
   setLocation = noop,
-  viewNearbyOrigin = noop,
-  viewNearbyDestination = noop,
+  setViewNearby = noop,
   showUserSettings,
   toLocation
 }: Props): ReactElement => (
@@ -142,7 +138,7 @@ const EndpointsOverlay = ({
       MapMarkerIcon={MapMarkerIcon}
       rememberPlace={rememberPlace}
       setLocation={setLocation}
-      viewNearby={viewNearbyOrigin}
+      viewNearby={setViewNearby}
       showUserSettings={showUserSettings}
       type="from"
     />
@@ -171,7 +167,7 @@ const EndpointsOverlay = ({
       rememberPlace={rememberPlace}
       setLocation={setLocation}
       showUserSettings={showUserSettings}
-      viewNearby={viewNearbyDestination}
+      viewNearby={setViewNearby}
       type="to"
     />
   </div>

--- a/packages/endpoints-overlay/src/index.tsx
+++ b/packages/endpoints-overlay/src/index.tsx
@@ -138,7 +138,7 @@ const EndpointsOverlay = ({
       MapMarkerIcon={MapMarkerIcon}
       rememberPlace={rememberPlace}
       setLocation={setLocation}
-      viewNearby={setViewNearby}
+      setViewNearby={setViewNearby}
       showUserSettings={showUserSettings}
       type="from"
     />
@@ -167,7 +167,7 @@ const EndpointsOverlay = ({
       rememberPlace={rememberPlace}
       setLocation={setLocation}
       showUserSettings={showUserSettings}
-      viewNearby={setViewNearby}
+      setViewNearby={setViewNearby}
       type="to"
     />
   </div>

--- a/packages/endpoints-overlay/src/index.tsx
+++ b/packages/endpoints-overlay/src/index.tsx
@@ -66,9 +66,13 @@ interface Props {
    */
   setLocation?: (arg: MapLocationActionArg) => void;
   /**
+   * Opens the nearby view from the location coordinates
+   */
+  viewNearbyOrigin?: () => void;
+  viewNearbyDestination?: () => void;
+  /**
    * Whether or not to show the user settings popup when an endpoint is clicked.
    */
-  setViewedStop?: () => void;
   showUserSettings?: boolean;
   toIsStop?: boolean;
   /**
@@ -118,29 +122,27 @@ function DefaultMapMarkerIcon({
 const EndpointsOverlay = ({
   clearLocation = noop,
   forgetPlace = noop,
-  fromIsStop = false,
   fromLocation,
   intermediatePlaces = [],
   locations = [],
   MapMarkerIcon = DefaultMapMarkerIcon,
   rememberPlace = noop,
   setLocation = noop,
-  setViewedStop = noop,
+  viewNearbyOrigin = noop,
+  viewNearbyDestination = noop,
   showUserSettings,
-  toIsStop = false,
   toLocation
 }: Props): ReactElement => (
   <div>
     <Endpoint
       clearLocation={clearLocation}
       forgetPlace={forgetPlace}
-      isStop={fromIsStop}
       location={fromLocation}
       locations={locations}
       MapMarkerIcon={MapMarkerIcon}
       rememberPlace={rememberPlace}
       setLocation={setLocation}
-      setViewedStop={setViewedStop}
+      viewNearby={viewNearbyOrigin}
       showUserSettings={showUserSettings}
       type="from"
     />
@@ -163,13 +165,13 @@ const EndpointsOverlay = ({
     <Endpoint
       clearLocation={clearLocation}
       forgetPlace={forgetPlace}
-      isStop={toIsStop}
       location={toLocation}
       locations={locations}
       MapMarkerIcon={MapMarkerIcon}
       rememberPlace={rememberPlace}
       setLocation={setLocation}
       showUserSettings={showUserSettings}
+      viewNearby={viewNearbyDestination}
       type="to"
     />
   </div>


### PR DESCRIPTION
Pass ability to `setViewedStop` to endpoint layer, so user can see it in the nearby view.

Maybe the string should be "Open in nearby view" instead of "View in nearby view"? Which one makes more sense? 

![image](https://github.com/user-attachments/assets/3132817f-cb67-4891-9878-697edc47e4c1)
