### PR TITLE
Upgrade map dependencies

### DIFF
--- a/packages/base-map/__mocks__/AllVehicles.tsx
+++ b/packages/base-map/__mocks__/AllVehicles.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Marker } from "react-map-gl";
+import { Marker } from "react-map-gl/maplibre";
 import { LeafletStyleMarker, Popup } from "../src/styled";
 
 const vehicleData = require("./vehicle-data/all-trimet.json");

--- a/packages/base-map/package.json
+++ b/packages/base-map/package.json
@@ -9,9 +9,8 @@
   "module": "esm/index.js",
   "private": false,
   "dependencies": {
-    "maplibre-gl": "^2.1.9",
+    "maplibre-gl": "^5.3.1",
     "react-map-gl": "catalog:",
-    "mapbox-gl": "npm:empty-npm-package@1.0.0",
     "@opentripplanner/building-blocks": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/base-map/package.json
+++ b/packages/base-map/package.json
@@ -9,7 +9,7 @@
   "module": "esm/index.js",
   "private": false,
   "dependencies": {
-    "maplibre-gl": "^5.3.1",
+    "maplibre-gl": "^5.5.0",
     "react-map-gl": "catalog:",
     "@opentripplanner/building-blocks": "workspace:*"
   },

--- a/packages/base-map/src/MarkerWithPopup.tsx
+++ b/packages/base-map/src/MarkerWithPopup.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import { FocusTrapWrapper } from "@opentripplanner/building-blocks";
 import React, { useState } from "react";
-import { Marker, PopupProps } from "react-map-gl";
+import { Marker, PopupProps } from "react-map-gl/maplibre";
 import { LeafletStyleMarker, Popup } from "./styled";
 
 type Props = React.ComponentPropsWithoutRef<React.ElementType> & {

--- a/packages/base-map/src/index.story.tsx
+++ b/packages/base-map/src/index.story.tsx
@@ -6,7 +6,7 @@ import {
   NavigationControl,
   ScaleControl,
   useMap
-} from "react-map-gl";
+} from "react-map-gl/maplibre";
 import { action } from "@storybook/addon-actions";
 import { ComponentStory } from "@storybook/react";
 

--- a/packages/base-map/src/index.story.tsx
+++ b/packages/base-map/src/index.story.tsx
@@ -57,6 +57,8 @@ const a11yOverrideParameters = {
 export const clickAndViewportchangedEvents = Template.bind({});
 clickAndViewportchangedEvents.args = {
   center,
+  // Note: Although onClick and onContextMenu are correctly triggered,
+  // the parameter returned by these events contains a cyclical reference that prevents Storybook from printing them.
   onClick,
   onContextMenu,
   onViewportChanged

--- a/packages/base-map/src/index.tsx
+++ b/packages/base-map/src/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { Map, MapProps } from "react-map-gl";
+import { Map, MapProps } from "react-map-gl/maplibre";
 import maplibregl, { Event } from "maplibre-gl";
 
 import { useIntl } from "react-intl";
@@ -139,7 +139,6 @@ const BaseMap = ({
       latitude={viewState.latitude}
       locale={generateMapControlTranslations(intl)}
       longitude={viewState.longitude}
-      // @ts-expect-error wrong type because we're using maplibre-gl
       mapLib={maplibregl}
       mapStyle={activeBaseLayer}
       maxZoom={maxZoom}

--- a/packages/base-map/src/index.tsx
+++ b/packages/base-map/src/index.tsx
@@ -134,6 +134,16 @@ const BaseMap = ({
     <Map
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...mapLibreProps}
+      canvasContextAttributes={{
+        // Copy of defaults at https://maplibre.org/maplibre-gl-js/docs/API/type-aliases/MapOptions/#default-value_5,
+        // except for contextType = undefined (from the source code)
+        // and preserveDrawingBuffer = true to support printing.
+        antialias: false,
+        desynchronized: false,
+        failIfMajorPerformanceCaveat: false,
+        powerPreference: "high-performance",
+        preserveDrawingBuffer: true
+      }}
       id={id}
       latitude={viewState.latitude}
       locale={generateMapControlTranslations(intl)}
@@ -166,7 +176,6 @@ const BaseMap = ({
       }}
       onTouchCancel={clearLongPressTimer}
       onTouchEnd={clearLongPressTimer}
-      preserveDrawingBuffer
       style={style}
       zoom={viewState.zoom}
     >

--- a/packages/base-map/src/index.tsx
+++ b/packages/base-map/src/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Map, MapProps } from "react-map-gl/maplibre";
-import maplibregl, { Event } from "maplibre-gl";
+import maplibregl, { MapLayerMouseEvent } from "maplibre-gl";
 
 import { useIntl } from "react-intl";
 
@@ -38,10 +38,9 @@ type Props = React.ComponentPropsWithoutRef<React.ElementType> & {
   /** The maximum zoom level the map should allow */
   maxZoom?: number;
   /** A callback method which is fired when the map is clicked with the left mouse button/tapped */
-  onClick?: (evt: Event) => void;
+  onClick?: (e: MapLayerMouseEvent) => void;
   /** A callback method which is fired when the map is clicked with the right mouse button/long tapped */
-  // Unknown is used here because of a maplibre/mapbox issue with the true type, MapLayerMouseEvent
-  onContextMenu?: (e: unknown) => void;
+  onContextMenu?: (e: MapLayerMouseEvent) => void;
   /** A callback method which is fired when the map zoom or map bounds change */
   onViewportChanged?: (e: State) => void;
   /** When set to true, all hidden layers will be removed. No layers will be uncheckable until
@@ -154,7 +153,13 @@ const BaseMap = ({
         // If the user is pinching the map or does other multi-touch actions, cancel long-press detection.
         const touchPointCount = e.points.length;
         if (touchPointCount === 1) {
-          setLongPressTimer(setTimeout(() => onContextMenu(e), 600));
+          setLongPressTimer(
+            setTimeout(
+              // TODO: Check that the type conversion is still correct.
+              () => onContextMenu((e as unknown) as MapLayerMouseEvent),
+              600
+            )
+          );
         } else {
           clearLongPressTimer();
         }

--- a/packages/base-map/src/styled.ts
+++ b/packages/base-map/src/styled.ts
@@ -1,4 +1,4 @@
-import { Popup as MapGlPopup } from "react-map-gl";
+import { Popup as MapGlPopup } from "react-map-gl/maplibre";
 import styled from "styled-components";
 
 /**

--- a/packages/base-map/src/styled.ts
+++ b/packages/base-map/src/styled.ts
@@ -5,8 +5,7 @@ import styled from "styled-components";
  * Adds a box shadow and tweaks border radius to make popups easier to read.
  */
 export const Popup = styled(MapGlPopup)`
-  & > .maplibregl-popup-content,
-  & > .mapboxgl-popup-content {
+  & > .maplibregl-popup-content {
     border-radius: 10px;
     box-shadow: 0 3px 14px 4px rgb(0 0 0 / 20%);
   }

--- a/packages/base-map/src/util.ts
+++ b/packages/base-map/src/util.ts
@@ -1,4 +1,8 @@
-import { LngLatBoundsLike, MapRef, PaddingOptions } from "react-map-gl";
+import {
+  LngLatBoundsLike,
+  MapRef,
+  PaddingOptions
+} from "react-map-gl/maplibre";
 
 /**
  * Computes padding dimensions based on roughly 1/20 of the map's canvas dimensions
@@ -12,7 +16,6 @@ export function getFitBoundsPadding(
   paddingRatio = 0.1
 ): PaddingOptions {
   const canvas = map.getCanvas();
-  // @ts-expect-error getPixelRatio not defined in MapRef type.
   const pixelRatio = map.getPixelRatio();
   const horizPadding = (canvas.width * paddingRatio) / pixelRatio;
   const vertPadding = (canvas.height * paddingRatio) / pixelRatio;

--- a/packages/endpoints-overlay/src/endpoint.tsx
+++ b/packages/endpoints-overlay/src/endpoint.tsx
@@ -10,7 +10,7 @@ import {
 import { FormattedMessage, useIntl } from "react-intl";
 import { Home } from "@styled-icons/fa-solid/Home";
 import { MapMarkerAlt } from "@styled-icons/fa-solid/MapMarkerAlt";
-import { Marker, MarkerDragEvent } from "react-map-gl";
+import { Marker, MarkerDragEvent } from "react-map-gl/maplibre";
 import { Sync } from "@styled-icons/fa-solid/Sync";
 import { Times } from "@styled-icons/fa-solid/Times";
 import coreUtils from "@opentripplanner/core-utils";

--- a/packages/otp2-tile-overlay/src/index.tsx
+++ b/packages/otp2-tile-overlay/src/index.tsx
@@ -1,22 +1,20 @@
-import EntityPopup from "@opentripplanner/map-popup"
+import EntityPopup from "@opentripplanner/map-popup";
 import {
   ConfiguredCompany,
   MapLocationActionArg,
   Station,
   Stop,
-  StopEventHandler,
-} from "@opentripplanner/types"
-// eslint-disable-next-line prettier/prettier
-import type { EventData } from "mapbox-gl"
-import React, { useCallback, useEffect, useState } from "react"
-import { Layer, Popup, Source, useMap } from "react-map-gl"
+  StopEventHandler
+} from "@opentripplanner/types";
+import { FilterSpecification, MapLayerMouseEvent } from "maplibre-gl";
+import React, { useCallback, useEffect, useState } from "react";
+import { Layer, Popup, Source, useMap } from "react-map-gl/maplibre";
 
-// eslint-disable-next-line prettier/prettier
-import { generateLayerPaint, ROUTE_COLOR_EXPRESSION } from "./util"
+import { generateLayerPaint, ROUTE_COLOR_EXPRESSION } from "./util";
 
-const SOURCE_ID = "otp2-tiles"
-const AREA_TYPES = ["areaStops"]
-const STOPS_AND_STATIONS_TYPE = "OTP-UI-stopsAndStations"
+const SOURCE_ID = "otp2-tiles";
+const AREA_TYPES = ["areaStops"];
+const STOPS_AND_STATIONS_TYPE = "OTP-UI-stopsAndStations";
 
 const OTP2TileLayerWithPopup = ({
   color,
@@ -37,15 +35,15 @@ const OTP2TileLayerWithPopup = ({
    * bikeshare companies. If this is provided, scooter/bikeshare company names can be rendered in the
    * default scooter/bike popup.
    */
-  configCompanies?: ConfiguredCompany[]
-  getEntityPrefix?: (entity: Stop | Station) => JSX.Element
-  id: string
-  name?: string
+  configCompanies?: ConfiguredCompany[];
+  getEntityPrefix?: (entity: Stop | Station) => JSX.Element;
+  id: string;
+  name?: string;
   /**
    * If `network` is specified, the layer will be filtered to only show vehicles from
    * that network
    */
-  network?: string
+  network?: string;
   /**
    * The minimum zoom to show the layer at. Defaults to 14
    */
@@ -55,73 +53,76 @@ const OTP2TileLayerWithPopup = ({
    * WILL APPEAR ON CLICK. The implementer will be responsible for handling all click events
    * in accordance with the MapLibreGL api.
    */
-  onMapClick?: (event: EventData) => void
+  onMapClick?: (event: MapLayerMouseEvent) => void;
   /**
    * A method fired when a stop is selected as from or to in the default popup. If this method
    * is not passed, the from/to buttons will not be shown.
    */
-  setLocation?: (location: MapLocationActionArg) => void
+  setLocation?: (location: MapLocationActionArg) => void;
   /**
    * A method fired when the stop viewer is opened in the default popup. If this method is
    * not passed, the stop viewer link will not be shown.
    */
-  setViewedStop?: StopEventHandler
+  setViewedStop?: StopEventHandler;
   /**
    * A list of GTFS stop ids (with agency prepended). If specified, all stops that
    * are NOT in this list will be HIDDEN.
    */
-  stopsWhitelist?: string[]
+  stopsWhitelist?: string[];
   /**
    * Determines which layer of the OTP2 tile data to display. Also determines icon color.
    */
-  type: string
-  visible?: boolean
+  type: string;
+  visible?: boolean;
 }): JSX.Element => {
-  const { current: map } = useMap()
+  const { current: map } = useMap();
 
   // TODO: handle this complex type: it can be a stop, a station, and some extra fields too
-  const [clickedEntity, setClickedEntity] = useState<any>(null)
+  const [clickedEntity, setClickedEntity] = useState<any>(null);
 
-  const defaultClickHandler = (event: EventData) => {
-    const { sourceLayer } = event.features?.[0]
+  const defaultClickHandler = (event: MapLayerMouseEvent) => {
+    const { sourceLayer } = event.features?.[0];
     const synthesizedEntity = {
       ...event.features?.[0].properties,
       lat: event.lngLat.lat,
       lon: event.lngLat.lng,
       sourceLayer
-    }
+    };
 
     // TODO: once the popup converges into a single one that can handle
     // stops, stations, and vehicles, this re-writing will not be needed
     // See: https://github.com/opentripplanner/otp-ui/pull/472#discussion_r1023124055
     if (sourceLayer === "stops" || sourceLayer === "stations") {
-      setClickedEntity(synthesizedEntity)
+      setClickedEntity(synthesizedEntity);
     }
-    if (
-      sourceLayer === "rentalVehicles" ||
-      sourceLayer === "rentalStations"
-    ) {
+    if (sourceLayer === "rentalVehicles" || sourceLayer === "rentalStations") {
       setClickedEntity({
         // GraphQL field not in the tile info, but we can deduce it
         isFloatingBike:
           sourceLayer === "rentalVehicles" &&
+          // @ts-expect-error TODO Find/implement the correct type
           synthesizedEntity.formFactor === "BICYCLE",
         // GraphQL field not in the tile info, but we can deduce it
         isFloatingVehicle:
           sourceLayer === "rentalVehicles" &&
+          // @ts-expect-error TODO Find/implement the correct type
           synthesizedEntity.formFactor === "SCOOTER",
         // OTP1 compatibility -- will get overwritten if possible
+        // @ts-expect-error TODO Decide whether to keep this
         networks: [synthesizedEntity.network],
         ...synthesizedEntity,
         // OTP1 compatibility
+        // @ts-expect-error TODO Decide whether to keep this
         bikesAvailable: synthesizedEntity.vehiclesAvailable,
         // OTP1 compatibility
+        // TODO Decide whether to keep this
         x: synthesizedEntity.lon,
         // OTP1 compatibility
+        // TODO Decide whether to keep this
         y: synthesizedEntity.lat
-      })
+      });
     }
-  }
+  };
 
   const onLayerEnter = useCallback(() => {
     map.getCanvas().style.cursor = "pointer";
@@ -132,13 +133,13 @@ const OTP2TileLayerWithPopup = ({
   }, [map]);
 
   useEffect(() => {
-    map?.on("mouseenter", id, onLayerEnter)
-    map?.on("mouseleave", id, onLayerLeave)
-    map?.on("click", id, onMapClick || defaultClickHandler)
+    map?.on("mouseenter", id, onLayerEnter);
+    map?.on("mouseleave", id, onLayerLeave);
+    map?.on("click", id, onMapClick || defaultClickHandler);
 
-    map?.on("mouseenter", `${id}-secondary`, onLayerEnter)
-    map?.on("mouseleave", `${id}-secondary`, onLayerLeave)
-    map?.on("click", `${id}-secondary`, onMapClick || defaultClickHandler)
+    map?.on("mouseenter", `${id}-secondary`, onLayerEnter);
+    map?.on("mouseleave", `${id}-secondary`, onLayerLeave);
+    map?.on("click", `${id}-secondary`, onMapClick || defaultClickHandler);
 
     return () => {
       map?.off("mouseenter", id, onLayerEnter);
@@ -147,81 +148,101 @@ const OTP2TileLayerWithPopup = ({
 
       map?.off("mouseenter", `${id}-secondary`, onLayerEnter);
       map?.off("mouseleave", `${id}-secondary`, onLayerLeave);
-      map?.off("click", `${id}-secondary`, onMapClick || defaultClickHandler)
+      map?.off("click", `${id}-secondary`, onMapClick || defaultClickHandler);
     };
-  }, [id, map])
+  }, [id, map]);
 
-  let filter: any[] = ["all"]
+  let filter: FilterSpecification = ["all"];
   if (network) {
-    filter = ["all", ["==", "network", network]]
+    filter = ["all", ["==", "network", network]];
   }
-  if (type === "stops" || type === "areaStops" || type === STOPS_AND_STATIONS_TYPE) {
-    filter = ["all", ["!", ["has", "parentStation"]], ["!=", ["get", "routes"], ["literal", "[]"]]]
+  if (
+    type === "stops" ||
+    type === "areaStops" ||
+    type === STOPS_AND_STATIONS_TYPE
+  ) {
+    filter = [
+      "all",
+      ["!", ["has", "parentStation"]],
+      ["!=", ["get", "routes"], ["literal", "[]"]]
+    ];
   }
   if (stopsWhitelist) {
-    filter = ["in", ["get", "gtfsId"], ["literal", stopsWhitelist]]
+    filter = ["in", ["get", "gtfsId"], ["literal", stopsWhitelist]];
   }
 
-  const isArea = AREA_TYPES.includes(type)
-  const isStopsAndStations = type === STOPS_AND_STATIONS_TYPE
+  const isArea = AREA_TYPES.includes(type);
+  const isStopsAndStations = type === STOPS_AND_STATIONS_TYPE;
   return (
     <>
-      {isArea && <Layer
-        filter={filter}
-        id={`${id}-fill`}
-        paint={{
-          "fill-color": ROUTE_COLOR_EXPRESSION,
-          "fill-opacity": 0.2,
-        }}
-        source-layer={type}
-        source={SOURCE_ID}
-        minzoom={stopsWhitelist ? 2 : minZoom}
-        type="fill"
-      />}
-      {isArea && <Layer
-        filter={filter}
-        id={`${id}-outline`}
-        layout={{ "line-join": "round", "line-cap": "round" }}
-        minzoom={stopsWhitelist ? 2 : minZoom}
-        paint={{
-          "line-color": ROUTE_COLOR_EXPRESSION,
-          "line-opacity": 0.8,
-          "line-width": 3
-        }}
-        source-layer={type}
-        source={SOURCE_ID}
-        type="line"
-      />}
-      {isStopsAndStations && <Layer
-        filter={filter}
-        id={id}
-        key={`${id}-stops`}
-        paint={generateLayerPaint(color).stops}
-        source={SOURCE_ID}
-        minzoom={stopsWhitelist ? 2 : minZoom}
-        source-layer="stops"
-        type="circle"
-      />}
-      {isStopsAndStations && <Layer
-        filter={filter}
-        id={`${id}-secondary`}
-        key={`${id}-stations`}
-        paint={generateLayerPaint(color).stops}
-        source={SOURCE_ID}
-        minzoom={stopsWhitelist ? 2 : minZoom}
-        source-layer="stations"
-        type="circle"
-      />}
-      {!isArea && !isStopsAndStations && <Layer
-        filter={filter}
-        id={id}
-        key={id}
-        paint={generateLayerPaint(color)[type]}
-        source={SOURCE_ID}
-        minzoom={stopsWhitelist ? 2 : minZoom}
-        source-layer={type}
-        type="circle"
-      />}
+      {isArea && (
+        <Layer
+          filter={filter}
+          id={`${id}-fill`}
+          paint={{
+            // @ts-expect-error TODO Find the correct type
+            "fill-color": ROUTE_COLOR_EXPRESSION,
+            "fill-opacity": 0.2
+          }}
+          source-layer={type}
+          source={SOURCE_ID}
+          minzoom={stopsWhitelist ? 2 : minZoom}
+          type="fill"
+        />
+      )}
+      {isArea && (
+        <Layer
+          filter={filter}
+          id={`${id}-outline`}
+          layout={{ "line-join": "round", "line-cap": "round" }}
+          minzoom={stopsWhitelist ? 2 : minZoom}
+          paint={{
+            // @ts-expect-error TODO Find the correct type
+            "line-color": ROUTE_COLOR_EXPRESSION,
+            "line-opacity": 0.8,
+            "line-width": 3
+          }}
+          source-layer={type}
+          source={SOURCE_ID}
+          type="line"
+        />
+      )}
+      {isStopsAndStations && (
+        <Layer
+          filter={filter}
+          id={id}
+          key={`${id}-stops`}
+          paint={generateLayerPaint(color).stops}
+          source={SOURCE_ID}
+          minzoom={stopsWhitelist ? 2 : minZoom}
+          source-layer="stops"
+          type="circle"
+        />
+      )}
+      {isStopsAndStations && (
+        <Layer
+          filter={filter}
+          id={`${id}-secondary`}
+          key={`${id}-stations`}
+          paint={generateLayerPaint(color).stops}
+          source={SOURCE_ID}
+          minzoom={stopsWhitelist ? 2 : minZoom}
+          source-layer="stations"
+          type="circle"
+        />
+      )}
+      {!isArea && !isStopsAndStations && (
+        <Layer
+          filter={filter}
+          id={id}
+          key={id}
+          paint={generateLayerPaint(color)[type]}
+          source={SOURCE_ID}
+          minzoom={stopsWhitelist ? 2 : minZoom}
+          source-layer={type}
+          type="circle"
+        />
+      )}
       {clickedEntity && (
         <Popup
           latitude={clickedEntity.lat}
@@ -233,33 +254,57 @@ const OTP2TileLayerWithPopup = ({
           <EntityPopup
             closePopup={() => setClickedEntity(null)}
             configCompanies={configCompanies}
-            entity={{ ...clickedEntity, id: clickedEntity?.id || clickedEntity?.gtfsId }}
+            entity={{
+              ...clickedEntity,
+              id: clickedEntity?.id || clickedEntity?.gtfsId
+            }}
             getEntityPrefix={getEntityPrefix}
-            setLocation={setLocation ? (location) => { setClickedEntity(null); setLocation(location) } : null}
-            setViewedStop={setViewedStop ? (stop) => { setClickedEntity(null);setViewedStop(stop) } : null}
+            setLocation={
+              setLocation
+                ? location => {
+                    setClickedEntity(null);
+                    setLocation(location);
+                  }
+                : null
+            }
+            setViewedStop={
+              setViewedStop
+                ? stop => {
+                    setClickedEntity(null);
+                    setViewedStop(stop);
+                  }
+                : null
+            }
           />
-
         </Popup>
       )}
     </>
-  )
-}
+  );
+};
 
 /**
- * Generates an array of MapLibreGL Source and Layer components with included popups for 
+ * Generates an array of MapLibreGL Source and Layer components with included popups for
  * rendering OTP2 tile data.
- * 
+ *
  * @param layers          A list of layers, with some minimal config, matching what is configured on the server.
  *                        This list will be used to craft the tilejson request to OTP.
  * @param endpoint        The OTP endpoint to make the requests to
  * @param setLocation     An optional method to make from/to buttons functional. See component for more detail.
- * @param setViewedStop   An optional method to make stop viewer button functional. See component for more detail. 
- * @param stopsWhitelist  An optional list of stops to display singularly. See component for more detail. 
+ * @param setViewedStop   An optional method to make stop viewer button functional. See component for more detail.
+ * @param stopsWhitelist  An optional list of stops to display singularly. See component for more detail.
  * @param configCompanies An optional list of companies used to prettify network information.
  * @returns               Array of <Source> and <OTP2TileLayerWithPopup> components
  */
 const generateOTP2TileLayers = (
-  layers: { color?: string; name?: string; network?: string; type: string, initiallyVisible?: boolean, minZoom?: number, overrideType?: string }[],
+  layers: {
+    color?: string;
+    initiallyVisible?: boolean;
+    minZoom?: number;
+    name?: string;
+    network?: string;
+    overrideType?: string;
+    type: string;
+  }[],
   endpoint: string,
   setLocation?: (location: MapLocationActionArg) => void,
   setViewedStop?: (stop: Stop) => void,
@@ -267,9 +312,11 @@ const generateOTP2TileLayers = (
   configCompanies?: ConfiguredCompany[],
   getEntityPrefix?: (entity: Stop | Station) => JSX.Element
 ): JSX.Element[] => {
-  const fakeOtpUiLayerIndex = layers.findIndex(l=>l.type === STOPS_AND_STATIONS_TYPE)
+  const fakeOtpUiLayerIndex = layers.findIndex(
+    l => l.type === STOPS_AND_STATIONS_TYPE
+  );
   if (fakeOtpUiLayerIndex > -1) {
-    layers[fakeOtpUiLayerIndex].overrideType = "stops,stations"
+    layers[fakeOtpUiLayerIndex].overrideType = "stops,stations";
   }
 
   return [
@@ -280,12 +327,14 @@ const generateOTP2TileLayers = (
       key={SOURCE_ID}
       type="vector"
       // Only grab the data we need based on layers defined
-      url={`${endpoint}/${layers.map((l) => l.overrideType || l.type).join(",")}/tilejson.json`}
+      url={`${endpoint}/${layers
+        .map(l => l.overrideType || l.type)
+        .join(",")}/tilejson.json`}
     />,
     ...layers.map((layer) => {
-      const { color, name, network, type, minZoom, initiallyVisible } = layer
+      const { color, name, network, type, minZoom, initiallyVisible } = layer;
 
-      const id = `${type}${network ? `-${network}` : ""}`
+      const id = `${type}${network ? `-${network}` : ""}`;
       return (
         <OTP2TileLayerWithPopup
           color={color}
@@ -302,9 +351,9 @@ const generateOTP2TileLayers = (
           type={type}
           visible={initiallyVisible}
         />
-      )
+      );
     })
-  ]
-}
+  ];
+};
 
-export default generateOTP2TileLayers
+export default generateOTP2TileLayers;

--- a/packages/otp2-tile-overlay/src/index.tsx
+++ b/packages/otp2-tile-overlay/src/index.tsx
@@ -47,7 +47,7 @@ const OTP2TileLayerWithPopup = ({
   /**
    * The minimum zoom to show the layer at. Defaults to 14
    */
-  minZoom?: number
+  minZoom?: number;
   /**
    * An optional method to override the map click handler. If a method is passed, NO POPUPS
    * WILL APPEAR ON CLICK. The implementer will be responsible for handling all click events
@@ -331,7 +331,7 @@ const generateOTP2TileLayers = (
         .map(l => l.overrideType || l.type)
         .join(",")}/tilejson.json`}
     />,
-    ...layers.map((layer) => {
+    ...layers.map(layer => {
       const { color, name, network, type, minZoom, initiallyVisible } = layer;
 
       const id = `${type}${network ? `-${network}` : ""}`;

--- a/packages/otp2-tile-overlay/src/util.ts
+++ b/packages/otp2-tile-overlay/src/util.ts
@@ -1,5 +1,3 @@
-import { Expression } from "mapbox-gl";
-
 const generateFloatingVehicleColor = (formFactor: string) => [
   "case",
   ["==", ["get", formFactor], "SCOOTER"],
@@ -9,7 +7,7 @@ const generateFloatingVehicleColor = (formFactor: string) => [
   "#333"
 ];
 
-export const ROUTE_COLOR_EXPRESSION: Expression = [
+export const ROUTE_COLOR_EXPRESSION = [
   "concat",
   "#",
   [

--- a/packages/route-viewer-overlay/src/index.tsx
+++ b/packages/route-viewer-overlay/src/index.tsx
@@ -1,7 +1,7 @@
 import { util } from "@opentripplanner/base-map";
 import { Stop } from "@opentripplanner/types";
 import { LngLatBounds } from "maplibre-gl";
-import { Layer, LngLatLike, Source, useMap } from "react-map-gl";
+import { Layer, LngLatLike, Source, useMap } from "react-map-gl/maplibre";
 import React, { useEffect } from "react";
 
 import polyline from "@mapbox/polyline";
@@ -125,6 +125,8 @@ const RouteViewerOverlay = (props: Props): JSX.Element => {
           const coordsArray = geoJson.coordinates[0];
           bounds = coordsArray.reduce(
             reduceBounds,
+            // Per https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.1, GeoJson points should have 2+ dimensions.
+            // @ts-expect-error LngLatBounds requires number[2+], which GoeJson points should provide.
             bounds || new LngLatBounds(coordsArray[0], coordsArray[0])
           );
         } else if (geoJson?.type === "GeometryCollection") {
@@ -158,7 +160,9 @@ const RouteViewerOverlay = (props: Props): JSX.Element => {
           }
           bounds = bounds
             ? bounds.extend(coords)
-            : new LngLatBounds(coords, coords);
+            : // Per https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.1, GeoJson points should have 2+ dimensions.
+              // @ts-expect-error LngLatBounds requires number[2+], which GoeJson points should provide.
+              new LngLatBounds(coords, coords);
         }
       });
     });

--- a/packages/stop-viewer-overlay/src/StopViewerOverlay.story.tsx
+++ b/packages/stop-viewer-overlay/src/StopViewerOverlay.story.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Marker } from "react-map-gl";
+import { Marker } from "react-map-gl/maplibre";
 import DefaultStopMarker from "./default-stop-marker";
 import StopViewerOverlay, { StopContainer } from ".";
 import { withMap } from "../../../.storybook/base-map-wrapper";

--- a/packages/stop-viewer-overlay/src/index.tsx
+++ b/packages/stop-viewer-overlay/src/index.tsx
@@ -1,5 +1,5 @@
 import { Stop } from "@opentripplanner/types";
-import { useMap } from "react-map-gl";
+import { useMap } from "react-map-gl/maplibre";
 import React, { useEffect } from "react";
 
 export type StopContainer = { stop: Stop };

--- a/packages/stops-overlay/src/index.tsx
+++ b/packages/stops-overlay/src/index.tsx
@@ -4,8 +4,8 @@ import {
   Stop,
   StopEventHandler
 } from "@opentripplanner/types";
-import { EventData } from "mapbox-gl";
-import { Layer, Source, useMap } from "react-map-gl";
+import { MapLayerMouseEvent } from "maplibre-gl";
+import { Layer, Source, useMap } from "react-map-gl/maplibre";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 import StopPopup from "@opentripplanner/map-popup";
@@ -83,14 +83,14 @@ const StopsOverlay = (props: Props): JSX.Element => {
   }, [map]);
 
   const onLayerClick = useCallback(
-    (event: EventData) => {
+    (event: MapLayerMouseEvent) => {
       setClickedStop(event.features?.[0].properties);
     },
     [setClickedStop]
   );
 
   const onZoomEnd = useCallback(
-    (event: EventData) => {
+    event => {
       if (event.viewState.zoom < minZoom) setClickedStop(null);
     },
     [setClickedStop, minZoom]

--- a/packages/transit-vehicle-overlay/README.md
+++ b/packages/transit-vehicle-overlay/README.md
@@ -1,10 +1,7 @@
 ## WHAT:
 
-Presentational React Components used to build an interactive vehicle map .
+Presentational React Components based on react-map-gl and maplibre-gl used to build an interactive vehicle map .
 This component uses functional components and hooks (no more class components).
-
-NOTE: eventually want this component (and OTP-UI in general) to support both leaflet and
-mapbox gl libraries.
 
 ### CURRENTLY:
 
@@ -38,4 +35,3 @@ Only input in the form of https://github.com/opentripplanner/otp-ui/blob/master/
 ## TODO:
 
 1.  more / better unit tests
-2.  mapbox gl

--- a/packages/transitive-overlay/src/index.tsx
+++ b/packages/transitive-overlay/src/index.tsx
@@ -1,7 +1,7 @@
-import { SymbolLayout } from "mapbox-gl";
+import { FilterSpecification } from "maplibre-gl";
 import { util } from "@opentripplanner/base-map";
 import React, { useEffect } from "react";
-import { Layer, MapRef, Source, useMap } from "react-map-gl";
+import { Layer, MapRef, Source, useMap } from "react-map-gl/maplibre";
 import polyline from "@mapbox/polyline";
 import {
   Leg,
@@ -40,7 +40,7 @@ const defaultTextPaintParams = {
 /**
  * Common text settings.
  */
-const commonTextLayoutParams: SymbolLayout = {
+const commonTextLayoutParams = {
   "symbol-placement": "point",
   "text-allow-overlap": false,
   "text-field": ["get", "name"],
@@ -52,7 +52,7 @@ const commonTextLayoutParams: SymbolLayout = {
 /**
  * Text size and layout that lets maplibre relocate text space permitting.
  */
-const defaultTextLayoutParams: SymbolLayout = {
+const defaultTextLayoutParams = {
   ...commonTextLayoutParams,
   "text-variable-anchor": [
     "left",
@@ -76,9 +76,9 @@ const defaultBoldTextLayoutParams = {
   "text-overlap": "never"
 };
 
-const routeFilter = ["==", "type", "route"];
-const stopFilter = ["==", "type", "stop"];
-const accessLegFilter = [
+const routeFilter: FilterSpecification = ["==", "type", "route"];
+const stopFilter: FilterSpecification = ["==", "type", "stop"];
+const accessLegFilter: FilterSpecification = [
   "match",
   ["get", "type"],
   ["BICYCLE", "SCOOTER", "MICROMOBILITY", "MICROMOBILITY_RENT", "CAR"],
@@ -101,16 +101,17 @@ type MapImage = {
 
 const loadImages = (map: MapRef, images: MapImage[]) => {
   images.forEach(img => {
-    map.loadImage(img.url, (error, image) => {
-      if (error) {
+    map
+      .loadImage(img.url)
+      .then(response => {
+        if (!map.hasImage(img.id)) {
+          map.addImage(img.id, response.data, { sdf: true });
+        }
+      })
+      .catch(error => {
         // eslint-disable-next-line no-console
         console.error(`Error loading image ${img.id}:`, error);
-        return;
-      }
-      if (!map.hasImage(img.id)) {
-        map.addImage(img.id, image, { sdf: true });
-      }
-    });
+      });
   });
 };
 
@@ -362,6 +363,7 @@ const TransitiveCanvasOverlay = ({
       <Layer
         filter={accessLegFilter}
         id="access-leg-labels"
+        // @ts-expect-error TODO: use parts of SymbolLayerSpecification
         layout={defaultTextLayoutParams}
         paint={defaultTextPaintParams}
         type="symbol"
@@ -369,6 +371,7 @@ const TransitiveCanvasOverlay = ({
       <Layer
         filter={stopFilter}
         id="stops-labels"
+        // @ts-expect-error TODO: use parts of SymbolLayerSpecification
         layout={defaultTextLayoutParams}
         paint={defaultTextPaintParams}
         type="symbol"
@@ -398,6 +401,7 @@ const TransitiveCanvasOverlay = ({
       <Layer
         filter={["==", "type", "from"]}
         id="from-label"
+        // @ts-expect-error TODO: use parts of SymbolLayerSpecification
         layout={{
           ...defaultBoldTextLayoutParams,
           "text-anchor": fromAnchor
@@ -408,6 +412,7 @@ const TransitiveCanvasOverlay = ({
       <Layer
         filter={["==", "type", "to"]}
         id="to-label"
+        // @ts-expect-error TODO: use parts of SymbolLayerSpecification
         layout={{
           ...defaultBoldTextLayoutParams,
           "text-anchor": toAnchor

--- a/packages/transitive-overlay/src/route-layers.ts
+++ b/packages/transitive-overlay/src/route-layers.ts
@@ -1,5 +1,4 @@
 import polyline from "@mapbox/polyline";
-import { SymbolLayout } from "mapbox-gl";
 import { TransitivePattern, TransitiveRoute } from "@opentripplanner/types";
 
 import { drawArc } from "./util";
@@ -58,7 +57,16 @@ export function patternToRouteFeature(
 /**
  * Obtains common layout options for route label layers.
  */
-export function getRouteLayerLayout(textField: string): SymbolLayout {
+export function getRouteLayerLayout(
+  textField: string
+): {
+  "symbol-placement": "line-center";
+  "text-allow-overlap": boolean;
+  "text-field": ["get", string];
+  "text-ignore-placement": boolean;
+  "text-rotation-alignment": "viewport";
+  "text-size": number;
+} {
   return {
     "symbol-placement": "line-center",
     "text-allow-overlap": true,

--- a/packages/transitive-overlay/src/util.ts
+++ b/packages/transitive-overlay/src/util.ts
@@ -1,5 +1,3 @@
-import { Anchor } from "mapbox-gl";
-
 import lineArc from "@turf/line-arc";
 import lineDistance from "@turf/line-distance";
 import midpoint from "@turf/midpoint";
@@ -26,6 +24,18 @@ import {
   TransitiveStop
 } from "@opentripplanner/types";
 import { IntlShape } from "react-intl";
+
+// TODO: Find an existing type.
+export type Anchor =
+  | "center"
+  | "left"
+  | "right"
+  | "top"
+  | "bottom"
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right";
 
 const CAR_PARK_ITIN_PREFIX = "itin_car_";
 

--- a/packages/trip-viewer-overlay/src/index.tsx
+++ b/packages/trip-viewer-overlay/src/index.tsx
@@ -1,7 +1,7 @@
 import polyline from "@mapbox/polyline";
 import { LngLatBounds } from "maplibre-gl";
 import { util } from "@opentripplanner/base-map";
-import { Layer, Source, useMap } from "react-map-gl";
+import { Layer, Source, useMap } from "react-map-gl/maplibre";
 import React, { useEffect, useMemo } from "react";
 
 type Props = {

--- a/packages/vehicle-rental-overlay/src/index.tsx
+++ b/packages/vehicle-rental-overlay/src/index.tsx
@@ -129,7 +129,6 @@ const VehicleRentalOverlay = ({
     });
     map.on("zoom", (e: ViewStateChangeEvent) => {
       // Avoid too many re-renders by only updating state if we are a whole number value different
-      // @ts-expect-error viewState not declared
       const { zoom: newZoom } = e.viewState;
       if (Math.floor(zoom / 2) !== Math.floor(newZoom / 2)) {
         setZoom(newZoom);

--- a/packages/vehicle-rental-overlay/src/index.tsx
+++ b/packages/vehicle-rental-overlay/src/index.tsx
@@ -129,6 +129,7 @@ const VehicleRentalOverlay = ({
     });
     map.on("zoom", (e: ViewStateChangeEvent) => {
       // Avoid too many re-renders by only updating state if we are a whole number value different
+      // @ts-expect-error viewState not declared
       const { zoom: newZoom } = e.viewState;
       if (Math.floor(zoom / 2) !== Math.floor(newZoom / 2)) {
         setZoom(newZoom);

--- a/packages/vehicle-rental-overlay/src/index.tsx
+++ b/packages/vehicle-rental-overlay/src/index.tsx
@@ -5,9 +5,8 @@ import {
   MapLocationActionArg,
   Station
 } from "@opentripplanner/types";
-import { EventData } from "mapbox-gl";
 import React, { useEffect, useState } from "react";
-import { Layer, Source, useMap } from "react-map-gl";
+import { Layer, Source, useMap } from "react-map-gl/maplibre";
 
 import StationPopup from "@opentripplanner/map-popup";
 import { BaseBikeRentalIcon, StationMarker } from "./styled";
@@ -119,12 +118,13 @@ const VehicleRentalOverlay = ({
       map?.on("mouseleave", stopLayer, () => {
         map.getCanvas().style.cursor = "";
       });
-      map?.on("click", stopLayer, (event: EventData) => {
+      map?.on("click", stopLayer, event => {
         setClickedVehicle(event.features?.[0].properties);
       });
     });
     map.on("zoom", e => {
       // Avoid too many re-renders by only updating state if we are a whole number value different
+      // @ts-expect-error viewState not declared
       const { zoom: newZoom } = e.viewState;
       if (Math.floor(zoom / 2) !== Math.floor(newZoom / 2)) {
         setZoom(newZoom);

--- a/packages/vehicle-rental-overlay/src/index.tsx
+++ b/packages/vehicle-rental-overlay/src/index.tsx
@@ -6,7 +6,12 @@ import {
   Station
 } from "@opentripplanner/types";
 import React, { useEffect, useState } from "react";
-import { Layer, Source, useMap } from "react-map-gl/maplibre";
+import {
+  Layer,
+  Source,
+  useMap,
+  ViewStateChangeEvent
+} from "react-map-gl/maplibre";
 
 import StationPopup from "@opentripplanner/map-popup";
 import { BaseBikeRentalIcon, StationMarker } from "./styled";
@@ -122,9 +127,8 @@ const VehicleRentalOverlay = ({
         setClickedVehicle(event.features?.[0].properties);
       });
     });
-    map.on("zoom", e => {
+    map.on("zoom", (e: ViewStateChangeEvent) => {
       // Avoid too many re-renders by only updating state if we are a whole number value different
-      // @ts-expect-error viewState not declared
       const { zoom: newZoom } = e.viewState;
       if (Math.floor(zoom / 2) !== Math.floor(newZoom / 2)) {
         setZoom(newZoom);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ catalogs:
       specifier: ^6.8.4
       version: 6.8.4
     react-map-gl:
-      specifier: ^7.0.15
-      version: 7.1.7
+      specifier: ^8.0.4
+      version: 8.0.4
     styled-components:
       specifier: ^5.3.0
       version: 5.3.11
@@ -351,18 +351,15 @@ importers:
       '@opentripplanner/types':
         specifier: workspace:*
         version: link:../types
-      mapbox-gl:
-        specifier: npm:empty-npm-package@1.0.0
-        version: empty-npm-package@1.0.0
       maplibre-gl:
-        specifier: ^2.1.9
-        version: 2.4.0
+        specifier: ^5.3.1
+        version: 5.3.1
       react:
         specifier: 'catalog:'
         version: 18.2.0
       react-map-gl:
         specifier: 'catalog:'
-        version: 7.1.7(empty-npm-package@1.0.0)(maplibre-gl@2.4.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       styled-components:
         specifier: 'catalog:'
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
@@ -463,7 +460,7 @@ importers:
         version: 6.8.4(react@18.2.0)(typescript@4.9.5)
       react-map-gl:
         specifier: 'catalog:'
-        version: 7.1.7(empty-npm-package@1.0.0)(maplibre-gl@2.4.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       styled-components:
         specifier: 'catalog:'
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
@@ -681,7 +678,7 @@ importers:
         version: 18.2.0
       react-map-gl:
         specifier: 'catalog:'
-        version: 7.1.7(empty-npm-package@1.0.0)(maplibre-gl@2.4.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@opentripplanner/base-map':
         specifier: workspace:*
@@ -709,7 +706,7 @@ importers:
         version: 18.3.1(react@18.2.0)
       react-map-gl:
         specifier: 'catalog:'
-        version: 7.1.7(empty-npm-package@1.0.0)(maplibre-gl@2.4.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       styled-components:
         specifier: 'catalog:'
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
@@ -786,7 +783,7 @@ importers:
         version: 18.2.0
       react-map-gl:
         specifier: 'catalog:'
-        version: 7.1.7(empty-npm-package@1.0.0)(maplibre-gl@2.4.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@opentripplanner/types':
         specifier: workspace:*
@@ -814,7 +811,7 @@ importers:
         version: 6.8.4(react@18.2.0)(typescript@4.9.5)
       react-map-gl:
         specifier: 'catalog:'
-        version: 7.1.7(empty-npm-package@1.0.0)(maplibre-gl@2.4.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       styled-components:
         specifier: 'catalog:'
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
@@ -848,7 +845,7 @@ importers:
         version: 6.8.4(react@18.2.0)(typescript@4.9.5)
       react-map-gl:
         specifier: 'catalog:'
-        version: 7.1.7(empty-npm-package@1.0.0)(maplibre-gl@2.4.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       styled-components:
         specifier: 'catalog:'
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
@@ -897,7 +894,7 @@ importers:
         version: 18.2.0
       react-map-gl:
         specifier: 'catalog:'
-        version: 7.1.7(empty-npm-package@1.0.0)(maplibre-gl@2.4.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@opentripplanner/endpoints-overlay':
         specifier: workspace:*
@@ -1011,7 +1008,7 @@ importers:
         version: 18.2.0
       react-map-gl:
         specifier: 'catalog:'
-        version: 7.1.7(empty-npm-package@1.0.0)(maplibre-gl@2.4.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
 
   packages/types: {}
 
@@ -1049,7 +1046,7 @@ importers:
         version: 6.8.4(react@18.2.0)(typescript@4.9.5)
       react-map-gl:
         specifier: 'catalog:'
-        version: 7.1.7(empty-npm-package@1.0.0)(maplibre-gl@2.4.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       styled-components:
         specifier: 'catalog:'
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
@@ -1074,7 +1071,7 @@ importers:
         version: 18.2.0
       react-map-gl:
         specifier: 'catalog:'
-        version: 7.1.7(empty-npm-package@1.0.0)(maplibre-gl@2.4.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       styled-components:
         specifier: 'catalog:'
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
@@ -2374,9 +2371,6 @@ packages:
     resolution: {integrity: sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==}
     engines: {node: '>= 0.6'}
 
-  '@mapbox/mapbox-gl-supported@2.0.1':
-    resolution: {integrity: sha512-HP6XvfNIzfoMVfyGjBckjiAOQK9WfX0ywdLubuPMPv+Vqf5fj0uCbgBQYpiqcWZT6cbyyRnTSXDheT1ugvF6UQ==}
-
   '@mapbox/point-geometry@0.1.0':
     resolution: {integrity: sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==}
 
@@ -2399,6 +2393,10 @@ packages:
 
   '@maplibre/maplibre-gl-style-spec@19.3.3':
     resolution: {integrity: sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==}
+    hasBin: true
+
+  '@maplibre/maplibre-gl-style-spec@23.1.0':
+    resolution: {integrity: sha512-R6/ihEuC5KRexmKIYkWqUv84Gm+/QwsOUgHyt1yy2XqCdGdLvlBWVWIIeTZWN4NGdwmY6xDzdSGU2R9oBLNg2w==}
     hasBin: true
 
   '@mdx-js/react@3.1.0':
@@ -3492,8 +3490,11 @@ packages:
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
 
-  '@types/geojson@7946.0.14':
-    resolution: {integrity: sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==}
+  '@types/geojson-vt@3.2.5':
+    resolution: {integrity: sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/glob@7.2.0':
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
@@ -3536,9 +3537,6 @@ packages:
 
   '@types/junit-report-builder@3.0.2':
     resolution: {integrity: sha512-R5M+SYhMbwBeQcNXYWNCZkl09vkVfAtcPIaCGdzIkkbeaTrVbGQ7HVgi4s+EmM/M1K4ZuWQH0jGcvMvNePfxYA==}
-
-  '@types/mapbox-gl@3.4.0':
-    resolution: {integrity: sha512-tbn++Mm94H1kE7W6FF0oVC9rMXHVzDDNUbS7KfBMRF8NV/8csFi+67ytKcZJ4LsrpsJ+8MC6Os6ZinEDCsrunw==}
 
   '@types/mapbox__point-geometry@0.1.4':
     resolution: {integrity: sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==}
@@ -3611,6 +3609,9 @@ packages:
 
   '@types/styled-components@5.1.34':
     resolution: {integrity: sha512-mmiVvwpYklFIv9E8qfxuPyIt/OuyIrn6gMOAMOFUO3WJfSrSE+sGUoa4PiZj77Ut7bKZpaa6o1fBKS/4TOEvnA==}
+
+  '@types/supercluster@7.1.3':
+    resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
 
   '@types/throttle-debounce@2.1.0':
     resolution: {integrity: sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ==}
@@ -3702,6 +3703,26 @@ packages:
   '@typescript-eslint/visitor-keys@4.33.0':
     resolution: {integrity: sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
+
+  '@vis.gl/react-mapbox@8.0.4':
+    resolution: {integrity: sha512-NFk0vsWcNzSs0YCsVdt2100Zli9QWR+pje8DacpLkkGEAXFaJsFtI1oKD0Hatiate4/iAIW39SQHhgfhbeEPfQ==}
+    peerDependencies:
+      mapbox-gl: '>=3.5.0'
+      react: '>=16.3.0'
+      react-dom: '>=16.3.0'
+    peerDependenciesMeta:
+      mapbox-gl:
+        optional: true
+
+  '@vis.gl/react-maplibre@8.0.4':
+    resolution: {integrity: sha512-HwZyfLjEu+y1mUFvwDAkVxinGm8fEegaWN+O8np/WZ2Sqe5Lv6OXFpV6GWz9LOEvBYMbGuGk1FQdejo+4HCJ5w==}
+    peerDependencies:
+      maplibre-gl: '>=4.0.0'
+      react: '>=16.3.0'
+      react-dom: '>=16.3.0'
+    peerDependenciesMeta:
+      maplibre-gl:
+        optional: true
 
   '@visulima/fs@3.1.0':
     resolution: {integrity: sha512-KpM4yPvAtxmN/3XbdgWJwhOBvcRqJD+qGxzKpoSkZ6j/PM/0A2/yQVVLyOEGIMtstMca42io1DegISyq53Wn9w==}
@@ -5069,9 +5090,6 @@ packages:
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
-  csscolorparser@1.0.3:
-    resolution: {integrity: sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==}
-
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -5392,8 +5410,8 @@ packages:
   duplexify@3.7.1:
     resolution: {integrity: sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==}
 
-  earcut@2.2.4:
-    resolution: {integrity: sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==}
+  earcut@3.0.1:
+    resolution: {integrity: sha512-0l1/0gOjESMeQyYaK5IDiPNvFeu93Z/cO0TjZh9eZ1vyCtZnA7KMZ8rQggpsJHIbGSdrqYq9OhuveadOVHCshw==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -5438,9 +5456,6 @@ packages:
   emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
     engines: {node: '>= 4'}
-
-  empty-npm-package@1.0.0:
-    resolution: {integrity: sha512-q4Mq/+XO7UNDdMiPpR/LIBIW1Zl4V0Z6UT9aKGqIAnBCtCb3lvZJM1KbDbdzdC8fKflwflModfjR29Nt0EpcwA==}
 
   encoding@0.1.13:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
@@ -6185,8 +6200,8 @@ packages:
   geocoder-arcgis@2.0.5:
     resolution: {integrity: sha512-KebkgRbjJ5+682DVUswqRrNHGhcCz8CG3kqP21l6xeGWDbaoSkuFzgE+fMHrKs0Ij2NJHe2/R4Z779EaXdR/3w==}
 
-  geojson-vt@3.2.1:
-    resolution: {integrity: sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==}
+  geojson-vt@4.0.2:
+    resolution: {integrity: sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -6357,6 +6372,10 @@ packages:
   global-prefix@3.0.0:
     resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==}
     engines: {node: '>=6'}
+
+  global-prefix@4.0.0:
+    resolution: {integrity: sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==}
+    engines: {node: '>=16'}
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -7572,6 +7591,9 @@ packages:
   json-stringify-pretty-compact@3.0.0:
     resolution: {integrity: sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==}
 
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
@@ -7618,8 +7640,8 @@ packages:
   just-diff@6.0.2:
     resolution: {integrity: sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==}
 
-  kdbush@3.0.0:
-    resolution: {integrity: sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==}
+  kdbush@4.0.2:
+    resolution: {integrity: sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -7904,8 +7926,9 @@ packages:
     resolution: {integrity: sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==}
     engines: {node: '>=0.10.0'}
 
-  maplibre-gl@2.4.0:
-    resolution: {integrity: sha512-csNFylzntPmHWidczfgCZpvbTSmhaWvLRj9e1ezUDBEPizGgshgm3ea1T5TCNEEBq0roauu7BPuRZjA3wO4KqA==}
+  maplibre-gl@5.3.1:
+    resolution: {integrity: sha512-Ihx+oUUSsZkjMou1Cw5J6silE+5OtFFQSPslWF9+7v4yFC/XDHrpsORYO9lWE4KZI0djCEUpZQJpkpnMArAbeA==}
+    engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   markdown-escapes@1.0.4:
     resolution: {integrity: sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==}
@@ -9156,8 +9179,8 @@ packages:
     resolution: {integrity: sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  potpack@1.0.2:
-    resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
+  potpack@2.0.0:
+    resolution: {integrity: sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw==}
 
   prelude-ls@1.1.2:
     resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
@@ -9349,8 +9372,8 @@ packages:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
     engines: {node: '>=8'}
 
-  quickselect@2.0.0:
-    resolution: {integrity: sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==}
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
   raf-schd@4.0.3:
     resolution: {integrity: sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==}
@@ -9431,8 +9454,8 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-map-gl@7.1.7:
-    resolution: {integrity: sha512-mwjc0obkBJOXCcoXQr3VoLqmqwo9vS4bXfbGsdxXzEgVCv/PM0v+1QggL7W0d/ccIy+VCjbXNlGij+PENz6VNg==}
+  react-map-gl@8.0.4:
+    resolution: {integrity: sha512-SHdpvFIvswsZBg6BCPcwY/nbKuCo3sJM1Cj7Sd+gA3gFRFOixD+KtZ2XSuUWq2WySL2emYEXEgrLZoXsV4Ut4Q==}
     peerDependencies:
       mapbox-gl: '>=1.13.0'
       maplibre-gl: '>=1.13.0'
@@ -10388,8 +10411,8 @@ packages:
     resolution: {integrity: sha512-CY8u7DtbvucKuquCmOFEKhr9Besln7n9uN8eFbwcoGYWXOMW07u2o8njWaiXt11ylS3qoGF55pILjRmPlbodyg==}
     engines: {node: '>=18'}
 
-  supercluster@7.1.5:
-    resolution: {integrity: sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==}
+  supercluster@8.0.1:
+    resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
 
   supports-color@2.0.0:
     resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
@@ -10570,8 +10593,8 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyqueue@2.0.3:
-    resolution: {integrity: sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==}
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
   tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
@@ -13279,8 +13302,6 @@ snapshots:
 
   '@mapbox/jsonlint-lines-primitives@2.0.2': {}
 
-  '@mapbox/mapbox-gl-supported@2.0.1': {}
-
   '@mapbox/point-geometry@0.1.0': {}
 
   '@mapbox/polyline@1.2.1':
@@ -13305,6 +13326,16 @@ snapshots:
       minimist: 1.2.8
       rw: 1.3.3
       sort-object: 3.0.3
+
+  '@maplibre/maplibre-gl-style-spec@23.1.0':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/unitbezier': 0.0.1
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      rw: 1.3.3
+      tinyqueue: 3.0.0
 
   '@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0)':
     dependencies:
@@ -14791,7 +14822,11 @@ snapshots:
     dependencies:
       '@types/node': 15.14.9
 
-  '@types/geojson@7946.0.14': {}
+  '@types/geojson-vt@3.2.5':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/glob@7.2.0':
     dependencies:
@@ -14839,15 +14874,11 @@ snapshots:
 
   '@types/junit-report-builder@3.0.2': {}
 
-  '@types/mapbox-gl@3.4.0':
-    dependencies:
-      '@types/geojson': 7946.0.14
-
   '@types/mapbox__point-geometry@0.1.4': {}
 
   '@types/mapbox__vector-tile@1.3.4':
     dependencies:
-      '@types/geojson': 7946.0.14
+      '@types/geojson': 7946.0.16
       '@types/mapbox__point-geometry': 0.1.4
       '@types/pbf': 3.0.5
 
@@ -14908,6 +14939,10 @@ snapshots:
       '@types/hoist-non-react-statics': 3.3.5
       '@types/react': 18.3.12
       csstype: 3.1.3
+
+  '@types/supercluster@7.1.3':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/throttle-debounce@2.1.0': {}
 
@@ -15023,6 +15058,19 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 4.33.0
       eslint-visitor-keys: 2.1.0
+
+  '@vis.gl/react-mapbox@8.0.4(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.3.1(react@18.2.0)
+
+  '@vis.gl/react-maplibre@8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@maplibre/maplibre-gl-style-spec': 19.3.3
+      react: 18.2.0
+      react-dom: 18.3.1(react@18.2.0)
+    optionalDependencies:
+      maplibre-gl: 5.3.1
 
   '@visulima/fs@3.1.0':
     dependencies:
@@ -16673,8 +16721,6 @@ snapshots:
 
   css.escape@1.5.1: {}
 
-  csscolorparser@1.0.3: {}
-
   cssesc@3.0.0: {}
 
   cssom@0.3.8: {}
@@ -16973,7 +17019,7 @@ snapshots:
       readable-stream: 2.3.8
       stream-shift: 1.0.3
 
-  earcut@2.2.4: {}
+  earcut@3.0.1: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -17013,8 +17059,6 @@ snapshots:
   emojilib@2.4.0: {}
 
   emojis-list@3.0.0: {}
-
-  empty-npm-package@1.0.0: {}
 
   encoding@0.1.13:
     dependencies:
@@ -17997,7 +18041,7 @@ snapshots:
       lodash.isobject: 3.0.2
       lodash.isstring: 4.0.1
 
-  geojson-vt@3.2.1: {}
+  geojson-vt@4.0.2: {}
 
   get-caller-file@2.0.5: {}
 
@@ -18202,6 +18246,12 @@ snapshots:
       ini: 1.3.8
       kind-of: 6.0.3
       which: 1.3.1
+
+  global-prefix@4.0.0:
+    dependencies:
+      ini: 4.1.3
+      kind-of: 6.0.3
+      which: 4.0.0
 
   globals@11.12.0: {}
 
@@ -19868,6 +19918,8 @@ snapshots:
 
   json-stringify-pretty-compact@3.0.0: {}
 
+  json-stringify-pretty-compact@4.0.0: {}
+
   json-stringify-safe@5.0.1: {}
 
   json5@1.0.2:
@@ -19912,7 +19964,7 @@ snapshots:
 
   just-diff@6.0.2: {}
 
-  kdbush@3.0.0: {}
+  kdbush@4.0.2: {}
 
   keyv@4.5.4:
     dependencies:
@@ -20328,31 +20380,33 @@ snapshots:
     dependencies:
       object-visit: 1.0.1
 
-  maplibre-gl@2.4.0:
+  maplibre-gl@5.3.1:
     dependencies:
       '@mapbox/geojson-rewind': 0.5.2
       '@mapbox/jsonlint-lines-primitives': 2.0.2
-      '@mapbox/mapbox-gl-supported': 2.0.1
       '@mapbox/point-geometry': 0.1.0
       '@mapbox/tiny-sdf': 2.0.6
       '@mapbox/unitbezier': 0.0.1
       '@mapbox/vector-tile': 1.3.1
       '@mapbox/whoots-js': 3.1.0
-      '@types/geojson': 7946.0.14
+      '@maplibre/maplibre-gl-style-spec': 23.1.0
+      '@types/geojson': 7946.0.16
+      '@types/geojson-vt': 3.2.5
       '@types/mapbox__point-geometry': 0.1.4
       '@types/mapbox__vector-tile': 1.3.4
       '@types/pbf': 3.0.5
-      csscolorparser: 1.0.3
-      earcut: 2.2.4
-      geojson-vt: 3.2.1
+      '@types/supercluster': 7.1.3
+      earcut: 3.0.1
+      geojson-vt: 4.0.2
       gl-matrix: 3.4.3
-      global-prefix: 3.0.0
+      global-prefix: 4.0.0
+      kdbush: 4.0.2
       murmurhash-js: 1.0.0
       pbf: 3.3.0
-      potpack: 1.0.2
-      quickselect: 2.0.0
-      supercluster: 7.1.5
-      tinyqueue: 2.0.3
+      potpack: 2.0.0
+      quickselect: 3.0.0
+      supercluster: 8.0.1
+      tinyqueue: 3.0.0
       vt-pbf: 3.1.3
 
   markdown-escapes@1.0.4: {}
@@ -21617,7 +21671,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  potpack@1.0.2: {}
+  potpack@2.0.0: {}
 
   prelude-ls@1.1.2: {}
 
@@ -21802,7 +21856,7 @@ snapshots:
 
   quick-lru@4.0.1: {}
 
-  quickselect@2.0.0: {}
+  quickselect@3.0.0: {}
 
   raf-schd@4.0.3: {}
 
@@ -21899,15 +21953,14 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-map-gl@7.1.7(empty-npm-package@1.0.0)(maplibre-gl@2.4.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0):
+  react-map-gl@8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@maplibre/maplibre-gl-style-spec': 19.3.3
-      '@types/mapbox-gl': 3.4.0
+      '@vis.gl/react-mapbox': 8.0.4(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@vis.gl/react-maplibre': 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
     optionalDependencies:
-      mapbox-gl: empty-npm-package@1.0.0
-      maplibre-gl: 2.4.0
+      maplibre-gl: 5.3.1
 
   react-resize-detector@4.2.3(react-dom@18.3.1(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -23136,9 +23189,9 @@ snapshots:
       function-timeout: 1.0.2
       time-span: 5.1.0
 
-  supercluster@7.1.5:
+  supercluster@8.0.1:
     dependencies:
-      kdbush: 3.0.0
+      kdbush: 4.0.2
 
   supports-color@2.0.0: {}
 
@@ -23332,7 +23385,7 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyqueue@2.0.3: {}
+  tinyqueue@3.0.0: {}
 
   tinyrainbow@1.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,7 +299,7 @@ importers:
         version: 1.0.2(semantic-release@24.2.3(typescript@4.9.5))
       semver:
         specifier: ^7.3.2
-        version: 7.6.3
+        version: 7.7.1
       storybook:
         specifier: ^8.6.4
         version: 8.6.4(prettier@1.19.1)
@@ -352,14 +352,14 @@ importers:
         specifier: workspace:*
         version: link:../types
       maplibre-gl:
-        specifier: ^5.3.1
-        version: 5.3.1
+        specifier: ^5.5.0
+        version: 5.5.0
       react:
         specifier: 'catalog:'
         version: 18.2.0
       react-map-gl:
         specifier: 'catalog:'
-        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.5.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       styled-components:
         specifier: 'catalog:'
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
@@ -423,7 +423,7 @@ importers:
         version: 4.5.0
       qs:
         specifier: ^6.9.1
-        version: 6.13.0
+        version: 6.14.0
     devDependencies:
       '@opentripplanner/types':
         specifier: workspace:*
@@ -460,7 +460,7 @@ importers:
         version: 6.8.4(react@18.2.0)(typescript@4.9.5)
       react-map-gl:
         specifier: 'catalog:'
-        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.5.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       styled-components:
         specifier: 'catalog:'
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
@@ -678,7 +678,7 @@ importers:
         version: 18.2.0
       react-map-gl:
         specifier: 'catalog:'
-        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.5.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@opentripplanner/base-map':
         specifier: workspace:*
@@ -706,7 +706,7 @@ importers:
         version: 18.3.1(react@18.2.0)
       react-map-gl:
         specifier: 'catalog:'
-        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.5.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       styled-components:
         specifier: 'catalog:'
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
@@ -783,7 +783,7 @@ importers:
         version: 18.2.0
       react-map-gl:
         specifier: 'catalog:'
-        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.5.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@opentripplanner/types':
         specifier: workspace:*
@@ -811,7 +811,7 @@ importers:
         version: 6.8.4(react@18.2.0)(typescript@4.9.5)
       react-map-gl:
         specifier: 'catalog:'
-        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.5.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       styled-components:
         specifier: 'catalog:'
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
@@ -845,7 +845,7 @@ importers:
         version: 6.8.4(react@18.2.0)(typescript@4.9.5)
       react-map-gl:
         specifier: 'catalog:'
-        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.5.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       styled-components:
         specifier: 'catalog:'
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
@@ -894,7 +894,7 @@ importers:
         version: 18.2.0
       react-map-gl:
         specifier: 'catalog:'
-        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.5.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@opentripplanner/endpoints-overlay':
         specifier: workspace:*
@@ -1008,7 +1008,7 @@ importers:
         version: 18.2.0
       react-map-gl:
         specifier: 'catalog:'
-        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.5.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
 
   packages/types: {}
 
@@ -1046,7 +1046,7 @@ importers:
         version: 6.8.4(react@18.2.0)(typescript@4.9.5)
       react-map-gl:
         specifier: 'catalog:'
-        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.5.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       styled-components:
         specifier: 'catalog:'
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
@@ -1071,7 +1071,7 @@ importers:
         version: 18.2.0
       react-map-gl:
         specifier: 'catalog:'
-        version: 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.0.4(maplibre-gl@5.5.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       styled-components:
         specifier: 'catalog:'
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
@@ -2395,8 +2395,8 @@ packages:
     resolution: {integrity: sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==}
     hasBin: true
 
-  '@maplibre/maplibre-gl-style-spec@23.1.0':
-    resolution: {integrity: sha512-R6/ihEuC5KRexmKIYkWqUv84Gm+/QwsOUgHyt1yy2XqCdGdLvlBWVWIIeTZWN4NGdwmY6xDzdSGU2R9oBLNg2w==}
+  '@maplibre/maplibre-gl-style-spec@23.3.0':
+    resolution: {integrity: sha512-IGJtuBbaGzOUgODdBRg66p8stnwj9iDXkgbYKoYcNiiQmaez5WVRfXm4b03MCDwmZyX93csbfHFWEJJYHnn5oA==}
     hasBin: true
 
   '@mdx-js/react@3.1.0':
@@ -7926,8 +7926,8 @@ packages:
     resolution: {integrity: sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==}
     engines: {node: '>=0.10.0'}
 
-  maplibre-gl@5.3.1:
-    resolution: {integrity: sha512-Ihx+oUUSsZkjMou1Cw5J6silE+5OtFFQSPslWF9+7v4yFC/XDHrpsORYO9lWE4KZI0djCEUpZQJpkpnMArAbeA==}
+  maplibre-gl@5.5.0:
+    resolution: {integrity: sha512-p8AOPuzzqn1ZA9gcXxKw0IED715we/2Owa/YUr6PANmgMvNMe/JG+V/C1hRra43Wm62Biz+Aa8AgbOLJimA8tA==}
     engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   markdown-escapes@1.0.4:
@@ -8590,10 +8590,6 @@ packages:
   object-copy@0.1.0:
     resolution: {integrity: sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==}
     engines: {node: '>=0.10.0'}
-
-  object-inspect@1.13.2:
-    resolution: {integrity: sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==}
-    engines: {node: '>= 0.4'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -9342,10 +9338,6 @@ packages:
     resolution: {integrity: sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==}
     engines: {node: '>=6.0.0'}
 
-  qs@6.13.0:
-    resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
-    engines: {node: '>=0.6'}
-
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
@@ -9876,11 +9868,6 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.6.3:
-    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.7.1:
     resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
     engines: {node: '>=10'}
@@ -9958,10 +9945,6 @@ packages:
 
   side-channel-weakmap@1.0.2:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
-    engines: {node: '>= 0.4'}
-
-  side-channel@1.0.6:
-    resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
     engines: {node: '>= 0.4'}
 
   side-channel@1.1.0:
@@ -13327,7 +13310,7 @@ snapshots:
       rw: 1.3.3
       sort-object: 3.0.3
 
-  '@maplibre/maplibre-gl-style-spec@23.1.0':
+  '@maplibre/maplibre-gl-style-spec@23.3.0':
     dependencies:
       '@mapbox/jsonlint-lines-primitives': 2.0.2
       '@mapbox/unitbezier': 0.0.1
@@ -15001,7 +14984,7 @@ snapshots:
       functional-red-black-tree: 1.0.1
       ignore: 5.3.2
       regexpp: 3.2.0
-      semver: 7.6.3
+      semver: 7.7.1
       tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
       typescript: 4.9.5
@@ -15064,13 +15047,13 @@ snapshots:
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
 
-  '@vis.gl/react-maplibre@8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@vis.gl/react-maplibre@8.0.4(maplibre-gl@5.5.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@maplibre/maplibre-gl-style-spec': 19.3.3
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
     optionalDependencies:
-      maplibre-gl: 5.3.1
+      maplibre-gl: 5.5.0
 
   '@visulima/fs@3.1.0':
     dependencies:
@@ -15603,7 +15586,7 @@ snapshots:
       es-abstract: 1.23.3
       es-array-method-boxes-properly: 1.0.0
       es-errors: 1.3.0
-      es-object-atoms: 1.0.0
+      es-object-atoms: 1.1.1
       is-string: 1.0.7
 
   arraybuffer.prototype.slice@1.0.3:
@@ -15613,7 +15596,7 @@ snapshots:
       define-properties: 1.2.1
       es-abstract: 1.23.3
       es-errors: 1.3.0
-      get-intrinsic: 1.2.4
+      get-intrinsic: 1.3.0
       is-array-buffer: 3.0.4
       is-shared-array-buffer: 1.0.3
 
@@ -17160,7 +17143,7 @@ snapshots:
       is-string: 1.0.7
       is-typed-array: 1.1.13
       is-weakref: 1.0.2
-      object-inspect: 1.13.2
+      object-inspect: 1.13.4
       object-keys: 1.1.1
       object.assign: 4.1.5
       regexp.prototype.flags: 1.5.3
@@ -17198,7 +17181,7 @@ snapshots:
 
   es-set-tostringtag@2.0.3:
     dependencies:
-      get-intrinsic: 1.2.4
+      get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
@@ -17470,7 +17453,7 @@ snapshots:
       optionator: 0.9.4
       progress: 2.0.3
       regexpp: 3.2.0
-      semver: 7.6.3
+      semver: 7.7.1
       strip-ansi: 6.0.1
       strip-json-comments: 3.1.1
       table: 6.8.2
@@ -18113,7 +18096,7 @@ snapshots:
     dependencies:
       call-bind: 1.0.7
       es-errors: 1.3.0
-      get-intrinsic: 1.2.4
+      get-intrinsic: 1.3.0
 
   get-value@2.0.6: {}
 
@@ -18311,7 +18294,7 @@ snapshots:
 
   gopd@1.0.1:
     dependencies:
-      get-intrinsic: 1.2.4
+      get-intrinsic: 1.3.0
 
   gopd@1.2.0: {}
 
@@ -18704,7 +18687,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       hasown: 2.0.2
-      side-channel: 1.0.6
+      side-channel: 1.1.0
 
   interpret@1.4.0: {}
 
@@ -18750,7 +18733,7 @@ snapshots:
   is-array-buffer@3.0.4:
     dependencies:
       call-bind: 1.0.7
-      get-intrinsic: 1.2.4
+      get-intrinsic: 1.3.0
 
   is-arrayish@0.2.1: {}
 
@@ -18935,7 +18918,7 @@ snapshots:
 
   is-symbol@1.0.4:
     dependencies:
-      has-symbols: 1.0.3
+      has-symbols: 1.1.0
 
   is-text-path@1.0.1:
     dependencies:
@@ -18994,7 +18977,7 @@ snapshots:
     dependencies:
       '@conveyal/lonlat': 1.4.1
       isomorphic-fetch: 3.0.0(encoding@0.1.13)
-      qs: 6.13.0
+      qs: 6.14.0
     transitivePeerDependencies:
       - encoding
 
@@ -20049,7 +20032,7 @@ snapshots:
       read-cmd-shim: 4.0.0
       resolve-from: 5.0.0
       rimraf: 4.4.1
-      semver: 7.6.3
+      semver: 7.7.1
       set-blocking: 2.0.0
       signal-exit: 3.0.7
       slash: 3.0.0
@@ -20380,7 +20363,7 @@ snapshots:
     dependencies:
       object-visit: 1.0.1
 
-  maplibre-gl@5.3.1:
+  maplibre-gl@5.5.0:
     dependencies:
       '@mapbox/geojson-rewind': 0.5.2
       '@mapbox/jsonlint-lines-primitives': 2.0.2
@@ -20389,7 +20372,7 @@ snapshots:
       '@mapbox/unitbezier': 0.0.1
       '@mapbox/vector-tile': 1.3.1
       '@mapbox/whoots-js': 3.1.0
-      '@maplibre/maplibre-gl-style-spec': 23.1.0
+      '@maplibre/maplibre-gl-style-spec': 23.3.0
       '@types/geojson': 7946.0.16
       '@types/geojson-vt': 3.2.5
       '@types/mapbox__point-geometry': 0.1.4
@@ -21084,8 +21067,6 @@ snapshots:
       copy-descriptor: 0.1.1
       define-property: 0.2.5
       kind-of: 3.2.2
-
-  object-inspect@1.13.2: {}
 
   object-inspect@1.13.4: {}
 
@@ -21836,10 +21817,6 @@ snapshots:
 
   pvutils@1.1.3: {}
 
-  qs@6.13.0:
-    dependencies:
-      side-channel: 1.0.6
-
   qs@6.14.0:
     dependencies:
       side-channel: 1.1.0
@@ -21953,14 +21930,14 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-map-gl@8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0):
+  react-map-gl@8.0.4(maplibre-gl@5.5.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0):
     dependencies:
       '@vis.gl/react-mapbox': 8.0.4(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@vis.gl/react-maplibre': 8.0.4(maplibre-gl@5.3.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@vis.gl/react-maplibre': 8.0.4(maplibre-gl@5.5.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
     optionalDependencies:
-      maplibre-gl: 5.3.1
+      maplibre-gl: 5.5.0
 
   react-resize-detector@4.2.3(react-dom@18.3.1(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -22349,7 +22326,7 @@ snapshots:
   safe-array-concat@1.1.2:
     dependencies:
       call-bind: 1.0.7
-      get-intrinsic: 1.2.4
+      get-intrinsic: 1.3.0
       has-symbols: 1.0.3
       isarray: 2.0.5
 
@@ -22455,7 +22432,7 @@ snapshots:
       read-pkg: 5.2.0
       registry-auth-token: 4.2.2
       semantic-release: 24.2.3(typescript@4.9.5)
-      semver: 7.6.3
+      semver: 7.7.1
       tempy: 1.0.1
 
   semantic-release@24.2.3(typescript@4.9.5):
@@ -22497,15 +22474,13 @@ snapshots:
 
   semver-diff@4.0.0:
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.1
 
   semver-regex@4.0.5: {}
 
   semver@5.7.2: {}
 
   semver@6.3.1: {}
-
-  semver@7.6.3: {}
 
   semver@7.7.1: {}
 
@@ -22596,13 +22571,6 @@ snapshots:
       get-intrinsic: 1.3.0
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
-
-  side-channel@1.0.6:
-    dependencies:
-      call-bind: 1.0.7
-      es-errors: 1.3.0
-      get-intrinsic: 1.2.4
-      object-inspect: 1.13.2
 
   side-channel@1.1.0:
     dependencies:
@@ -23731,7 +23699,7 @@ snapshots:
   url@0.11.4:
     dependencies:
       punycode: 1.4.1
-      qs: 6.13.0
+      qs: 6.14.0
 
   urlpattern-polyfill@8.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,7 @@ catalog:
   react-animate-height: ^3.0.4
   react-dom: ^18.2.0
   react-intl: ^6.8.4
-  react-map-gl: ^7.0.15
+  react-map-gl: ^8.0.4
   styled-components: ^5.3.0
   styled-icons: ^10.34.0
 packages:


### PR DESCRIPTION
This PR upgrades maplibre and react-map-gl to very recent versions. The breaking change is that map dependencies to react-map-gl is now a peer dependency that implementers must reference themselves.

Behind the scenes, the map becomes uncontrolled, we got rid of the internal and redundant position state.