### PR TITLE
fix: Clean up temporary directory

### DIFF
--- a/scripts/pack-and-extract-single.sh
+++ b/scripts/pack-and-extract-single.sh
@@ -18,6 +18,12 @@ fi
 # Define and create the target temporary directory
 TEMP_DIR_BASE="/tmp/otp-ui-pkg"
 TEMP_DIR="$TEMP_DIR_BASE/$PACKAGE_NAME"
+
+if [ -d "$TEMP_DIR" ]; then 
+  echo "Cleaning up $TEMP_DIR"
+  rm -rf "$TEMP_DIR"
+fi
+
 mkdir -p "$TEMP_DIR"
 
 # Extract the tarball to the temporary directory


### PR DESCRIPTION
Clean up the temporary directory before extracting the tar to eliminate problems when the version changes or files are removed. 