### PR TITLE
More OTP-UI new map releases

### DIFF
--- a/packages/park-and-ride-overlay/src/index.tsx
+++ b/packages/park-and-ride-overlay/src/index.tsx
@@ -30,6 +30,7 @@ const ParkAndRideOverlay = (props: Props): JSX.Element => {
     <>
       {parkAndRideLocations.map((location, k) => {
         // TODO: extract park-and-ride names from international "Park-And-Ride" string constructs.
+        // The code below gets rid of "P+R " prefixes returned by some OTP instances.
         const name = location.name.startsWith("P+R ")
           ? location.name.substring(4)
           : location.name;

--- a/packages/transit-vehicle-overlay/src/index.tsx
+++ b/packages/transit-vehicle-overlay/src/index.tsx
@@ -62,7 +62,7 @@ type Props = {
   VehicleIcon?: FC<VehicleIconProps>;
 
   /**
-   * The list of vehicles to create stop markers for.
+   * The list of vehicles to create markers for.
    */
   vehicles?: TransitVehicle[];
 };


### PR DESCRIPTION
This PR adds two breaking-change commits to trigger releases of the transit-vehicle-overlay and park-and-ride-overlay that were not updated by #848.