### PR TITLE
Use type import syntax for RequiredOptionsForTransportMode

### DIFF
--- a/packages/trip-form/src/index.ts
+++ b/packages/trip-form/src/index.ts
@@ -18,8 +18,10 @@ import {
   populateSettingWithValue,
   getBannedRoutesFromSubmodes,
   findRequiredOptionsForTransportMode,
-  RequiredOptionsForTransportMode
 } from "./MetroModeSelector/utils";
+// Prettier does not support typescript annotation
+// eslint-disable-next-line prettier/prettier
+import type { RequiredOptionsForTransportMode } from "./MetroModeSelector/utils";
 import { ModeSettingRenderer } from "./MetroModeSelector/SubSettingsPane";
 import TripOptions, { Styled as TripOptionsStyled } from "./TripOptions";
 import defaultModeSettings from "../modeSettings.yml";


### PR DESCRIPTION
Fixes an error caused by the incorrect import of `RequiredOptionsForTransportMode`