### PR TITLE
Add ensureAtLeastOneMinute util 

### DIFF
--- a/packages/core-utils/src/query-gen.ts
+++ b/packages/core-utils/src/query-gen.ts
@@ -180,7 +180,7 @@ function isCombinationValid(
 
   return !!VALID_COMBOS.find(
     vc =>
-      simplifiedModes.every(m => vc.includes(m)) &&
+      simplifiedModes.length === vc.length &&
       vc.every(m => simplifiedModes.includes(m))
   );
 }

--- a/packages/core-utils/src/time.ts
+++ b/packages/core-utils/src/time.ts
@@ -27,6 +27,13 @@ export function toHoursMinutesSeconds(
 }
 
 /**
+ * If a duration is less than 60 seconds, round it to one minute, to avoid a duration
+ * of 0 minutes on a leg.
+ */
+export const ensureAtLeastOneMinute = (duration: number): number =>
+  duration < 60 ? 60 : duration;
+
+/**
  * @param  {[type]} config the OTP config object found in store
  * @return {string}        the config-defined time formatter or HH:mm (24-hr time)
  */

--- a/packages/core-utils/src/time.ts
+++ b/packages/core-utils/src/time.ts
@@ -29,6 +29,8 @@ export function toHoursMinutesSeconds(
 /**
  * If a duration is less than 60 seconds, round it to one minute, to avoid a duration
  * of 0 minutes on a leg.
+ * @param {number} duration The leg or trip duration in seconds
+ * @returns a duration in seconds of at least 60 seconds.
  */
 export const ensureAtLeastOneMinute = (duration: number): number =>
   duration < 60 ? 60 : duration;


### PR DESCRIPTION
Creates a util to round a leg duration up to at least one minute (to prevent small durations from being shown as 0 min)

Based off discussion in https://github.com/opentripplanner/otp-ui/pull/816

I also updated the query gen file to apply [this feedback](https://github.com/opentripplanner/otp-react-redux/pull/1366#discussion_r2001325156), since I got the idea for the `ValidModeCombo` check in that PR from `isCombinationValid`