### PR TITLE
fix(location-field): set message to null when location changes

### DIFF
--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -377,6 +377,7 @@ const LocationField = ({
     // location could be null if none is set
     setValue(location?.name || "");
     setGeocodedFeatures([]);
+    setMessage(null);
   }, [location]);
 
   useEffect(() => {


### PR DESCRIPTION
Fixes a bug where the user has text in the location field, moves the map and the locations changes, but the message still reflects the old location. 