### PR TITLE
Eliminate erroneous warn logs in itinerary-body

### DIFF
--- a/packages/itinerary-body/src/util.ts
+++ b/packages/itinerary-body/src/util.ts
@@ -152,10 +152,8 @@ export function getPlaceName(
   // Other times, it can be a name with relevant information for the user.
   // Here we detect if the name is just a UUID and generate a better name.
   // It is also possible to configure station name overrides in the config using overridePlaceNames.
-  const company = getCompanyForNetwork(
-    place.networks?.[0] || place?.rentalVehicle?.network,
-    companies
-  );
+  const network = place.networks?.[0] || place?.rentalVehicle?.network;
+  const company = network && getCompanyForNetwork(network, companies);
   if (
     intl &&
     // Don't ever show this useless OTP default string


### PR DESCRIPTION
The `itinerary-body` component in writing the the following message to the console for each walk leg in an itinerary, each time the component renders:

<img width="825" height="435" alt="Screenshot 2025-08-08 125510" src="https://github.com/user-attachments/assets/243bf2fe-ab46-4540-ba14-0c7685db05b1" />

This happens because the `getPlaceName` util in `itinerary-body` makes a call to `getCompanyForNetwork` to get a validated company name.  The latter function logs a warning when its `networkString` parameter is not in the otp-ui company config. This works fine for micromobility legs, but `getPlaceName` is also used for walk legs, which never have an associated network, so this warning emitted a lot and obscures other output in the console.  

This PR alters the call to `getCompanyFromNetwork` to only be made when the `place` parameter has a truthy network value to eliminates the invalid warnings

### Testing

* Load the [hosted](http://www.opentripplanner.org/otp-ui/?path=/story/basemap--click-and-viewportchanged-events&globals=locale:en-US) version of Storybook for this project
* Open the devtools, activate the console and make sure warning logging is turned on
* In Storybook activate the: ItineraryBody --> otp-ui --> Walk Transit Walk Itinerary story
* Look and the console and you should see several instance of the error from the image above
* Now check out the source branch for this PR and spin up Storybook locally
* Follow step 3 & 4 with the local instance of Storybook
* You should not see these warnings in the console
* Look through a few of the itinerary stories and confirm that they have valid place names that match the hosted instance of Storybook
  * The place name is the text to the left of the leg badge, e.g.:
  <img width="311" height="43" alt="Screenshot 2025-08-08 131022" src="https://github.com/user-attachments/assets/e5728d21-809a-48f5-ae37-9b17f74d73b5" />
