### PR TITLE
fix: remove duplicate stop code title

### DIFF
--- a/packages/map-popup/i18n/en-US.yml
+++ b/packages/map-popup/i18n/en-US.yml
@@ -6,5 +6,7 @@ otpUi:
     floatingCar: "Car: {name}"
     floatingEScooter: "E-scooter: {name}"
     popupTitle: "{stationNetwork, select, false {{name}} other {{stationNetwork} {name}}}"
-    stopId: "Stop ID: {stopId}"
+    stopId: >-
+      {feedName, select, undefined {Stop ID: {stopId}} other {Stop ID:
+      {feedName} {stopId}}}
     stopViewer: Stop Viewer

--- a/packages/map-popup/src/index.tsx
+++ b/packages/map-popup/src/index.tsx
@@ -74,7 +74,7 @@ const StationHubDetails = ({ station }: { station: TileLayerStation }) => {
   )
 }
 
-const StopDetails = ({ id, setViewedStop }: { id: string, setViewedStop: () => void; }) => {
+const StopDetails = ({ id, feedName, setViewedStop }: { id: string, feedName?: string, setViewedStop: () => void; }) => {
   return (
     <Styled.PopupRow>
       {id &&
@@ -84,6 +84,7 @@ const StopDetails = ({ id, setViewedStop }: { id: string, setViewedStop: () => v
             description="Displays the stop id"
             id="otpUi.MapPopup.stopId"
             values={{
+              feedName,
               stopId: id
             }}
           />
@@ -103,7 +104,7 @@ type Props = {
   closePopup?: (arg?: boolean) => void
   configCompanies?: ConfiguredCompany[];
   entity: Entity
-  getEntityName?: (entity: Entity, configCompanies: Company[], feedName?: string) => string;
+  getEntityName?: (entity: Entity, configCompanies: Company[], feedName?: string, includeParenthetical?: boolean) => string;
   getEntityPrefix?: (entity: Entity) => JSX.Element
   feeds?: Feed[]
   setLocation?: ({ location, locationType }: { location: Location, locationType: string }) => void;
@@ -142,6 +143,7 @@ export function MapPopup({
   }
   
   const name = getNameFunc(entity, configCompanies, feedName);
+  const titleName = getNameFunc(entity, configCompanies, feedName, false);
 
   const stationNetwork = getNetwork(entity, configCompanies);
 
@@ -159,7 +161,7 @@ export function MapPopup({
           defaultMessage={defaultMessages["otpUi.MapPopup.popupTitle"]}
           description="Text for title of the popup, contains an optional company name"
           id="otpUi.MapPopup.popupTitle"
-          values={{ name, stationNetwork }}
+          values={{ name: titleName, stationNetwork }}
         />
       </Styled.PopupTitle>
       {/* render dock info if it is available */}
@@ -169,6 +171,7 @@ export function MapPopup({
       {setViewedStop && !bikesAvailablePresent && (
         <StopDetails
           id={stopId}
+          feedName={feedName}
           setViewedStop={useCallback(() => setViewedStop(entity as Stop), [entity])}
         />
       )}

--- a/packages/map-popup/src/util.ts
+++ b/packages/map-popup/src/util.ts
@@ -15,7 +15,7 @@ export function getNetwork(entity: Entity, configCompanies: Company[]): string {
   return (
     "network" in entity &&
     (coreUtils.itinerary.getCompaniesLabelFromNetworks(
-      [entity.network] || [],
+      [entity.network],
       configCompanies
     ) ||
       entity.network)
@@ -30,7 +30,8 @@ export function makeDefaultGetEntityName(
   return function defaultGetEntityName(
     entity: Entity,
     configCompanies: Company[],
-    feedName?: string
+    feedName?: string,
+    includeParenthetical = true
   ): string | null {
     let stationName: string | null = entity.name || entity.id;
     // If the station name or id is a giant UUID (with more than 3 "-" characters)
@@ -78,7 +79,7 @@ export function makeDefaultGetEntityName(
         },
         { name: stationName }
       );
-    } else if (feedName && "code" in entity) {
+    } else if (includeParenthetical && feedName && "code" in entity) {
       stationName = `${stationName} (${feedName} ${entity.code})`;
     }
     return stationName;


### PR DESCRIPTION
This adjusts the way the feed name is rendered so you don't see duplicate info. Instead we move the feed name into the existing stop ID section, but use the parenthesis title in the location name for the from/to location picker. 
<img width="229" height="103" alt="image" src="https://github.com/user-attachments/assets/35d99763-4b54-428e-a53a-96072a0f21f1" />
