### PR TITLE
fix(location-field): Fix keyboard navigation

### DIFF
--- a/packages/geocoder/package.json
+++ b/packages/geocoder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentripplanner/geocoder",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Geocoding tools for multiple geocoding providers",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -38,16 +38,6 @@ import defaultEnglishMessages from "../i18n/en-US.yml";
 
 type IndexedOptionLookup = Array<{ id: string; locationSelected: () => void }>;
 
-const optionIdPrefix = "otpui-locf-option";
-
-/**
- * Formats the option id based on its given index position.
- * This assumes only one location dropdown is shown at a time.
- */
-function getOptionId(index: number): string {
-  return `${optionIdPrefix}-${index}`;
-}
-
 function generateOptionId(optionPrefix, feature) {
   // Use a default id if the feature does not have an id.
   const featureId =
@@ -726,7 +716,7 @@ const LocationField = ({
         matchingLocations.map(userLocation =>
           makeUserOption(
             userLocation,
-            generateOptionId("userLocationResults", userLocation),
+            generateOptionId("user-saved-results", userLocation),
             activeIndex,
             pushToIndexedOptions,
             indexedOptionLookup
@@ -747,7 +737,7 @@ const LocationField = ({
     const geocodedFeaturesWithId = geocodedFeatures.map(feature => {
       return {
         ...feature,
-        id: generateOptionId("geocodedResults", feature),
+        id: generateOptionId("geocoder", feature),
         locationSelected: () => setLocationSelected(feature)
       };
     });
@@ -927,10 +917,7 @@ const LocationField = ({
           setLocation(sessionLocation, "SESSION");
         };
 
-        const locationId = generateOptionId(
-          "recentSearchResults",
-          sessionLocation
-        );
+        const locationId = generateOptionId("recent", sessionLocation);
 
         // Add to the selection handler lookup (for use in onKeyDown)
         pushToIndexedOptions(locationSelected, locationId);
@@ -970,7 +957,7 @@ const LocationField = ({
       userLocationRenderData.map(userLocation =>
         makeUserOption(
           userLocation,
-          generateOptionId("userLocations", userLocation),
+          generateOptionId("user-saved", userLocation),
           activeIndex,
           pushToIndexedOptions,
           indexedOptionLookup
@@ -1061,7 +1048,7 @@ const LocationField = ({
   const textControl = (
     <S.Input
       aria-activedescendant={
-        activeIndex !== null ? getOptionId(activeIndex) : null
+        activeIndex !== null ? indexedOptionLookup[activeIndex]?.id : null
       }
       aria-autocomplete="list"
       aria-controls={listBoxId}

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -710,7 +710,7 @@ const LocationField = ({
 
   const statusMessages = [];
   let menuItems = []; // array of menu items for display (may include non-selectable items e.g. dividers/headings)
-  const indexedOptionLookup = []; // array of menu item ids and locationSelected handlers for reference (does not include non-selectable items e.g. dividers/headings)
+  const indexedOptionLookup = []; // array of menu item ids and associated locationSelected handlers for onKeyDown (does not include non-selectable items e.g. dividers/headings)
   const userLocationRenderData = showUserSettings
     ? userLocationsAndRecentPlaces.map(loc =>
         getRenderData(loc, setLocation, UserLocationIconComponent, intl)

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -250,11 +250,11 @@ const FeaturesElements = ({
   GeocodedOptionIconComponent,
   headerMessage,
   headingType,
+  indexedOptionLookup,
   layerColorMap,
   operatorIconMap,
   showSecondaryLabels,
-  title,
-  indexedOptionLookup
+  title
 }: {
   activeIndex: number;
   addLocationSearch: ({
@@ -712,7 +712,9 @@ const LocationField = ({
 
   const statusMessages = [];
   let menuItems = []; // array of menu items for display (may include non-selectable items e.g. dividers/headings)
-  const indexedOptionLookup: IndexedOptionLookup = []; // array of menu item ids and associated locationSelected handlers for onKeyDown (does not include non-selectable items e.g. dividers/headings)
+  /* array of menu item ids and associated locationSelected handlers for onKeyDown
+  (does not include non-selectable items e.g. dividers/headings) */
+  const indexedOptionLookup: IndexedOptionLookup = [];
   const userLocationRenderData = showUserSettings
     ? userLocationsAndRecentPlaces.map(loc =>
         getRenderData(loc, setLocation, UserLocationIconComponent, intl)
@@ -720,8 +722,7 @@ const LocationField = ({
     : [];
 
   const pushToIndexedOptions = (locationSelected, id) => {
-    const obj = { id, locationSelected };
-    indexedOptionLookup.push(obj);
+    indexedOptionLookup.push({ id, locationSelected });
   };
 
   /* 0) Include user saved locations if the typed text contains those locations name. */
@@ -733,16 +734,15 @@ const LocationField = ({
     if (matchingLocations.length) {
       // Iterate through any saved locations
       menuItems = menuItems.concat(
-        matchingLocations.map(userLocation => {
-          const featureId = generateOptionId(userLocation, indexedOptionLookup);
-          return makeUserOption(
+        matchingLocations.map(userLocation =>
+          makeUserOption(
             userLocation,
-            featureId,
+            generateOptionId(userLocation, indexedOptionLookup),
             activeIndex,
             pushToIndexedOptions,
             indexedOptionLookup
-          );
-        })
+          )
+        )
       );
     }
   }
@@ -778,16 +778,16 @@ const LocationField = ({
       let element;
 
       const FeaturesElementProps = {
+        activeIndex,
+        addLocationSearch,
+        GeocodedOptionIconComponent,
+        geocoderConfig,
         headingType,
+        indexedOptionLookup,
+        layerColorMap,
         operatorIconMap,
         setLocation,
-        addLocationSearch,
-        showSecondaryLabels,
-        activeIndex,
-        GeocodedOptionIconComponent,
-        layerColorMap,
-        geocoderConfig,
-        indexedOptionLookup
+        showSecondaryLabels
       };
       switch (result) {
         case GeocoderResultsConstants.OTHER:
@@ -901,7 +901,7 @@ const LocationField = ({
         pushToIndexedOptions(locationSelected, stopId);
 
         // Create and return the option menu item
-        const option = (
+        return (
           <TransitStopOption
             id={stopId}
             isActive={indexedOptionLookup[activeIndex]?.id === stopId}
@@ -911,7 +911,6 @@ const LocationField = ({
             stopOptionIcon={stopOptionIcon}
           />
         );
-        return option;
       })
     );
   }
@@ -946,8 +945,9 @@ const LocationField = ({
 
         // Add to the selection handler lookup (for use in onKeyDown)
         pushToIndexedOptions(locationSelected, locationId);
+
         // Create and return the option menu item
-        const option = (
+        return (
           <Option
             icon={sessionOptionIcon}
             id={locationId}
@@ -959,7 +959,6 @@ const LocationField = ({
             title={sessionLocation.main || sessionLocation.name}
           />
         );
-        return option;
       })
     );
   }
@@ -979,16 +978,15 @@ const LocationField = ({
 
     // Iterate through any saved locations
     menuItems = menuItems.concat(
-      userLocationRenderData.map(userLocation => {
-        const locationId = generateOptionId(userLocation, indexedOptionLookup);
-        return makeUserOption(
+      userLocationRenderData.map(userLocation =>
+        makeUserOption(
           userLocation,
-          locationId,
+          generateOptionId(userLocation, indexedOptionLookup),
           activeIndex,
           pushToIndexedOptions,
           indexedOptionLookup
-        );
-      })
+        )
+      )
     );
   }
 
@@ -1027,7 +1025,7 @@ const LocationField = ({
 
   const optionId = `current-position`;
 
-  // Add to the selection handler lookup (for use in onKeyDown
+  // Add to the selection handler lookup (for use in onKeyDown)
   pushToIndexedOptions(locationSelected, optionId);
 
   if (!suppressNearby) {

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -52,14 +52,14 @@ function generateOptionId(feature, indexedOptionLookup) {
   // Use a default id if the feature does not have an id.
   let id = "000";
 
-  // User saved locations do not have an id, so use the label.
-  if (feature.displayName) {
-    id = feature.displayName.replace(/\s/g, "");
-  }
-
   // Some geocoders will return an id. Use that if it exists.
   if (feature.properties) {
     id = feature.properties.id || feature.properties.label.replace(/\s/g, "");
+  }
+
+  // User saved locations do not have an id, so use the label.
+  if (feature.displayName) {
+    id = feature.displayName.replace(/\s/g, "");
   }
 
   // There are some cases, such as when we're using user-saved locations, where
@@ -712,8 +712,8 @@ const LocationField = ({
 
   const statusMessages = [];
   let menuItems = []; // array of menu items for display (may include non-selectable items e.g. dividers/headings)
-  /* array of menu item ids and associated locationSelected handlers for onKeyDown
-  (does not include non-selectable items e.g. dividers/headings) */
+  // array of menu item ids and associated locationSelected handlers for onKeyDown
+  // (does not include non-selectable items e.g. dividers/headings)
   const indexedOptionLookup: IndexedOptionLookup = [];
   const userLocationRenderData = showUserSettings
     ? userLocationsAndRecentPlaces.map(loc =>

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -38,13 +38,14 @@ import defaultEnglishMessages from "../i18n/en-US.yml";
 
 type IndexedOptionLookup = Array<{ id: string; locationSelected: () => void }>;
 
-function generateOptionId(optionPrefix, feature) {
+function generateOptionId(optionPrefix, feature, featureIndex) {
   // Use a default id if the feature does not have an id.
   const featureId =
     feature.properties?.id ||
     feature.properties?.label ||
     feature.displayName ||
-    "000";
+    // As a last resort, use the index of the feature in the category
+    featureIndex;
   const id = `${optionPrefix}-${featureId.replace(/\s/g, "-")}`;
   return id;
 }
@@ -713,10 +714,10 @@ const LocationField = ({
     if (matchingLocations.length) {
       // Iterate through any saved locations
       menuItems = menuItems.concat(
-        matchingLocations.map(userLocation =>
+        matchingLocations.map((userLocation, index) =>
           makeUserOption(
             userLocation,
-            generateOptionId("user-saved-results", userLocation),
+            generateOptionId("user-saved-results", userLocation, index),
             activeIndex,
             pushToIndexedOptions,
             indexedOptionLookup
@@ -734,10 +735,10 @@ const LocationField = ({
      * feature beforehand, and then push them to the indexedOptionLookup array
      * after sorting.
      */
-    const geocodedFeaturesWithId = geocodedFeatures.map(feature => {
+    const geocodedFeaturesWithId = geocodedFeatures.map((feature, index) => {
       return {
         ...feature,
-        id: generateOptionId("geocoder", feature),
+        id: generateOptionId("geocoder", feature, index),
         locationSelected: () => setLocationSelected(feature)
       };
     });
@@ -911,13 +912,13 @@ const LocationField = ({
 
     // Iterate through any saved locations
     menuItems = menuItems.concat(
-      sessionSearches.map(sessionLocation => {
+      sessionSearches.map((sessionLocation, index) => {
         // Create the location-selected handler
         const locationSelected = () => {
           setLocation(sessionLocation, "SESSION");
         };
 
-        const locationId = generateOptionId("recent", sessionLocation);
+        const locationId = generateOptionId("recent", sessionLocation, index);
 
         // Add to the selection handler lookup (for use in onKeyDown)
         pushToIndexedOptions(locationSelected, locationId);
@@ -954,10 +955,10 @@ const LocationField = ({
 
     // Iterate through any saved locations
     menuItems = menuItems.concat(
-      userLocationRenderData.map(userLocation =>
+      userLocationRenderData.map((userLocation, index) =>
         makeUserOption(
           userLocation,
-          generateOptionId("user-saved", userLocation),
+          generateOptionId("user-saved", userLocation, index),
           activeIndex,
           pushToIndexedOptions,
           indexedOptionLookup

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -36,6 +36,8 @@ import {
 } from "./utils";
 import defaultEnglishMessages from "../i18n/en-US.yml";
 
+type IndexedOptionLookup = Array<{ id: string; locationSelected: () => void }>;
+
 const optionIdPrefix = "otpui-locf-option";
 
 /**
@@ -271,7 +273,7 @@ const FeaturesElements = ({
   setLocation: (newLocation: Location, resultType: ResultType) => void;
   showSecondaryLabels: boolean;
   title: string;
-  indexedOptionLookup: any;
+  indexedOptionLookup: IndexedOptionLookup;
 }) => {
   return (
     <>
@@ -710,7 +712,7 @@ const LocationField = ({
 
   const statusMessages = [];
   let menuItems = []; // array of menu items for display (may include non-selectable items e.g. dividers/headings)
-  const indexedOptionLookup = []; // array of menu item ids and associated locationSelected handlers for onKeyDown (does not include non-selectable items e.g. dividers/headings)
+  const indexedOptionLookup: IndexedOptionLookup = []; // array of menu item ids and associated locationSelected handlers for onKeyDown (does not include non-selectable items e.g. dividers/headings)
   const userLocationRenderData = showUserSettings
     ? userLocationsAndRecentPlaces.map(loc =>
         getRenderData(loc, setLocation, UserLocationIconComponent, intl)

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -48,25 +48,14 @@ function getOptionId(index: number): string {
   return `${optionIdPrefix}-${index}`;
 }
 
-function generateOptionId(feature, indexedOptionLookup) {
+function generateOptionId(optionPrefix, feature) {
   // Use a default id if the feature does not have an id.
-  let id = "000";
-
-  // Some geocoders will return an id. Use that if it exists.
-  if (feature.properties) {
-    id = feature.properties.id || feature.properties.label.replace(/\s/g, "");
-  }
-
-  // User saved locations do not have an id, so use the label.
-  if (feature.displayName) {
-    id = feature.displayName.replace(/\s/g, "");
-  }
-
-  // There are some cases, such as when we're using user-saved locations, where
-  // the id is not unique. In this case, append a number to the end of the id.
-  if (indexedOptionLookup.find(item => item.id === id)) {
-    id = `${id}-0`;
-  }
+  const featureId =
+    feature.properties?.id ||
+    feature.properties?.label ||
+    feature.displayName ||
+    "000";
+  const id = `${optionPrefix}-${featureId.replace(/\s/g, "-")}`;
   return id;
 }
 
@@ -737,7 +726,7 @@ const LocationField = ({
         matchingLocations.map(userLocation =>
           makeUserOption(
             userLocation,
-            generateOptionId(userLocation, indexedOptionLookup),
+            generateOptionId("userLocationResults", userLocation),
             activeIndex,
             pushToIndexedOptions,
             indexedOptionLookup
@@ -758,7 +747,7 @@ const LocationField = ({
     const geocodedFeaturesWithId = geocodedFeatures.map(feature => {
       return {
         ...feature,
-        id: generateOptionId(feature, indexedOptionLookup),
+        id: generateOptionId("geocodedResults", feature),
         locationSelected: () => setLocationSelected(feature)
       };
     });
@@ -939,8 +928,8 @@ const LocationField = ({
         };
 
         const locationId = generateOptionId(
-          sessionLocation,
-          indexedOptionLookup
+          "recentSearchResults",
+          sessionLocation
         );
 
         // Add to the selection handler lookup (for use in onKeyDown)
@@ -981,7 +970,7 @@ const LocationField = ({
       userLocationRenderData.map(userLocation =>
         makeUserOption(
           userLocation,
-          generateOptionId(userLocation, indexedOptionLookup),
+          generateOptionId("userLocations", userLocation),
           activeIndex,
           pushToIndexedOptions,
           indexedOptionLookup

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -39,7 +39,6 @@ import defaultEnglishMessages from "../i18n/en-US.yml";
 type IndexedOptionLookup = Array<{ id: string; locationSelected: () => void }>;
 
 function generateOptionId(optionPrefix, feature, featureIndex) {
-  // Use a default id if the feature does not have an id.
   const featureId =
     feature.properties?.id ||
     feature.properties?.label ||

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -44,7 +44,7 @@ function generateOptionId(optionPrefix, feature, featureIndex) {
     feature.properties?.label ||
     feature.displayName ||
     // As a last resort, use the index of the feature in the category
-    featureIndex;
+    featureIndex.toString();
   const id = `${optionPrefix}-${featureId.replace(/\s/g, "-")}`;
   return id;
 }

--- a/packages/location-field/src/stories/__snapshots__/Desktop.story.tsx.snap
+++ b/packages/location-field/src/stories/__snapshots__/Desktop.story.tsx.snap
@@ -780,7 +780,7 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
       Other
     </h2>
     <li aria-live="off"
-        id="way/555892536"
+        id="geocoder-way/555892536"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -809,7 +809,7 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="node/5662026889"
+        id="geocoder-node/5662026889"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -844,7 +844,7 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="node/1934511929"
+        id="geocoder-node/1934511929"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -882,7 +882,7 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
       Stations
     </h2>
     <li aria-live="off"
-        id="TL_US::Sound Transit::stations"
+        id="geocoder-TL_US::Sound-Transit::stations"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -916,7 +916,7 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
       Stops
     </h2>
     <li aria-live="off"
-        id="5::WA State Ferry::stops"
+        id="geocoder-5::WA-State-Ferry::stops"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -965,7 +965,7 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="1::Community Transit::stops"
+        id="geocoder-1::Community-Transit::stops"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -996,7 +996,7 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="7::Community Transit::stops"
+        id="geocoder-7::Community-Transit::stops"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1111,7 +1111,7 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
       Stations
     </h2>
     <li aria-live="off"
-        id="TL_US::Sound Transit::stations"
+        id="geocoder-TL_US::Sound-Transit::stations"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1145,7 +1145,7 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
       Stops
     </h2>
     <li aria-live="off"
-        id="5::WA State Ferry::stops"
+        id="geocoder-5::WA-State-Ferry::stops"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1194,7 +1194,7 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="1::Community Transit::stops"
+        id="geocoder-1::Community-Transit::stops"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1225,7 +1225,7 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="7::Community Transit::stops"
+        id="geocoder-7::Community-Transit::stops"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1259,7 +1259,7 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
       Other
     </h2>
     <li aria-live="off"
-        id="way/555892536"
+        id="geocoder-way/555892536"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1288,7 +1288,7 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="node/5662026889"
+        id="geocoder-node/5662026889"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1323,7 +1323,7 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="node/1934511929"
+        id="geocoder-node/1934511929"
         role="option"
         aria-selected="false"
         tabindex="-1"

--- a/packages/location-field/src/stories/__snapshots__/Desktop.story.tsx.snap
+++ b/packages/location-field/src/stories/__snapshots__/Desktop.story.tsx.snap
@@ -780,7 +780,7 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
       Other
     </h2>
     <li aria-live="off"
-        id="otpui-locf-option-0"
+        id="way/555892536"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -809,7 +809,7 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-1"
+        id="node/5662026889"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -844,7 +844,7 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-2"
+        id="node/1934511929"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -882,7 +882,7 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
       Stations
     </h2>
     <li aria-live="off"
-        id="otpui-locf-option-0"
+        id="TL_US::Sound Transit::stations"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -916,7 +916,7 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
       Stops
     </h2>
     <li aria-live="off"
-        id="otpui-locf-option-0"
+        id="5::WA State Ferry::stops"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -965,7 +965,7 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-1"
+        id="1::Community Transit::stops"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -996,7 +996,7 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-2"
+        id="7::Community Transit::stops"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1027,7 +1027,7 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-0"
+        id="current-position"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1111,7 +1111,7 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
       Stations
     </h2>
     <li aria-live="off"
-        id="otpui-locf-option-0"
+        id="TL_US::Sound Transit::stations"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1145,7 +1145,7 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
       Stops
     </h2>
     <li aria-live="off"
-        id="otpui-locf-option-0"
+        id="5::WA State Ferry::stops"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1194,7 +1194,7 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-1"
+        id="1::Community Transit::stops"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1225,7 +1225,7 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-2"
+        id="7::Community Transit::stops"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1259,7 +1259,7 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
       Other
     </h2>
     <li aria-live="off"
-        id="otpui-locf-option-0"
+        id="way/555892536"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1288,7 +1288,7 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-1"
+        id="node/5662026889"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1323,7 +1323,7 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-2"
+        id="node/1934511929"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1358,7 +1358,7 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-0"
+        id="current-position"
         role="option"
         aria-selected="false"
         tabindex="-1"

--- a/packages/location-field/src/stories/__snapshots__/Mobile.story.tsx.snap
+++ b/packages/location-field/src/stories/__snapshots__/Mobile.story.tsx.snap
@@ -49,7 +49,7 @@ exports[`LocationField/Mobile Context Blank smoke-test 1`] = `
       class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 bMzPj eECpsp"
   >
     <li aria-live="off"
-        id="otpui-locf-option-0"
+        id="current-position"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -130,7 +130,7 @@ exports[`LocationField/Mobile Context GeocoderNoResults smoke-test 1`] = `
       class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 bMzPj eECpsp"
   >
     <li aria-live="off"
-        id="otpui-locf-option-0"
+        id="current-position"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -211,7 +211,7 @@ exports[`LocationField/Mobile Context GeocoderUnreachable smoke-test 1`] = `
       class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 bMzPj eECpsp"
   >
     <li aria-live="off"
-        id="otpui-locf-option-0"
+        id="current-position"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -294,7 +294,7 @@ exports[`LocationField/Mobile Context LocationUnavailable smoke-test 1`] = `
   >
     <li aria-hidden="true"
         aria-live="off"
-        id="otpui-locf-option-0"
+        id="current-position"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -393,7 +393,7 @@ exports[`LocationField/Mobile Context SelectedLocation smoke-test 1`] = `
       class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 bMzPj eECpsp"
   >
     <li aria-live="off"
-        id="otpui-locf-option-0"
+        id="current-position"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -492,7 +492,7 @@ exports[`LocationField/Mobile Context SelectedLocationCustomClear smoke-test 1`]
       class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 bMzPj eECpsp"
   >
     <li aria-live="off"
-        id="otpui-locf-option-0"
+        id="current-position"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -573,7 +573,7 @@ exports[`LocationField/Mobile Context SlowGeocoder smoke-test 1`] = `
       class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 bMzPj eECpsp"
   >
     <li aria-live="off"
-        id="otpui-locf-option-0"
+        id="current-position"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -654,7 +654,7 @@ exports[`LocationField/Mobile Context Styled smoke-test 1`] = `
       class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 bMzPj eECpsp"
   >
     <li aria-live="off"
-        id="otpui-locf-option-0"
+        id="current-position"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -738,7 +738,7 @@ exports[`LocationField/Mobile Context WithCustomIcons smoke-test 1`] = `
       Nearby Stops
     </h2>
     <li aria-live="off"
-        id="otpui-locf-option-0"
+        id="1"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -777,7 +777,7 @@ exports[`LocationField/Mobile Context WithCustomIcons smoke-test 1`] = `
       </div>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-1"
+        id="2"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -819,7 +819,7 @@ exports[`LocationField/Mobile Context WithCustomIcons smoke-test 1`] = `
       Recently Searched
     </h2>
     <li aria-live="off"
-        id="otpui-locf-option-2"
+        id="000"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -851,7 +851,7 @@ exports[`LocationField/Mobile Context WithCustomIcons smoke-test 1`] = `
       My Places
     </h2>
     <li aria-live="off"
-        id="otpui-locf-option-3"
+        id="Home(456SuburbSt)"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -880,7 +880,7 @@ exports[`LocationField/Mobile Context WithCustomIcons smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-4"
+        id="Work(789BusySt)"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -909,7 +909,7 @@ exports[`LocationField/Mobile Context WithCustomIcons smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-5"
+        id="CoffeeRoastersShop,55CoffeeStreet"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -938,7 +938,7 @@ exports[`LocationField/Mobile Context WithCustomIcons smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-6"
+        id="123MainSt"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -967,7 +967,7 @@ exports[`LocationField/Mobile Context WithCustomIcons smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-7"
+        id="current-position"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1051,7 +1051,7 @@ exports[`LocationField/Mobile Context WithNearbyStops smoke-test 1`] = `
       Nearby Stops
     </h2>
     <li aria-live="off"
-        id="otpui-locf-option-0"
+        id="1"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1090,7 +1090,7 @@ exports[`LocationField/Mobile Context WithNearbyStops smoke-test 1`] = `
       </div>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-1"
+        id="2"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1129,7 +1129,7 @@ exports[`LocationField/Mobile Context WithNearbyStops smoke-test 1`] = `
       </div>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-2"
+        id="current-position"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1213,7 +1213,7 @@ exports[`LocationField/Mobile Context WithSessionSearches smoke-test 1`] = `
       Recently Searched
     </h2>
     <li aria-live="off"
-        id="otpui-locf-option-0"
+        id="000"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1242,7 +1242,7 @@ exports[`LocationField/Mobile Context WithSessionSearches smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-1"
+        id="current-position"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1326,7 +1326,7 @@ exports[`LocationField/Mobile Context WithUserSettings smoke-test 1`] = `
       My Places
     </h2>
     <li aria-live="off"
-        id="otpui-locf-option-0"
+        id="Home(456SuburbSt)"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1355,7 +1355,7 @@ exports[`LocationField/Mobile Context WithUserSettings smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-1"
+        id="Work(789BusySt)"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1384,7 +1384,7 @@ exports[`LocationField/Mobile Context WithUserSettings smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-2"
+        id="CoffeeRoastersShop,55CoffeeStreet"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1413,7 +1413,7 @@ exports[`LocationField/Mobile Context WithUserSettings smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-3"
+        id="123MainSt"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1442,7 +1442,7 @@ exports[`LocationField/Mobile Context WithUserSettings smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="otpui-locf-option-4"
+        id="current-position"
         role="option"
         aria-selected="false"
         tabindex="-1"

--- a/packages/location-field/src/stories/__snapshots__/Mobile.story.tsx.snap
+++ b/packages/location-field/src/stories/__snapshots__/Mobile.story.tsx.snap
@@ -819,7 +819,7 @@ exports[`LocationField/Mobile Context WithCustomIcons smoke-test 1`] = `
       Recently Searched
     </h2>
     <li aria-live="off"
-        id="000"
+        id="recent-000"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -851,7 +851,7 @@ exports[`LocationField/Mobile Context WithCustomIcons smoke-test 1`] = `
       My Places
     </h2>
     <li aria-live="off"
-        id="Home(456SuburbSt)"
+        id="user-saved-Home-(456-Suburb-St)"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -880,7 +880,7 @@ exports[`LocationField/Mobile Context WithCustomIcons smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="Work(789BusySt)"
+        id="user-saved-Work-(789-Busy-St)"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -909,7 +909,7 @@ exports[`LocationField/Mobile Context WithCustomIcons smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="CoffeeRoastersShop,55CoffeeStreet"
+        id="user-saved-Coffee-Roasters-Shop,-55-Coffee-Street"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -938,7 +938,7 @@ exports[`LocationField/Mobile Context WithCustomIcons smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="123MainSt"
+        id="user-saved-123-Main-St"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1213,7 +1213,7 @@ exports[`LocationField/Mobile Context WithSessionSearches smoke-test 1`] = `
       Recently Searched
     </h2>
     <li aria-live="off"
-        id="000"
+        id="recent-000"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1326,7 +1326,7 @@ exports[`LocationField/Mobile Context WithUserSettings smoke-test 1`] = `
       My Places
     </h2>
     <li aria-live="off"
-        id="Home(456SuburbSt)"
+        id="user-saved-Home-(456-Suburb-St)"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1355,7 +1355,7 @@ exports[`LocationField/Mobile Context WithUserSettings smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="Work(789BusySt)"
+        id="user-saved-Work-(789-Busy-St)"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1384,7 +1384,7 @@ exports[`LocationField/Mobile Context WithUserSettings smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="CoffeeRoastersShop,55CoffeeStreet"
+        id="user-saved-Coffee-Roasters-Shop,-55-Coffee-Street"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1413,7 +1413,7 @@ exports[`LocationField/Mobile Context WithUserSettings smoke-test 1`] = `
       </span>
     </li>
     <li aria-live="off"
-        id="123MainSt"
+        id="user-saved-123-Main-St"
         role="option"
         aria-selected="false"
         tabindex="-1"

--- a/packages/location-field/src/stories/__snapshots__/Mobile.story.tsx.snap
+++ b/packages/location-field/src/stories/__snapshots__/Mobile.story.tsx.snap
@@ -819,7 +819,7 @@ exports[`LocationField/Mobile Context WithCustomIcons smoke-test 1`] = `
       Recently Searched
     </h2>
     <li aria-live="off"
-        id="recent-000"
+        id="recent-0"
         role="option"
         aria-selected="false"
         tabindex="-1"
@@ -1213,7 +1213,7 @@ exports[`LocationField/Mobile Context WithSessionSearches smoke-test 1`] = `
       Recently Searched
     </h2>
     <li aria-live="off"
-        id="recent-000"
+        id="recent-0"
         role="option"
         aria-selected="false"
         tabindex="-1"


### PR DESCRIPTION
Splitting the geocoded features into categories broke the way we applied `itemIndex` to the list of menu items, which subsequently broke keyboard navigation. Instead of tracking the options by index, and also using a location function lookup, now we use `indexedOptionLookup` to create an array of all the ids and location handlers, and use that to iterate through the options in `onKeyDown`

Also added `generateOptionId` to create bespoke consistent ids for each element (open to feedback on this, it's pretty hacky)