### PR TITLE
fix(itinerary-body):  Correctly apply aria-expanded to alerts button

### DIFF
--- a/packages/itinerary-body/src/TransitLegBody/index.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/index.tsx
@@ -184,6 +184,20 @@ class TransitLegBody extends Component<Props, State> {
         defaultFareSelector.riderCategoryId
       );
 
+    const alertLabelContents = (
+      <>
+        <AlertToggleIcon />{" "}
+        <FormattedMessage
+          defaultMessage={defaultMessages["otpUi.TransitLegBody.alertsHeader"]}
+          description="Number of alerts header"
+          id="otpUi.TransitLegBody.alertsHeader"
+          values={{
+            alertCount: alerts?.length
+          }}
+        />
+      </>
+    );
+
     return (
       <>
         {TransitLegSubheader && <TransitLegSubheader leg={leg} />}
@@ -298,40 +312,36 @@ class TransitLegBody extends Component<Props, State> {
               </S.CallAheadWarning>
             )}
             {/* Alerts toggle */}
-            {alerts?.length > 0 && (
-              <S.TransitAlertToggle
-                className="alert-toggle"
-                isButton={!shouldOnlyShowAlertsExpanded}
-                as={shouldOnlyShowAlertsExpanded && "div"}
-                onClick={this.onToggleAlertsClick}
-              >
-                <AlertToggleIcon />{" "}
-                <FormattedMessage
-                  defaultMessage={
-                    defaultMessages["otpUi.TransitLegBody.alertsHeader"]
-                  }
-                  description="Number of alerts header"
-                  id="otpUi.TransitLegBody.alertsHeader"
-                  values={{
-                    alertCount: alerts.length
-                  }}
-                />
-                {!shouldOnlyShowAlertsExpanded && (
-                  <>
-                    <S.CaretToggle expanded={alertsExpanded} />
-                    <S.InvisibleAdditionalDetails>
-                      <FormattedMessage
-                        defaultMessage={
-                          defaultMessages["otpUi.TransitLegBody.expandDetails"]
-                        }
-                        description="Screen reader text added to expand steps"
-                        id="otpUi.TransitLegBody.expandDetails"
-                      />
-                    </S.InvisibleAdditionalDetails>
-                  </>
-                )}
-              </S.TransitAlertToggle>
-            )}
+            {alerts?.length > 0 &&
+              (shouldOnlyShowAlertsExpanded ? (
+                <S.TransitAlertDiv className="alert-toggle">
+                  {alertLabelContents}
+                </S.TransitAlertDiv>
+              ) : (
+                <S.TransitAlertToggle
+                  aria-expanded={expandAlerts}
+                  className="alert-toggle"
+                  onClick={this.onToggleAlertsClick}
+                >
+                  {alertLabelContents}
+                  {!shouldOnlyShowAlertsExpanded && (
+                    <>
+                      <S.CaretToggle expanded={alertsExpanded} />
+                      <S.InvisibleAdditionalDetails>
+                        <FormattedMessage
+                          defaultMessage={
+                            defaultMessages[
+                              "otpUi.TransitLegBody.expandDetails"
+                            ]
+                          }
+                          description="Screen reader text added to expand steps"
+                          id="otpUi.TransitLegBody.expandDetails"
+                        />
+                      </S.InvisibleAdditionalDetails>
+                    </>
+                  )}
+                </S.TransitAlertToggle>
+              ))}
 
             {/* The Alerts body, if visible */}
             <AnimateHeight duration={500} height={expandAlerts ? "auto" : 0}>

--- a/packages/itinerary-body/src/styled.tsx
+++ b/packages/itinerary-body/src/styled.tsx
@@ -714,15 +714,24 @@ export const TransitAlerts = styled.ul`
   padding: 0;
 `;
 
-export const TransitAlertToggle = styled(TransparentButton)<{
-  isButton?: boolean;
-}>`
+const alertToggleStyling = css`
   color: #d14727;
-  cursor: ${props => (props.isButton ? "cursor" : "auto")};
-  display: inline-block;
+  display: flex;
   font-weight: 400;
   margin-top: 8px;
   padding: 0;
+
+  svg {
+    margin-right: 0.5em;
+  }
+`;
+export const TransitAlertToggle = styled(TransparentButton)`
+  cursor: "cursor";
+  ${alertToggleStyling}
+`;
+
+export const TransitAlertDiv = styled.div`
+  ${alertToggleStyling}
 `;
 
 export const TransitLegDetails = styled.div`


### PR DESCRIPTION
The alert button inside the itinerary body needed an `aria-expanded` prop, however we can't add that to a static `div`. This splits the alerts button into `button` and `div` elements and applies the appropriate props to each.

It also centers the alert label, which was previously off-center