### PR TITLE
Trip Details make header key optional on default fare type

### DIFF
--- a/packages/trip-details/src/components/fares.tsx
+++ b/packages/trip-details/src/components/fares.tsx
@@ -95,7 +95,8 @@ export default function Fares({
               id="otpUi.TripDetails.transitFareEntry"
               values={{
                 name:
-                  fareKeyNameMap?.[defaultFareType.headerKey] ||
+                  (defaultFareType.headerKey &&
+                    fareKeyNameMap?.[defaultFareType.headerKey]) ||
                   fareNameFallback,
                 strong: boldText,
                 value: renderFare(
@@ -125,7 +126,8 @@ export default function Fares({
                   key={Object.values(fareType).join("-")}
                   values={{
                     name:
-                      fareKeyNameMap?.[defaultFareType.headerKey] ||
+                      (defaultFareType.headerKey &&
+                        fareKeyNameMap?.[defaultFareType.headerKey]) ||
                       fareNameFallback,
                     strong: boldText,
                     value: renderFare(

--- a/packages/trip-details/src/types.ts
+++ b/packages/trip-details/src/types.ts
@@ -55,8 +55,9 @@ export interface FareDetailsProps {
 export interface FareConfig {
   /**
    * Determines which transit fare should be displayed by default, should there be multiple transit fare types.
+   * Header key is used only in the old fare display.
    */
-  defaultFareType?: { headerKey: string } & FareProductSelector;
+  defaultFareType?: { headerKey?: string } & FareProductSelector;
   /**
    * Column and table configuration for fare details/fare by leg table.
    */


### PR DESCRIPTION
We don't need the header key here because it was just used on the old fare display which we don't really use anymore. 