### PR TITLE
fix: Add classname to PlaceName component

### DIFF
--- a/packages/itinerary-body/src/ItineraryBody/place-row.tsx
+++ b/packages/itinerary-body/src/ItineraryBody/place-row.tsx
@@ -129,7 +129,9 @@ export default function PlaceRow({
         />
       </S.LineColumn>
       <S.PlaceHeader>
-        <S.PlaceName aria-hidden>{placeName}</S.PlaceName>
+        <S.PlaceName aria-hidden className="place-name">
+          {placeName}
+        </S.PlaceName>
       </S.PlaceHeader>
       <S.TimeColumn>
         {/* Custom rendering of the departure/arrival time of the specified leg. */}


### PR DESCRIPTION
Adding a classname to the `PlaceName` component inside `PlaceRow`. This allows configurations to apply custom styling to this component without relying on nested selectors.