### PR TITLE
fix(location-field): add type to location field button for better keyboard nav control

### DIFF
--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -1103,6 +1103,7 @@ const LocationField = ({
         })}
         onClick={onDropdownToggle}
         tabIndex={-1}
+        type="button"
       >
         <LocationIconComponent locationType={locationType} />
       </S.DropdownButton>

--- a/packages/location-field/src/stories/__snapshots__/Desktop.story.tsx.snap
+++ b/packages/location-field/src/stories/__snapshots__/Desktop.story.tsx.snap
@@ -15,6 +15,7 @@ exports[`LocationField/Desktop Context AutoFocusWithMultipleControls smoke-test 
             aria-expanded="false"
             aria-label="Toggle displaying the list of suggested locations"
             tabindex="-1"
+            type="button"
             class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
     >
       <svg viewbox="0 0 512 512"
@@ -68,6 +69,7 @@ exports[`LocationField/Desktop Context Blank smoke-test 1`] = `
           aria-expanded="false"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -120,6 +122,7 @@ exports[`LocationField/Desktop Context GeocoderNoResults smoke-test 1`] = `
           aria-expanded="false"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -172,6 +175,7 @@ exports[`LocationField/Desktop Context GeocoderUnreachable smoke-test 1`] = `
           aria-expanded="false"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -224,6 +228,7 @@ exports[`LocationField/Desktop Context HereGeocoder smoke-test 1`] = `
           aria-expanded="false"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -276,6 +281,7 @@ exports[`LocationField/Desktop Context LocationUnavailable smoke-test 1`] = `
           aria-expanded="false"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -335,6 +341,7 @@ exports[`LocationField/Desktop Context NoAutoFocusWithMultipleControls smoke-tes
             aria-expanded="false"
             aria-label="Toggle displaying the list of suggested locations"
             tabindex="-1"
+            type="button"
             class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
     >
       <svg viewbox="0 0 512 512"
@@ -388,6 +395,7 @@ exports[`LocationField/Desktop Context RequiredAndInvalidState smoke-test 1`] = 
           aria-expanded="false"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -440,6 +448,7 @@ exports[`LocationField/Desktop Context SelectedLocation smoke-test 1`] = `
           aria-expanded="false"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"
@@ -510,6 +519,7 @@ exports[`LocationField/Desktop Context SelectedLocationCustomClear smoke-test 1`
           aria-expanded="false"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"
@@ -580,6 +590,7 @@ exports[`LocationField/Desktop Context SlowGeocoder smoke-test 1`] = `
           aria-expanded="false"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -632,6 +643,7 @@ exports[`LocationField/Desktop Context WithBadApiKeyHandlesBadAutocomplete smoke
           aria-expanded="false"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -684,6 +696,7 @@ exports[`LocationField/Desktop Context WithCustomResultColorsAndIcons smoke-test
           aria-expanded="false"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -736,6 +749,7 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
           aria-expanded="true"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -1067,6 +1081,7 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
           aria-expanded="true"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -1398,6 +1413,7 @@ exports[`LocationField/Desktop Context WithUserSettings smoke-test 1`] = `
           aria-expanded="false"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"

--- a/packages/location-field/src/stories/__snapshots__/Mobile.story.tsx.snap
+++ b/packages/location-field/src/stories/__snapshots__/Mobile.story.tsx.snap
@@ -8,6 +8,7 @@ exports[`LocationField/Mobile Context Blank smoke-test 1`] = `
           aria-expanded="true"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -89,6 +90,7 @@ exports[`LocationField/Mobile Context GeocoderNoResults smoke-test 1`] = `
           aria-expanded="true"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -170,6 +172,7 @@ exports[`LocationField/Mobile Context GeocoderUnreachable smoke-test 1`] = `
           aria-expanded="true"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -251,6 +254,7 @@ exports[`LocationField/Mobile Context LocationUnavailable smoke-test 1`] = `
           aria-expanded="true"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -334,6 +338,7 @@ exports[`LocationField/Mobile Context SelectedLocation smoke-test 1`] = `
           aria-expanded="true"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"
@@ -433,6 +438,7 @@ exports[`LocationField/Mobile Context SelectedLocationCustomClear smoke-test 1`]
           aria-expanded="true"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"
@@ -532,6 +538,7 @@ exports[`LocationField/Mobile Context SlowGeocoder smoke-test 1`] = `
           aria-expanded="true"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -613,6 +620,7 @@ exports[`LocationField/Mobile Context Styled smoke-test 1`] = `
           aria-expanded="true"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -694,6 +702,7 @@ exports[`LocationField/Mobile Context WithCustomIcons smoke-test 1`] = `
           aria-expanded="true"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 640 512"
@@ -1007,6 +1016,7 @@ exports[`LocationField/Mobile Context WithNearbyStops smoke-test 1`] = `
           aria-expanded="true"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"
@@ -1169,6 +1179,7 @@ exports[`LocationField/Mobile Context WithSessionSearches smoke-test 1`] = `
           aria-expanded="true"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"
@@ -1282,6 +1293,7 @@ exports[`LocationField/Mobile Context WithUserSettings smoke-test 1`] = `
           aria-expanded="true"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"


### PR DESCRIPTION
Adds `type=button` to the location field button for better keyboard navigation control.