### PR TITLE
Alert AT that subsettings are expanded in transit options

### DIFF
--- a/packages/trip-form/i18n/en-US.yml
+++ b/packages/trip-form/i18n/en-US.yml
@@ -11,6 +11,8 @@ otpUi:
       bicycle: Bike
       car: Drive
       rent: Rent
+      subsettingsCollapsed: " (Subsettings collapsed)"
+      subsettingsExpanded: " (Subsettings expanded)"
       transit: Transit
       walk: Walk
     settings:

--- a/packages/trip-form/i18n/fr.yml
+++ b/packages/trip-form/i18n/fr.yml
@@ -11,6 +11,8 @@ otpUi:
       bicycle: Vélo
       car: Voiture
       rent: Location
+      subsettingsCollapsed: " (Sous-paramètres réduits)"
+      subsettingsExpanded: " (Sous-paramètres étendus)"
       transit: Transports
       walk: Marche
     settings:

--- a/packages/trip-form/src/MetroModeSelector/AdvancedModeSettingsButton/index.tsx
+++ b/packages/trip-form/src/MetroModeSelector/AdvancedModeSettingsButton/index.tsx
@@ -110,18 +110,28 @@ const AdvancedModeSettingsButton = ({
   const checkboxId = `metro-submode-selector-mode-${id}`;
   const containsSubsettings = modeButton.modeSettings.length > 0;
 
+  const subsettingsStatusLabel = modeButton.enabled
+    ? intl.formatMessage({
+        id: "otpUi.ModeSelector.labels.subsettingsExpanded"
+      })
+    : intl.formatMessage({
+        id: "otpUi.ModeSelector.labels.subsettingsCollapsed"
+      });
+  const ariaLabel = containsSubsettings
+    ? label + subsettingsStatusLabel
+    : label;
+
   return (
     <SettingsContainer className="advanced-submode-container">
       <StyledModeSettingsButton
         accentColor={accentColor}
-        aria-expanded={containsSubsettings ? !!modeButton.enabled : undefined}
         className="advanced-submode-mode-button"
         fillModeIcons={fillModeIcons}
         id={modeButton.key}
         subsettings={containsSubsettings}
       >
         <input
-          aria-label={label}
+          aria-label={ariaLabel}
           checked={modeButton.enabled ?? undefined}
           id={checkboxId}
           onChange={onToggle}

--- a/packages/trip-form/src/MetroModeSelector/AdvancedModeSettingsButton/index.tsx
+++ b/packages/trip-form/src/MetroModeSelector/AdvancedModeSettingsButton/index.tsx
@@ -117,6 +117,8 @@ const AdvancedModeSettingsButton = ({
     : intl.formatMessage({
         id: "otpUi.ModeSelector.labels.subsettingsCollapsed"
       });
+
+  // Adding <InvisibleAllyLabel> to the label results in AT announcing "Transit (and 1 other item)", so we must present this information in the aria-label
   const ariaLabel = containsSubsettings
     ? label + subsettingsStatusLabel
     : label;

--- a/packages/trip-form/src/MetroModeSelector/AdvancedModeSettingsButton/index.tsx
+++ b/packages/trip-form/src/MetroModeSelector/AdvancedModeSettingsButton/index.tsx
@@ -108,14 +108,17 @@ const AdvancedModeSettingsButton = ({
   const intl = useIntl();
   const label = generateModeButtonLabel(modeButton.key, intl, modeButton.label);
   const checkboxId = `metro-submode-selector-mode-${id}`;
+  const containsSubsettings = modeButton.modeSettings.length > 0;
+
   return (
     <SettingsContainer className="advanced-submode-container">
       <StyledModeSettingsButton
         accentColor={accentColor}
+        aria-expanded={containsSubsettings ? !!modeButton.enabled : undefined}
         className="advanced-submode-mode-button"
         fillModeIcons={fillModeIcons}
         id={modeButton.key}
-        subsettings={modeButton.modeSettings.length > 0}
+        subsettings={containsSubsettings}
       >
         <input
           aria-label={label}
@@ -130,7 +133,7 @@ const AdvancedModeSettingsButton = ({
           {modeButton.enabled && <Check2 />}
         </label>
       </StyledModeSettingsButton>
-      {modeButton.modeSettings.length > 0 && (
+      {containsSubsettings && (
         <AnimateHeight duration={300} height={modeButton.enabled ? "auto" : 0}>
           <StyledSettingsContainer className="subsettings-container">
             <SubSettingsPane

--- a/packages/trip-form/src/MetroModeSelector/AdvancedModeSettingsButton/index.tsx
+++ b/packages/trip-form/src/MetroModeSelector/AdvancedModeSettingsButton/index.tsx
@@ -131,7 +131,6 @@ const AdvancedModeSettingsButton = ({
         subsettings={containsSubsettings}
       >
         <input
-          aria-owns="subsettings-container"
           aria-label={ariaLabel}
           checked={modeButton.enabled ?? undefined}
           id={checkboxId}
@@ -145,11 +144,7 @@ const AdvancedModeSettingsButton = ({
         </label>
       </StyledModeSettingsButton>
       {containsSubsettings && (
-        <AnimateHeight
-          id="subsettings-container"
-          duration={300}
-          height={modeButton.enabled ? "auto" : 0}
-        >
+        <AnimateHeight duration={300} height={modeButton.enabled ? "auto" : 0}>
           <StyledSettingsContainer className="subsettings-container">
             <SubSettingsPane
               onSettingUpdate={onSettingsUpdate}

--- a/packages/trip-form/src/MetroModeSelector/AdvancedModeSettingsButton/index.tsx
+++ b/packages/trip-form/src/MetroModeSelector/AdvancedModeSettingsButton/index.tsx
@@ -131,6 +131,7 @@ const AdvancedModeSettingsButton = ({
         subsettings={containsSubsettings}
       >
         <input
+          aria-owns="subsettings-container"
           aria-label={ariaLabel}
           checked={modeButton.enabled ?? undefined}
           id={checkboxId}
@@ -144,7 +145,11 @@ const AdvancedModeSettingsButton = ({
         </label>
       </StyledModeSettingsButton>
       {containsSubsettings && (
-        <AnimateHeight duration={300} height={modeButton.enabled ? "auto" : 0}>
+        <AnimateHeight
+          id="subsettings-container"
+          duration={300}
+          height={modeButton.enabled ? "auto" : 0}
+        >
           <StyledSettingsContainer className="subsettings-container">
             <SubSettingsPane
               onSettingUpdate={onSettingsUpdate}

--- a/packages/trip-form/src/MetroModeSelector/__snapshots__/AdvancedModeSettingsButton.story.tsx.snap
+++ b/packages/trip-form/src/MetroModeSelector/__snapshots__/AdvancedModeSettingsButton.story.tsx.snap
@@ -10,7 +10,7 @@ exports[`Trip Form Components/Advanced Mode Settings Buttons AdvancedModeSetting
       <div class="AdvancedModeSettingsButton__StyledModeSettingsButton-sc-1wd5ill-1 gkZqBg advanced-submode-mode-button"
            id="transit"
       >
-        <input aria-label="Transit"
+        <input aria-label="Transit (Subsettings expanded)"
                id="metro-submode-selector-mode-transit"
                type="checkbox"
                checked


### PR DESCRIPTION
Checkboxes do not support `aria-expanded` so add an additional string to the `aria-label` to include whether an option has expanded suboptions
<img width="654" alt="image" src="https://github.com/user-attachments/assets/62cc6d20-d3d5-49d5-b1e4-489c7c7d1865" />
