### PR TITLE
fix(trip-form): apply translation to mode label

### DIFF
--- a/packages/trip-form/src/MetroModeSelector/AdvancedModeSettingsButton/index.tsx
+++ b/packages/trip-form/src/MetroModeSelector/AdvancedModeSettingsButton/index.tsx
@@ -126,7 +126,7 @@ const AdvancedModeSettingsButton = ({
         />
         <label htmlFor={checkboxId}>
           <modeButton.Icon />
-          <span>{modeButton?.label}</span>
+          <span>{label}</span>
           {modeButton.enabled && <Check2 />}
         </label>
       </StyledModeSettingsButton>

--- a/packages/trip-form/src/MetroModeSelector/__snapshots__/AdvancedModeSettingsButton.story.tsx.snap
+++ b/packages/trip-form/src/MetroModeSelector/__snapshots__/AdvancedModeSettingsButton.story.tsx.snap
@@ -257,7 +257,7 @@ exports[`Trip Form Components/Advanced Mode Settings Buttons AdvancedModeSetting
             </path>
           </svg>
           <span>
-            Car
+            Drive
           </span>
         </label>
       </div>


### PR DESCRIPTION
We were generating the mode label translation and forgetting to apply it to the actual mode button whoops