### PR TITLE
Transitive Overlay Remove Un-needed refresh

### DIFF
--- a/packages/transitive-overlay/src/index.tsx
+++ b/packages/transitive-overlay/src/index.tsx
@@ -257,7 +257,7 @@ const TransitiveCanvasOverlay = ({
 
   useEffect(() => {
     loadImages(map, mapImages);
-  }, [map, mapImages]);
+  }, []);
 
   const geojson: GeoJSON.FeatureCollection<
     GeoJSON.Geometry,


### PR DESCRIPTION
the `useEffect` was a bit too liberal, and this was causing many unnecessary requests