### PR TITLE
fix(location-field): if no user text then clear geocoder results

### DIFF
--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -389,9 +389,10 @@ const LocationField = ({
   // TODO: is it possible to restore the useCallback while also setting
   // a new abort controller?
   const geocodeAutocomplete = debounce(300, (text: string) => {
-    if (!text) {
+    if (!text || text === "") {
       console.warn("No text entry provided for geocode autocomplete search.");
       setMessage(null);
+      setGeocodedFeatures([]);
       return;
     }
     setFetching(true);


### PR DESCRIPTION
Address a bug to clear geocoder results when there is no text in the search bar.