### PR TITLE
fix: Add vehicleRentalStation piece to getCompanyFromLeg method in co…

### DIFF
--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -244,6 +244,9 @@ export function getCompanyFromLeg(leg: Leg): string {
   if (from.rentalVehicle) {
     return from.rentalVehicle.network;
   }
+  if (from.vehicleRentalStation && from.vehicleRentalStation.rentalNetwork) {
+    return from.vehicleRentalStation.rentalNetwork.networkId;
+  }
   if (
     (mode === "MICROMOBILITY" || mode === "SCOOTER") &&
     rentedVehicle &&


### PR DESCRIPTION
This pull-request is a follow up to !839. It simply adds the 

```
  if (from.vehicleRentalStation && from.vehicleRentalStation.rentalNetwork) {
    return from.vehicleRentalStation.rentalNetwork.networkId;
  }
```
to packages/core-utils/src/itinerary.ts

so that in our client-code at Trimet, we can avoid having to do the following:
```
  const company =
    coreUtils.itinerary.getCompanyFromLeg(leg) ||
    leg.from.vehicleRentalStation?.rentalNetwork.networkId;
```
and instead just have this:
```
const company = coreUtils.itinerary.getCompanyFromLeg(leg);
```