### PR TITLE
fix(transitive-overlay): Prevent null route object from causing crash

### DIFF
--- a/packages/transitive-overlay/src/util.ts
+++ b/packages/transitive-overlay/src/util.ts
@@ -408,7 +408,7 @@ export function itineraryToTransitive(
         route_short_name: routeLabel
       };
 
-      if (typeof leg.route === "object") {
+      if (typeof leg.route === "object" && leg.route !== null) {
         routes[routeId] = {
           ...basicRouteAttributes,
           route_long_name: leg.route.longName || "",


### PR DESCRIPTION
While working on implementing a new data source to our Trimet application that includes new service providers, I noticed that sometimes the leg.route property was _null_ but it was still coming up truthy for the if/else comparison I adjusted that checks whether or not it is an object. This was breaking some trips on different types of buses from new providers, but also our proprietary MAX Rail rides, which have never been a problem before.

This little fix ensures that route.leg is not null. When I did this locally, all my trips were working.