### PR TITLE
Geocoder: Pelias: remove exact duplicates

### DIFF
--- a/packages/geocoder/src/geocoders/pelias.ts
+++ b/packages/geocoder/src/geocoders/pelias.ts
@@ -99,7 +99,7 @@ export default class PeliasGeocoder extends Geocoder {
   /**
    * Remove duplicates based on name, which Pelias sometimes creates
    */
-  rewriteAutocompleteResponse(response: unknown): MultiGeocoderResponse {
+  rewriteAutocompleteResponse(response: MultiGeocoderResponse): MultiGeocoderResponse {
     const features = (response as FeatureCollection)?.features;
 
     const filtered = features?.filter(

--- a/packages/geocoder/src/geocoders/pelias.ts
+++ b/packages/geocoder/src/geocoders/pelias.ts
@@ -7,7 +7,7 @@ import Geocoder from "./abstract-geocoder";
 import type { AutocompleteQuery, SearchQuery } from "..";
 import type { MultiGeocoderResponse, SingleOrMultiGeocoderResponse } from "./types";
 
-const DEFAULT_LAYERS = "address,venue,street,intersection"
+const DEFAULT_LAYERS = "address,venue,street,intersection";
 
 /**
  * Geocoder implementation for the Pelias geocoder.
@@ -20,7 +20,7 @@ export default class PeliasGeocoder extends Geocoder {
    * Generate an autocomplete query specifically for the Pelias API. The
    * `sources` parameter is a Pelias-specific option.
    * This function fills in some more fields of the query
-   * from the existing values in the GeocoderConfig. 
+   * from the existing values in the GeocoderConfig.
    */
   getAutocompleteQuery(query: AutocompleteQuery): AutocompleteQuery {
     const {
@@ -51,7 +51,7 @@ export default class PeliasGeocoder extends Geocoder {
    * Generate a search query specifically for the Pelias API. The
    * `sources` parameter is a Pelias-specific option.
    * This function fills in some more fields of the query
-   * from the existing values in the GeocoderConfig. 
+   * from the existing values in the GeocoderConfig.
    */
   getSearchQuery(query: SearchQuery): SearchQuery {
     const {
@@ -84,7 +84,7 @@ export default class PeliasGeocoder extends Geocoder {
    * first feature returned from the geocoder.
    */
   rewriteReverseResponse(response): SingleOrMultiGeocoderResponse {
-    if (this.geocoderConfig?.reverseUseFeatureCollection) return response
+    if (this.geocoderConfig?.reverseUseFeatureCollection) return response;
     const { lat, lon } = response.isomorphicMapzenSearchQuery.point;
 
     const firstFeature = response[0];
@@ -100,12 +100,24 @@ export default class PeliasGeocoder extends Geocoder {
    * Remove duplicates based on name, which Pelias sometimes creates
    */
   rewriteAutocompleteResponse(response: unknown): MultiGeocoderResponse {
-    const features = (response as FeatureCollection)?.features
+    const features = (response as FeatureCollection)?.features;
 
-    const filtered = features?.filter((feature, index) => 
-      !features.slice(index + 1).some(f => f?.properties?.name === feature?.properties?.name && JSON.stringify((feature?.geometry as Point)?.coordinates) === JSON.stringify((f?.geometry as Point)?.coordinates))     
-    )
+    const filtered = features?.filter(
+      (feature, index) =>
+        !features
+          .slice(index + 1)
+          .some(
+            f =>
+              f?.properties?.name === feature?.properties?.name &&
+              // This is unclean, but we know geometry will never contain objects
+              JSON.stringify((feature?.geometry as Point)?.coordinates) ===
+                JSON.stringify((f?.geometry as Point)?.coordinates)
+          )
+    );
 
-    return { ...(response as FeatureCollection), features: filtered } as MultiGeocoderResponse;
+    return {
+      ...(response as FeatureCollection),
+      features: filtered
+    } as MultiGeocoderResponse;
   }
 }

--- a/packages/geocoder/src/test-fixtures/pelias/autocomplete-response.json
+++ b/packages/geocoder/src/test-fixtures/pelias/autocomplete-response.json
@@ -60,6 +60,39 @@
         "continent_gid": "whosonfirst:continent:102191575",
         "label": "Mill Ends Park, Portland, OR, USA"
       }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-122.673377, 45.516278]
+      },
+      "properties": {
+        "id": "node/4243944023",
+        "gid": "openstreetmap:venue:node/4243944023",
+        "layer": "venue",
+        "source": "openstreetmap",
+        "source_id": "node/4243944023",
+        "name": "Mill Ends Park",
+        "distance": 0.491,
+        "accuracy": "point",
+        "country": "United States",
+        "country_gid": "whosonfirst:country:85633793",
+        "country_a": "USA",
+        "region": "Oregon",
+        "region_gid": "whosonfirst:region:85688513",
+        "region_a": "OR",
+        "county": "Multnomah County",
+        "county_gid": "whosonfirst:county:102081631",
+        "county_a": "MU",
+        "locality": "Portland",
+        "locality_gid": "whosonfirst:locality:101715829",
+        "neighbourhood": "Downtown",
+        "neighbourhood_gid": "whosonfirst:neighbourhood:85867131",
+        "continent": "North America",
+        "continent_gid": "whosonfirst:continent:102191575",
+        "label": "Mill Ends Park, Portland, OR, USA"
+      }
     }
   ],
   "bbox": [-122.673377, 45.516278, -122.673377, 45.516278]

--- a/yarn.lock
+++ b/yarn.lock
@@ -9232,9 +9232,14 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001587:
-  version "1.0.30001625"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001625.tgz"
-  integrity sha512-4KE9N2gcRH+HQhpeiRZXd+1niLB/XNLAhSy4z7fI8EzcbcPoAqjNInxVHTiTwWfTIV4w096XG8OtCOCQQKPv3w==
+  version "1.0.30001695"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz"
+  integrity sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==
+
+caniuse-lite@^1.0.30001695:
+  version "1.0.30001695"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz#39dfedd8f94851132795fdf9b79d29659ad9c4d4"
+  integrity sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -20725,7 +20730,7 @@ string-similarity@^4.0.4:
   resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-4.0.4.tgz#42d01ab0b34660ea8a018da8f56a3309bb8b2a5b"
   integrity sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -20742,15 +20747,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
@@ -20832,7 +20828,7 @@ stringify-package@^1.0.1:
   resolved "https://registry.yarnpkg.com/stringify-package/-/stringify-package-1.0.1.tgz#e5aa3643e7f74d0f28628b72f3dad5cecfc3ba85"
   integrity sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -20859,13 +20855,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -22642,7 +22631,7 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -22672,15 +22661,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
It seems like we've been seeing some exact duplicates coming back from Pelias in some cases. This PR removes them.

This will slow things down, but hopefully not too much.