### PR TITLE
feat: add support for rendering agency name with the stop name in map popup

### DIFF
--- a/packages/map-popup/src/MapPopup.story.tsx
+++ b/packages/map-popup/src/MapPopup.story.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { Station, Stop } from "@opentripplanner/types";
 import { IntlProvider } from "react-intl";
 import { Meta } from "@storybook/react";
-import MapPopupContents from "./index";
+import MapPopupContents, { Feed } from "./index";
 
 // HOC to wrap components with IntlProvider
 const withIntl = (Story: () => JSX.Element) => (
@@ -36,6 +36,37 @@ const STOP_WITH_CODE = {
   lon: -122.672529,
   name: "W Burnside & SW 2nd"
 };
+
+const STOP_WITH_FEED_ID = {
+  flex: false,
+  code: "9526",
+  gtfsId: "trimet:9526",
+  id: "trimet:9526",
+  lat: 45.523009,
+  lon: -122.672529,
+  name: "W Burnside & SW 2nd"
+};
+
+const SAMPLE_FEEDS: Feed[] = [
+  {
+    feedId: "trimet",
+    publisher: {
+      name: "TriMet"
+    }
+  },
+  {
+    feedId: "c-tran",
+    publisher: {
+      name: "C-TRAN"
+    }
+  },
+  {
+    feedId: "portland-streetcar",
+    publisher: {
+      name: "Portland Streetcar"
+    }
+  }
+];
 
 const STATION = {
   "stroke-width": 2,
@@ -102,6 +133,16 @@ const getEntityPrefixExample = (entity: Stop | Station) => {
 export const StopEntity = (): JSX.Element => (
   <MapPopupContents
     entity={STOP_WITH_CODE}
+    feeds={SAMPLE_FEEDS}
+    setLocation={action("setLocation")}
+    setViewedStop={action("setViewedStop")}
+  />
+);
+
+export const StopEntityWithFeedName = (): JSX.Element => (
+  <MapPopupContents
+    entity={STOP_WITH_FEED_ID}
+    feeds={SAMPLE_FEEDS}
     setLocation={action("setLocation")}
     setViewedStop={action("setViewedStop")}
   />

--- a/packages/map-popup/src/__snapshots__/MapPopup.story.tsx.snap
+++ b/packages/map-popup/src/__snapshots__/MapPopup.story.tsx.snap
@@ -385,3 +385,68 @@ exports[`Map Popup StopEntityWithEntityPrefix smoke-test 1`] = `
   </div>
 </div>
 `;
+
+exports[`Map Popup StopEntityWithFeedName smoke-test 1`] = `
+<div class="styled__MapOverlayPopup-sc-12kjso7-1 cPqJxe">
+  <div id="focus-trimet3A9526-popup-focus-trap"
+       role="presentation"
+  >
+    <header class="styled__PopupTitle-sc-12kjso7-3 jRNaQh">
+      W Burnside &amp; SW 2nd (TriMet 9526)
+    </header>
+    <p class="styled__PopupRow-sc-12kjso7-2 ckOOWr">
+      <strong>
+        Stop ID: 9526
+      </strong>
+      <button class="styled__ViewStopButton-sc-12v7ov3-0 hXaHvR">
+        Stop Viewer
+      </button>
+    </p>
+    <p class="styled__PopupRow-sc-12kjso7-2 ckOOWr">
+      <strong>
+        Plan a trip:
+      </strong>
+      <span class="styled__FromToPickerSpan-sc-vb4790-1 giBPod">
+        <span class="styled__LocationPickerSpan-sc-vb4790-0 gsVfXo">
+          <svg viewbox="0 0 512 512"
+               height="0.9em"
+               width="0.9em"
+               aria-hidden="true"
+               focusable="false"
+               fill="currentColor"
+               xmlns="http://www.w3.org/2000/svg"
+               class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__FromIcon-sc-n5xcvc-0 dDqEuj"
+          >
+            <path fill="currentColor"
+                  d="M160 256c0-53.9 42.1-96 96-96 53 0 96 42.1 96 96 0 53-43 96-96 96-53.9 0-96-43-96-96zm352 0c0 141.4-114.6 256-256 256S0 397.4 0 256 114.6 0 256 0s256 114.6 256 256zM256 48C141.1 48 48 141.1 48 256s93.1 208 208 208 208-93.1 208-208S370.9 48 256 48z"
+            >
+            </path>
+          </svg>
+          <button class="styled__Button-sc-vb4790-2 ekklXB">
+            From here
+          </button>
+        </span>
+        <span class="styled__LocationPickerSpan-sc-vb4790-0 gsVfXo">
+          <svg viewbox="0 0 384 512"
+               height="0.9em"
+               width="0.9em"
+               aria-hidden="true"
+               focusable="false"
+               fill="currentColor"
+               xmlns="http://www.w3.org/2000/svg"
+               class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__ToIcon-sc-n5xcvc-2 gZxRwk"
+          >
+            <path fill="currentColor"
+                  d="M215.7 499.2C267 435 384 279.4 384 192 384 86 298 0 192 0S0 86 0 192c0 87.4 117 243 168.3 307.2 12.3 15.3 35.1 15.3 47.4 0zM192 256c-35.3 0-64-28.7-64-64s28.7-64 64-64 64 28.7 64 64-28.7 64-64 64z"
+            >
+            </path>
+          </svg>
+          <button class="styled__Button-sc-vb4790-2 ekklXB">
+            To here
+          </button>
+        </span>
+      </span>
+    </p>
+  </div>
+</div>
+`;

--- a/packages/map-popup/src/index.tsx
+++ b/packages/map-popup/src/index.tsx
@@ -14,7 +14,7 @@ import { ViewStopButton } from "./styled";
 
 // Load the default messages.
 import defaultEnglishMessages from "../i18n/en-US.yml";
-import { makeDefaultGetEntityName } from "./util";
+import { makeDefaultGetEntityName, type StopIdAgencyMap } from "./util";
 
 // HACK: We should flatten the messages loaded above because
 // the YAML loaders behave differently between webpack and our version of jest:
@@ -90,8 +90,9 @@ type Props = {
   closePopup?: (arg?: any) => void
   configCompanies?: ConfiguredCompany[];
   entity: Entity
-  getEntityName?: (entity: Entity, configCompanies: Company[],) => string;
+  getEntityName?: (entity: Entity, configCompanies: Company[], stopIdAgencyMap?: StopIdAgencyMap) => string;
   getEntityPrefix?: (entity: Entity) => JSX.Element
+  stopIdAgencyMap?: StopIdAgencyMap
   setLocation?: ({ location, locationType }: { location: Location, locationType: string }) => void;
   setViewedStop?: StopEventHandler;
 };
@@ -103,13 +104,22 @@ function entityIsStation(entity: Entity): entity is Station {
 /**
  * Renders a map popup for a stop, scooter, or shared bike
  */
-export function MapPopup({ closePopup = () => {}, configCompanies, entity, getEntityName, getEntityPrefix, setLocation, setViewedStop }: Props): JSX.Element {
+export function MapPopup({ 
+  closePopup = () => {}, 
+  configCompanies, 
+  entity, 
+  getEntityName, 
+  getEntityPrefix, 
+  setLocation, 
+  setViewedStop, 
+  stopIdAgencyMap 
+}: Props): JSX.Element {
 
   const intl = useIntl()
   if (!entity) return <></>
 
   const getNameFunc = getEntityName || makeDefaultGetEntityName(intl, defaultMessages);
-  const name = getNameFunc(entity, configCompanies);
+  const name = getNameFunc(entity, configCompanies, stopIdAgencyMap);
 
   const stationNetwork = "networks" in entity && (coreUtils.itinerary.getCompaniesLabelFromNetworks(entity?.networks || [], configCompanies) || entity?.networks?.[0]);
 
@@ -158,3 +168,4 @@ export function MapPopup({ closePopup = () => {}, configCompanies, entity, getEn
 }
 
 export default MapPopup;
+export { type StopIdAgencyMap };

--- a/packages/map-popup/src/index.tsx
+++ b/packages/map-popup/src/index.tsx
@@ -3,7 +3,7 @@ import FromToLocationPicker from "@opentripplanner/from-to-location-picker";
 import coreUtils from "@opentripplanner/core-utils";
 
 // eslint-disable-next-line prettier/prettier
-import type { Company, ConfiguredCompany, Location, Station, Stop, StopEventHandler } from "@opentripplanner/types";
+import type { Agency, Company, ConfiguredCompany, Location, Station, Stop, StopEventHandler } from "@opentripplanner/types";
 
 import { FocusTrapWrapper } from "@opentripplanner/building-blocks";
 import { flatten } from "flat";
@@ -90,9 +90,9 @@ type Props = {
   closePopup?: (arg?: any) => void
   configCompanies?: ConfiguredCompany[];
   entity: Entity
-  getEntityName?: (entity: Entity, configCompanies: Company[], stopIdAgencyMap?: StopIdAgencyMap) => string;
+  getEntityName?: (entity: Entity, configCompanies: Company[], agencyName?: string) => string;
   getEntityPrefix?: (entity: Entity) => JSX.Element
-  stopIdAgencyMap?: StopIdAgencyMap
+  agency?: Agency
   setLocation?: ({ location, locationType }: { location: Location, locationType: string }) => void;
   setViewedStop?: StopEventHandler;
 };
@@ -112,14 +112,14 @@ export function MapPopup({
   getEntityPrefix, 
   setLocation, 
   setViewedStop, 
-  stopIdAgencyMap 
+  agency,
 }: Props): JSX.Element {
 
   const intl = useIntl()
   if (!entity) return <></>
 
   const getNameFunc = getEntityName || makeDefaultGetEntityName(intl, defaultMessages);
-  const name = getNameFunc(entity, configCompanies, stopIdAgencyMap);
+  const name = getNameFunc(entity, configCompanies, agency?.name);
 
   const stationNetwork = "networks" in entity && (coreUtils.itinerary.getCompaniesLabelFromNetworks(entity?.networks || [], configCompanies) || entity?.networks?.[0]);
 

--- a/packages/map-popup/src/index.tsx
+++ b/packages/map-popup/src/index.tsx
@@ -100,7 +100,7 @@ type Props = {
   entity: Entity
   getEntityName?: (entity: Entity, configCompanies: Company[], feedName?: string) => string;
   getEntityPrefix?: (entity: Entity) => JSX.Element
-  feeds: Feed[]
+  feeds?: Feed[]
   setLocation?: ({ location, locationType }: { location: Location, locationType: string }) => void;
   setViewedStop?: StopEventHandler;
 };

--- a/packages/map-popup/src/util.ts
+++ b/packages/map-popup/src/util.ts
@@ -12,7 +12,7 @@ export function makeDefaultGetEntityName(
   return function defaultGetEntityName(
     entity: Station | Stop,
     configCompanies: Company[],
-    stopIdAgencyMap?: StopIdAgencyMap
+    agencyName?: string
   ): string | null {
     // TODO: Stop generating this / passing it to the car string? Is it needed?
     // In English we say "Car: " instead
@@ -66,14 +66,8 @@ export function makeDefaultGetEntityName(
         },
         { name: stationName }
       );
-    } else if (
-      stopIdAgencyMap &&
-      entity.id in stopIdAgencyMap &&
-      "code" in entity
-    ) {
-      stationName = `${stationName} (${stopIdAgencyMap[entity.id].name} ${
-        entity.code
-      })`;
+    } else if (agencyName && "code" in entity) {
+      stationName = `${stationName} (${agencyName} ${entity.code})`;
     }
     return stationName;
   };

--- a/packages/map-popup/src/util.ts
+++ b/packages/map-popup/src/util.ts
@@ -1,6 +1,8 @@
-import { Company, Station, Stop } from "@opentripplanner/types";
+import { Agency, Company, Station, Stop } from "@opentripplanner/types";
 import { IntlShape } from "react-intl";
 import coreUtils from "@opentripplanner/core-utils";
+
+export type StopIdAgencyMap = Record<string, Agency>;
 
 // eslint-disable-next-line import/prefer-default-export
 export function makeDefaultGetEntityName(
@@ -9,7 +11,8 @@ export function makeDefaultGetEntityName(
 ) {
   return function defaultGetEntityName(
     entity: Station | Stop,
-    configCompanies: Company[]
+    configCompanies: Company[],
+    stopIdAgencyMap?: StopIdAgencyMap
   ): string | null {
     // TODO: Stop generating this / passing it to the car string? Is it needed?
     // In English we say "Car: " instead
@@ -63,6 +66,14 @@ export function makeDefaultGetEntityName(
         },
         { name: stationName }
       );
+    } else if (
+      stopIdAgencyMap &&
+      entity.id in stopIdAgencyMap &&
+      "code" in entity
+    ) {
+      stationName = `${stationName} (${stopIdAgencyMap[entity.id].name} ${
+        entity.code
+      })`;
     }
     return stationName;
   };

--- a/packages/map-popup/src/util.ts
+++ b/packages/map-popup/src/util.ts
@@ -12,7 +12,7 @@ export function makeDefaultGetEntityName(
   return function defaultGetEntityName(
     entity: Station | Stop,
     configCompanies: Company[],
-    agencyName?: string
+    feedName?: string
   ): string | null {
     // TODO: Stop generating this / passing it to the car string? Is it needed?
     // In English we say "Car: " instead
@@ -66,8 +66,8 @@ export function makeDefaultGetEntityName(
         },
         { name: stationName }
       );
-    } else if (agencyName && "code" in entity) {
-      stationName = `${stationName} (${agencyName} ${entity.code})`;
+    } else if (feedName && "code" in entity) {
+      stationName = `${stationName} (${feedName} ${entity.code})`;
     }
     return stationName;
   };

--- a/packages/otp2-tile-overlay/src/index.tsx
+++ b/packages/otp2-tile-overlay/src/index.tsx
@@ -1,4 +1,4 @@
-import EntityPopup, { StopIdAgencyMap } from "@opentripplanner/map-popup"
+import EntityPopup, { Feed } from "@opentripplanner/map-popup"
 import {
   ConfiguredCompany,
   MapLocationActionArg,
@@ -30,8 +30,7 @@ const OTP2TileLayerWithPopup = ({
   setViewedStop,
   stopsWhitelist,
   type,
-  stopIdAgencyMap,
-  requestAgencyForStop
+  feeds
 }: {
   color?: string;
   /**
@@ -59,11 +58,6 @@ const OTP2TileLayerWithPopup = ({
    */
   onMapClick?: (event: EventData) => void
   /**
-   * A method to request the agency for a given stop ID. If this method is not passed, the agency
-   * for a given stop ID will not be displayed in the popup.
-   */
-  requestAgencyForStop?: (stopId: string) => void
-  /**
    * A method fired when a stop is selected as from or to in the default popup. If this method
    * is not passed, the from/to buttons will not be shown.
    */
@@ -74,10 +68,10 @@ const OTP2TileLayerWithPopup = ({
    */
   setViewedStop?: StopEventHandler
   /**
-   * A map of stop IDs to agencies. If specified, the agency for a given stop ID will be used to
+   * A list of feeds from the GraphQL query. If specified, the feed publisher name will be used to
    * display the name of the stop in the popup.
    */
-  stopIdAgencyMap?: StopIdAgencyMap
+  feeds?: Feed[]
   /**
    * A list of GTFS stop ids (with agency prepended). If specified, all stops that
    * are NOT in this list will be HIDDEN.
@@ -108,7 +102,6 @@ const OTP2TileLayerWithPopup = ({
     // See: https://github.com/opentripplanner/otp-ui/pull/472#discussion_r1023124055
     if (sourceLayer === "stops" || sourceLayer === "stations") {
       setClickedEntity(synthesizedEntity)
-      requestAgencyForStop && requestAgencyForStop(synthesizedEntity.id)
     }
     if (
       sourceLayer === "rentalVehicles" ||
@@ -248,7 +241,7 @@ const OTP2TileLayerWithPopup = ({
             configCompanies={configCompanies}
             entity={{ ...clickedEntity, id: clickedEntity?.id || clickedEntity?.gtfsId }}
             getEntityPrefix={getEntityPrefix}
-            agency={stopIdAgencyMap?.[clickedEntity?.id || clickedEntity?.gtfsId]}
+            feeds={feeds}
             setLocation={setLocation ? (location) => { setClickedEntity(null); setLocation(location) } : null}
             setViewedStop={setViewedStop ? (stop) => { setClickedEntity(null);setViewedStop(stop) } : null}
           />
@@ -279,8 +272,7 @@ const generateOTP2TileLayers = (
   stopsWhitelist?: string[],
   configCompanies?: ConfiguredCompany[],
   getEntityPrefix?: (entity: Stop | Station) => JSX.Element,
-  requestAgencyForStop?: (stopId: string) => void,
-  stopIdAgencyMap?: StopIdAgencyMap
+  feeds?: Feed[]
 ): JSX.Element[] => {
   const fakeOtpUiLayerIndex = layers.findIndex(l=>l.type === STOPS_AND_STATIONS_TYPE)
   if (fakeOtpUiLayerIndex > -1) {
@@ -316,8 +308,7 @@ const generateOTP2TileLayers = (
           stopsWhitelist={stopsWhitelist}
           type={type}
           visible={initiallyVisible}
-          requestAgencyForStop={requestAgencyForStop}
-          stopIdAgencyMap={stopIdAgencyMap}
+          feeds={feeds}
         />
       )
     })

--- a/packages/otp2-tile-overlay/src/index.tsx
+++ b/packages/otp2-tile-overlay/src/index.tsx
@@ -248,11 +248,10 @@ const OTP2TileLayerWithPopup = ({
             configCompanies={configCompanies}
             entity={{ ...clickedEntity, id: clickedEntity?.id || clickedEntity?.gtfsId }}
             getEntityPrefix={getEntityPrefix}
-            stopIdAgencyMap={stopIdAgencyMap}
+            agency={stopIdAgencyMap?.[clickedEntity?.id || clickedEntity?.gtfsId]}
             setLocation={setLocation ? (location) => { setClickedEntity(null); setLocation(location) } : null}
             setViewedStop={setViewedStop ? (stop) => { setClickedEntity(null);setViewedStop(stop) } : null}
           />
-
         </Popup>
       )}
     </>

--- a/packages/otp2-tile-overlay/src/index.tsx
+++ b/packages/otp2-tile-overlay/src/index.tsx
@@ -1,6 +1,5 @@
 import EntityPopup, { StopIdAgencyMap } from "@opentripplanner/map-popup"
 import {
-  Agency,
   ConfiguredCompany,
   MapLocationActionArg,
   Station,
@@ -63,7 +62,7 @@ const OTP2TileLayerWithPopup = ({
    * A method to request the agency for a given stop ID. If this method is not passed, the agency
    * for a given stop ID will not be displayed in the popup.
    */
-  requestAgencyForStop?: (stopId: string) => Promise<Agency>
+  requestAgencyForStop?: (stopId: string) => void
   /**
    * A method fired when a stop is selected as from or to in the default popup. If this method
    * is not passed, the from/to buttons will not be shown.
@@ -281,7 +280,7 @@ const generateOTP2TileLayers = (
   stopsWhitelist?: string[],
   configCompanies?: ConfiguredCompany[],
   getEntityPrefix?: (entity: Stop | Station) => JSX.Element,
-  requestAgencyForStop?: (stopId: string) => Promise<Agency>,
+  requestAgencyForStop?: (stopId: string) => void,
   stopIdAgencyMap?: StopIdAgencyMap
 ): JSX.Element[] => {
   const fakeOtpUiLayerIndex = layers.findIndex(l=>l.type === STOPS_AND_STATIONS_TYPE)


### PR DESCRIPTION
This PR adds support for rendering the agency name, stop code, and stop name in the map popup used in otp2 tile overlay. It does this by accepting a prop containing a mapping of stop IDs to agencies, since this information is not available in the vector tile data. It also provides a callback prop so the component can tell its parent when a stop has been clicked on and the data is needed. 

Paired with https://github.com/opentripplanner/otp-react-redux/pull/1433