### PR TITLE
fix(location-field): add type to location field clear button

### DIFF
--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -1084,6 +1084,7 @@ const LocationField = ({
           id: "otpUi.LocationField.clearLocation"
         })}
         onClick={onClearButtonClick}
+        type="button"
       >
         {clearButtonIcon}
       </S.ClearButton>

--- a/packages/location-field/src/stories/__snapshots__/Desktop.story.tsx.snap
+++ b/packages/location-field/src/stories/__snapshots__/Desktop.story.tsx.snap
@@ -480,6 +480,7 @@ exports[`LocationField/Desktop Context SelectedLocation smoke-test 1`] = `
          value="123 Main St"
   >
   <button aria-label="Clear location"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__ClearButton-sc-xahsq2-2 hoozke cCkuXw"
   >
     <svg viewbox="0 0 320 512"
@@ -551,6 +552,7 @@ exports[`LocationField/Desktop Context SelectedLocationCustomClear smoke-test 1`
          value="123 Main St"
   >
   <button aria-label="Clear location"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__ClearButton-sc-xahsq2-2 hoozke cCkuXw"
   >
     <svg viewbox="0 0 512 512"

--- a/packages/location-field/src/stories/__snapshots__/Mobile.story.tsx.snap
+++ b/packages/location-field/src/stories/__snapshots__/Mobile.story.tsx.snap
@@ -370,6 +370,7 @@ exports[`LocationField/Mobile Context SelectedLocation smoke-test 1`] = `
          value="123 Main St"
   >
   <button aria-label="Clear location"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__ClearButton-sc-xahsq2-2 hoozke cCkuXw"
   >
     <svg viewbox="0 0 320 512"
@@ -470,6 +471,7 @@ exports[`LocationField/Mobile Context SelectedLocationCustomClear smoke-test 1`]
          value="123 Main St"
   >
   <button aria-label="Clear location"
+          type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__ClearButton-sc-xahsq2-2 hoozke cCkuXw"
   >
     <svg viewbox="0 0 512 512"


### PR DESCRIPTION
Fixes the clear button so it wont default to `type='submit'` when within a form