### PR TITLE
fix: Add new optional property to Place type

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -251,6 +251,7 @@ export type Place = {
   name: string;
   networks?: string[];
   rentalVehicle?: { network: string };
+  vehicleRentalStation?: { rentalNetwork: { networkId: string } };
   stop?: Stop;
   /**
    * @deprecated Only for OTP1 support, removal is immenent


### PR DESCRIPTION
This is meant to be step one of a two part pull-request situation.

This adds an optional value to the _Place_ type:
```
vehicleRentalStation?: { rentalNetwork: { networkId: string } };
```

The follow up pull request will add the following code in  the getCompanyFromLeg method in _core-utils/src/itinerary.ts_

```
  if (from.vehicleRentalStation && from.vehicleRentalStation.rentalNetwork) {
    return from.vehicleRentalStation.rentalNetwork.networkId;
  }
```

And all of this is so that in our client-code at Trimet, we can avoid having to do the following:
```
  const company =
    coreUtils.itinerary.getCompanyFromLeg(leg) ||
    leg.from.vehicleRentalStation?.rentalNetwork.networkId;
```
and instead just have this:
```
const company = coreUtils.itinerary.getCompanyFromLeg(leg);
```
