### PR TITLE
fix(base-map): fix firefox printing bug

### DIFF
--- a/packages/base-map/src/index.tsx
+++ b/packages/base-map/src/index.tsx
@@ -161,6 +161,7 @@ const BaseMap = ({
       }}
       onTouchCancel={clearLongPressTimer}
       onTouchEnd={clearLongPressTimer}
+      preserveDrawingBuffer
       style={style}
       zoom={viewState.zoom}
     >


### PR DESCRIPTION
Trying to print the printable itinerary in firefox resulted in the map being empty. Added `preserveDrawingBuffer` per this  thread  https://github.com/mapbox/mapbox-gl-js/issues/9810

<!--(Optional) Before and after screenshots for visual changes:-->
| Before | After |
|--------|-------|
|![image](https://github.com/user-attachments/assets/66457f45-b797-4c55-abba-4681255e4ecc)|![image](https://github.com/user-attachments/assets/55fda45b-940d-4330-81a0-4a0de0206033)|



