### PR TITLE
Correctly Lowercase "stop id"

### DIFF
--- a/packages/geocoder/src/apis/otp/index.ts
+++ b/packages/geocoder/src/apis/otp/index.ts
@@ -63,7 +63,7 @@ async function autocomplete({
   // If this magic string is found, don't send it to the geocoder. 
   const IGNORED_MAGIC_STRING = "stop id "
   if (text.toLowerCase().indexOf(IGNORED_MAGIC_STRING) > -1) {
-    shortenedText = text.split(IGNORED_MAGIC_STRING)[1]
+    shortenedText = text.toLowerCase().split(IGNORED_MAGIC_STRING)[1]
   }
   return run({
     query: shortenedText,


### PR DESCRIPTION
We forgot to `toLowerCase` in one place! Which caused a bug. This bug is here fixed