### PR TITLE
fix: Use type import syntax for RequiredOptionsForTransportMode

### DIFF
--- a/packages/trip-form/src/index.ts
+++ b/packages/trip-form/src/index.ts
@@ -19,7 +19,7 @@ import {
   getBannedRoutesFromSubmodes,
   findRequiredOptionsForTransportMode,
 } from "./MetroModeSelector/utils";
-// Prettier does not support typescript annotation
+// Prettier does not support typescript annotation 
 // eslint-disable-next-line prettier/prettier
 import type { RequiredOptionsForTransportMode } from "./MetroModeSelector/utils";
 import { ModeSettingRenderer } from "./MetroModeSelector/SubSettingsPane";


### PR DESCRIPTION
Forgot to include a semantic release commit for #873 🙃