### PR TITLE
Apply gradation map to accessibility annotations

### DIFF
--- a/packages/printable-itinerary/src/__snapshots__/PrintableItinerary.story.tsx.snap
+++ b/packages/printable-itinerary/src/__snapshots__/PrintableItinerary.story.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PrintableItinerary BikeOnlyItinerary smoke-test 1`] = `
-<div class="styled__PrintableItinerary-sc-1fqxr7x-11 iqiwLo">
+<div class="styled__PrintableItinerary-sc-1fqxr7x-12 bwuFHT">
   <div class="styled__Leg-sc-1fqxr7x-0 styled__CollapsedTop-sc-1fqxr7x-1 huReCP hTlAOC">
     <div class="styled__LegBody-sc-1fqxr7x-2 gEKanE">
       <div class="styled__LegHeader-sc-1fqxr7x-5 lhdQfn">
@@ -76,7 +76,7 @@ exports[`PrintableItinerary BikeOnlyItinerary smoke-test 1`] = `
 `;
 
 exports[`PrintableItinerary BikeRentalItinerary smoke-test 1`] = `
-<div class="styled__PrintableItinerary-sc-1fqxr7x-11 iqiwLo">
+<div class="styled__PrintableItinerary-sc-1fqxr7x-12 bwuFHT">
   <div class="styled__Leg-sc-1fqxr7x-0 styled__CollapsedTop-sc-1fqxr7x-1 huReCP hTlAOC">
     <div class="styled__LegBody-sc-1fqxr7x-2 gEKanE">
       <div class="styled__LegHeader-sc-1fqxr7x-5 lhdQfn">
@@ -288,7 +288,7 @@ exports[`PrintableItinerary BikeRentalItinerary smoke-test 1`] = `
 `;
 
 exports[`PrintableItinerary BikeRentalTransitItinerary smoke-test 1`] = `
-<div class="styled__PrintableItinerary-sc-1fqxr7x-11 iqiwLo">
+<div class="styled__PrintableItinerary-sc-1fqxr7x-12 bwuFHT">
   <div class="styled__Leg-sc-1fqxr7x-0 styled__CollapsedTop-sc-1fqxr7x-1 huReCP hTlAOC">
     <div class="styled__LegBody-sc-1fqxr7x-2 gEKanE">
       <div class="styled__LegHeader-sc-1fqxr7x-5 lhdQfn">
@@ -775,7 +775,7 @@ exports[`PrintableItinerary BikeRentalTransitItinerary smoke-test 1`] = `
 `;
 
 exports[`PrintableItinerary BikeTransitBikeItinerary smoke-test 1`] = `
-<div class="styled__PrintableItinerary-sc-1fqxr7x-11 iqiwLo">
+<div class="styled__PrintableItinerary-sc-1fqxr7x-12 bwuFHT">
   <div class="styled__Leg-sc-1fqxr7x-0 styled__CollapsedTop-sc-1fqxr7x-1 huReCP hTlAOC">
     <div class="styled__LegBody-sc-1fqxr7x-2 gEKanE">
       <div class="styled__LegHeader-sc-1fqxr7x-5 lhdQfn">
@@ -1065,7 +1065,7 @@ exports[`PrintableItinerary BikeTransitBikeItinerary smoke-test 1`] = `
 `;
 
 exports[`PrintableItinerary ClassicIconsAndParkAndRideItinerary smoke-test 1`] = `
-<div class="styled__PrintableItinerary-sc-1fqxr7x-11 iqiwLo">
+<div class="styled__PrintableItinerary-sc-1fqxr7x-12 bwuFHT">
   <div class="styled__Leg-sc-1fqxr7x-0 styled__CollapsedTop-sc-1fqxr7x-1 huReCP hTlAOC">
     <div class="styled__LegBody-sc-1fqxr7x-2 gEKanE">
       <div class="styled__LegHeader-sc-1fqxr7x-5 lhdQfn">
@@ -1433,7 +1433,7 @@ exports[`PrintableItinerary ClassicIconsAndParkAndRideItinerary smoke-test 1`] =
 `;
 
 exports[`PrintableItinerary EScooterRentalItinerary smoke-test 1`] = `
-<div class="styled__PrintableItinerary-sc-1fqxr7x-11 iqiwLo">
+<div class="styled__PrintableItinerary-sc-1fqxr7x-12 bwuFHT">
   <div class="styled__Leg-sc-1fqxr7x-0 styled__CollapsedTop-sc-1fqxr7x-1 huReCP hTlAOC">
     <div class="styled__LegBody-sc-1fqxr7x-2 gEKanE">
       <div class="styled__LegHeader-sc-1fqxr7x-5 lhdQfn">
@@ -1539,7 +1539,7 @@ exports[`PrintableItinerary EScooterRentalItinerary smoke-test 1`] = `
 `;
 
 exports[`PrintableItinerary EScooterRentalTransitItinerary smoke-test 1`] = `
-<div class="styled__PrintableItinerary-sc-1fqxr7x-11 iqiwLo">
+<div class="styled__PrintableItinerary-sc-1fqxr7x-12 bwuFHT">
   <div class="styled__Leg-sc-1fqxr7x-0 styled__CollapsedTop-sc-1fqxr7x-1 huReCP hTlAOC">
     <div class="styled__LegBody-sc-1fqxr7x-2 gEKanE">
       <div class="styled__LegHeader-sc-1fqxr7x-5 lhdQfn">
@@ -1943,7 +1943,7 @@ exports[`PrintableItinerary EScooterRentalTransitItinerary smoke-test 1`] = `
 `;
 
 exports[`PrintableItinerary OTP2ScooterItinerary smoke-test 1`] = `
-<div class="styled__PrintableItinerary-sc-1fqxr7x-11 iqiwLo">
+<div class="styled__PrintableItinerary-sc-1fqxr7x-12 bwuFHT">
   <div class="styled__Leg-sc-1fqxr7x-0 styled__CollapsedTop-sc-1fqxr7x-1 huReCP hTlAOC">
     <div class="styled__LegBody-sc-1fqxr7x-2 gEKanE">
       <div class="styled__LegHeader-sc-1fqxr7x-5 lhdQfn">
@@ -2148,7 +2148,7 @@ exports[`PrintableItinerary OTP2ScooterItinerary smoke-test 1`] = `
 `;
 
 exports[`PrintableItinerary OTP24Itinerary smoke-test 1`] = `
-<div class="styled__PrintableItinerary-sc-1fqxr7x-11 iqiwLo">
+<div class="styled__PrintableItinerary-sc-1fqxr7x-12 bwuFHT">
   <div class="styled__Leg-sc-1fqxr7x-0 styled__CollapsedTop-sc-1fqxr7x-1 huReCP hTlAOC">
     <div class="styled__LegBody-sc-1fqxr7x-2 gEKanE">
       <div class="styled__LegHeader-sc-1fqxr7x-5 lhdQfn">
@@ -2503,7 +2503,7 @@ exports[`PrintableItinerary OTP24Itinerary smoke-test 1`] = `
 `;
 
 exports[`PrintableItinerary ParkAndRideItinerary smoke-test 1`] = `
-<div class="styled__PrintableItinerary-sc-1fqxr7x-11 iqiwLo">
+<div class="styled__PrintableItinerary-sc-1fqxr7x-12 bwuFHT">
   <div class="styled__Leg-sc-1fqxr7x-0 styled__CollapsedTop-sc-1fqxr7x-1 huReCP hTlAOC">
     <div class="styled__LegBody-sc-1fqxr7x-2 gEKanE">
       <div class="styled__LegHeader-sc-1fqxr7x-5 lhdQfn">
@@ -2849,7 +2849,7 @@ exports[`PrintableItinerary ParkAndRideItinerary smoke-test 1`] = `
 `;
 
 exports[`PrintableItinerary StyledWalkTransitWalkItinerary smoke-test 1`] = `
-<div class="styled__PrintableItinerary-sc-1fqxr7x-11 iqiwLo PrintableItinerarystory__StyledPrintableItinerary-sc-1fgcguf-0 ZKSFh">
+<div class="styled__PrintableItinerary-sc-1fqxr7x-12 bwuFHT PrintableItinerarystory__StyledPrintableItinerary-sc-1fgcguf-0 ZKSFh">
   <div class="styled__Leg-sc-1fqxr7x-0 styled__CollapsedTop-sc-1fqxr7x-1 huReCP hTlAOC">
     <div class="styled__LegBody-sc-1fqxr7x-2 gEKanE">
       <div class="styled__LegHeader-sc-1fqxr7x-5 lhdQfn">
@@ -3025,7 +3025,7 @@ exports[`PrintableItinerary StyledWalkTransitWalkItinerary smoke-test 1`] = `
 `;
 
 exports[`PrintableItinerary TncTransitItinerary smoke-test 1`] = `
-<div class="styled__PrintableItinerary-sc-1fqxr7x-11 iqiwLo">
+<div class="styled__PrintableItinerary-sc-1fqxr7x-12 bwuFHT">
   <div class="styled__Leg-sc-1fqxr7x-0 styled__CollapsedTop-sc-1fqxr7x-1 huReCP hTlAOC">
     <div class="styled__LegBody-sc-1fqxr7x-2 gEKanE">
       <div class="styled__LegHeader-sc-1fqxr7x-5 lhdQfn">
@@ -3211,7 +3211,7 @@ exports[`PrintableItinerary TncTransitItinerary smoke-test 1`] = `
 `;
 
 exports[`PrintableItinerary WalkInterlinedTransitItinerary smoke-test 1`] = `
-<div class="styled__PrintableItinerary-sc-1fqxr7x-11 iqiwLo">
+<div class="styled__PrintableItinerary-sc-1fqxr7x-12 bwuFHT">
   <div class="styled__Leg-sc-1fqxr7x-0 styled__CollapsedTop-sc-1fqxr7x-1 huReCP hTlAOC">
     <div class="styled__LegBody-sc-1fqxr7x-2 gEKanE">
       <div class="styled__LegHeader-sc-1fqxr7x-5 lhdQfn">
@@ -3570,7 +3570,7 @@ exports[`PrintableItinerary WalkInterlinedTransitItinerary smoke-test 1`] = `
 `;
 
 exports[`PrintableItinerary WalkOnlyItinerary smoke-test 1`] = `
-<div class="styled__PrintableItinerary-sc-1fqxr7x-11 iqiwLo">
+<div class="styled__PrintableItinerary-sc-1fqxr7x-12 bwuFHT">
   <div class="styled__Leg-sc-1fqxr7x-0 styled__CollapsedTop-sc-1fqxr7x-1 huReCP hTlAOC">
     <div class="styled__LegBody-sc-1fqxr7x-2 gEKanE">
       <div class="styled__LegHeader-sc-1fqxr7x-5 lhdQfn">
@@ -3626,7 +3626,7 @@ exports[`PrintableItinerary WalkOnlyItinerary smoke-test 1`] = `
 `;
 
 exports[`PrintableItinerary WalkTransitTransferItinerary smoke-test 1`] = `
-<div class="styled__PrintableItinerary-sc-1fqxr7x-11 iqiwLo">
+<div class="styled__PrintableItinerary-sc-1fqxr7x-12 bwuFHT">
   <div class="styled__Leg-sc-1fqxr7x-0 styled__CollapsedTop-sc-1fqxr7x-1 huReCP hTlAOC">
     <div class="styled__LegBody-sc-1fqxr7x-2 gEKanE">
       <div class="styled__LegHeader-sc-1fqxr7x-5 lhdQfn">
@@ -3894,7 +3894,7 @@ exports[`PrintableItinerary WalkTransitTransferItinerary smoke-test 1`] = `
 `;
 
 exports[`PrintableItinerary WalkTransitTransferWithA11yItinerary smoke-test 1`] = `
-<div class="styled__PrintableItinerary-sc-1fqxr7x-11 iqiwLo">
+<div class="styled__PrintableItinerary-sc-1fqxr7x-12 bwuFHT">
   <div class="styled__Leg-sc-1fqxr7x-0 styled__CollapsedTop-sc-1fqxr7x-1 huReCP hTlAOC">
     <div class="styled__LegBody-sc-1fqxr7x-2 gEKanE">
       <div class="styled__LegHeader-sc-1fqxr7x-5 lhdQfn">
@@ -3919,11 +3919,11 @@ exports[`PrintableItinerary WalkTransitTransferWithA11yItinerary smoke-test 1`] 
         </svg>
       </div>
       <div color="transparent"
-           title="Wheelchair accessibility of this trip: likely accessible"
+           title="Wheelchair accessibility of this trip leg: likely accessible"
            class="accessibility-rating__Wrapper-sc-7g85t2-0 ghJxtf"
       >
         <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-27 dbEGNj invisible-additional-details">
-          Wheelchair accessibility of this trip: likely accessible
+          Wheelchair accessibility of this trip leg: likely accessible
         </span>
         <svg viewbox="0 0 100 100"
              aria-hidden="true"
@@ -3994,11 +3994,11 @@ exports[`PrintableItinerary WalkTransitTransferWithA11yItinerary smoke-test 1`] 
         </svg>
       </div>
       <div color="transparent"
-           title="Wheelchair accessibility of this trip: unknown"
+           title="Wheelchair accessibility of this trip leg: unknown"
            class="accessibility-rating__Wrapper-sc-7g85t2-0 ghJxtf"
       >
         <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-27 dbEGNj invisible-additional-details">
-          Wheelchair accessibility of this trip: unknown
+          Wheelchair accessibility of this trip leg: unknown
         </span>
         <svg viewbox="0 0 100 100"
              aria-hidden="true"
@@ -4128,11 +4128,11 @@ exports[`PrintableItinerary WalkTransitTransferWithA11yItinerary smoke-test 1`] 
         </svg>
       </div>
       <div color="transparent"
-           title="Wheelchair accessibility of this trip: inaccessible"
+           title="Wheelchair accessibility of this trip leg: inaccessible"
            class="accessibility-rating__Wrapper-sc-7g85t2-0 ghJxtf"
       >
         <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-27 dbEGNj invisible-additional-details">
-          Wheelchair accessibility of this trip: inaccessible
+          Wheelchair accessibility of this trip leg: inaccessible
         </span>
         <svg viewbox="0 0 100 100"
              aria-hidden="true"
@@ -4207,11 +4207,11 @@ exports[`PrintableItinerary WalkTransitTransferWithA11yItinerary smoke-test 1`] 
         </svg>
       </div>
       <div color="transparent"
-           title="Wheelchair accessibility of this trip: inaccessible"
+           title="Wheelchair accessibility of this trip leg: inaccessible"
            class="accessibility-rating__Wrapper-sc-7g85t2-0 ghJxtf"
       >
         <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-27 dbEGNj invisible-additional-details">
-          Wheelchair accessibility of this trip: inaccessible
+          Wheelchair accessibility of this trip leg: inaccessible
         </span>
         <svg viewbox="0 0 100 100"
              aria-hidden="true"
@@ -4286,7 +4286,7 @@ exports[`PrintableItinerary WalkTransitTransferWithA11yItinerary smoke-test 1`] 
 `;
 
 exports[`PrintableItinerary WalkTransitWalkItinerary smoke-test 1`] = `
-<div class="styled__PrintableItinerary-sc-1fqxr7x-11 iqiwLo">
+<div class="styled__PrintableItinerary-sc-1fqxr7x-12 bwuFHT">
   <div class="styled__Leg-sc-1fqxr7x-0 styled__CollapsedTop-sc-1fqxr7x-1 huReCP hTlAOC">
     <div class="styled__LegBody-sc-1fqxr7x-2 gEKanE">
       <div class="styled__LegHeader-sc-1fqxr7x-5 lhdQfn">

--- a/packages/printable-itinerary/src/accessibility-annotation.tsx
+++ b/packages/printable-itinerary/src/accessibility-annotation.tsx
@@ -24,6 +24,7 @@ export default function AccessibilityAnnotation({
       </S.ModeIcon>
       {leg.accessibilityScore !== null && leg.accessibilityScore > -1 && (
         <AccessibilityRating
+          isLeg
           gradationMap={accessibilityScoreGradationMap}
           grayscale={grayscale}
           score={leg.accessibilityScore}

--- a/packages/printable-itinerary/src/accessibility-annotation.tsx
+++ b/packages/printable-itinerary/src/accessibility-annotation.tsx
@@ -24,9 +24,9 @@ export default function AccessibilityAnnotation({
       </S.ModeIcon>
       {leg.accessibilityScore !== null && leg.accessibilityScore > -1 && (
         <AccessibilityRating
-          isLeg
           gradationMap={accessibilityScoreGradationMap}
           grayscale={grayscale}
+          isLeg
           score={leg.accessibilityScore}
         />
       )}

--- a/packages/printable-itinerary/src/index.tsx
+++ b/packages/printable-itinerary/src/index.tsx
@@ -74,9 +74,9 @@ function PrintableItinerary({
         ) : leg.rideHailingEstimate ? (
           <TNCLeg
             accessibilityScoreGradationMap={gradationMap}
+            key={k}
             leg={leg}
             LegIcon={LegIcon}
-            key={k}
           />
         ) : (
           <AccessLeg

--- a/packages/printable-itinerary/src/index.tsx
+++ b/packages/printable-itinerary/src/index.tsx
@@ -2,6 +2,7 @@ import { Config, Itinerary, LegIconComponent } from "@opentripplanner/types";
 import React, { ReactElement } from "react";
 import { FormattedMessage } from "react-intl";
 
+import { AccessibilityRating } from "@opentripplanner/itinerary-body/src";
 import AccessLeg from "./access-leg";
 import * as S from "./styled";
 import TNCLeg from "./tnc-leg";
@@ -25,8 +26,20 @@ function PrintableItinerary({
   itinerary,
   LegIcon
 }: Props): ReactElement {
+  const gradationMap = config.accessibilityScore?.gradationMap;
   return (
     <S.PrintableItinerary className={className}>
+      {itinerary.accessibilityScore && (
+        <S.TripAccessibilityScoreWrapper>
+          <AccessibilityRating
+            isLeg={false}
+            gradationMap={gradationMap}
+            grayscale
+            score={itinerary.accessibilityScore}
+          />
+        </S.TripAccessibilityScoreWrapper>
+      )}
+
       {itinerary.legs.length > 0 && (
         <S.CollapsedTop>
           <S.LegBody>
@@ -49,6 +62,7 @@ function PrintableItinerary({
       {itinerary.legs.map((leg, k) =>
         leg.transitLeg ? (
           <TransitLeg
+            accessibilityScoreGradationMap={gradationMap}
             interlineFollows={
               k < itinerary.legs.length - 1 &&
               itinerary.legs[k + 1].interlineWithPreviousLeg
@@ -58,9 +72,20 @@ function PrintableItinerary({
             LegIcon={LegIcon}
           />
         ) : leg.rideHailingEstimate ? (
-          <TNCLeg leg={leg} LegIcon={LegIcon} key={k} />
+          <TNCLeg
+            accessibilityScoreGradationMap={gradationMap}
+            leg={leg}
+            LegIcon={LegIcon}
+            key={k}
+          />
         ) : (
-          <AccessLeg config={config} key={k} leg={leg} LegIcon={LegIcon} />
+          <AccessLeg
+            accessibilityScoreGradationMap={gradationMap}
+            config={config}
+            key={k}
+            leg={leg}
+            LegIcon={LegIcon}
+          />
         )
       )}
     </S.PrintableItinerary>

--- a/packages/printable-itinerary/src/styled.ts
+++ b/packages/printable-itinerary/src/styled.ts
@@ -70,4 +70,8 @@ export const ModeIcon = styled.div`
   height: 32px;
 `;
 
+export const TripAccessibilityScoreWrapper = styled.div`
+  margin-bottom: 1em;
+`;
+
 export const PrintableItinerary = styled.div``;


### PR DESCRIPTION
Seems like an oversight where we just forgot to pass the custom annotations.


| Before | After |
|--------|-------|
|<img width="693" height="667" alt="image" src="https://github.com/user-attachments/assets/8e2b2118-40c4-4e73-a247-816378a61f1f" />|<img width="693" height="667" alt="image" src="https://github.com/user-attachments/assets/7b9a3019-1f90-4701-b439-dc3ef201c125" />|
Before

After

