### PR TITLE
Tooltip Dynamic Placement

### DIFF
--- a/packages/base-map/src/MarkerWithPopup.tsx
+++ b/packages/base-map/src/MarkerWithPopup.tsx
@@ -47,11 +47,11 @@ const MarkerWithPopup = ({
           autoOffset={autoOffset}
           // eslint-disable-next-line react/jsx-props-no-spreading
           {...popupProps}
-          subpixelPositioning
           closeButton={false}
           closeOnClick={false}
           latitude={position[0]}
           longitude={position[1]}
+          subpixelPositioning
         >
           {tooltipContents}
         </Popup>

--- a/packages/base-map/src/MarkerWithPopup.tsx
+++ b/packages/base-map/src/MarkerWithPopup.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import { FocusTrapWrapper } from "@opentripplanner/building-blocks";
 import React, { useState } from "react";
-import { Marker, PopupProps } from "react-map-gl/maplibre";
+import { Marker, PopupOptions } from "react-map-gl/maplibre";
 import { LeafletStyleMarker, Popup } from "./styled";
 
 type Props = React.ComponentPropsWithoutRef<React.ElementType> & {
+  autoOffset?: number;
   popupContents?: React.ReactNode;
-  popupProps?: PopupProps;
+  popupProps?: PopupOptions;
   position: [number, number];
   tooltipContents?: React.ReactNode;
 };
@@ -15,6 +16,7 @@ type Props = React.ComponentPropsWithoutRef<React.ElementType> & {
  * A MapLibre marker with a connected popup or tooltip
  */
 const MarkerWithPopup = ({
+  autoOffset,
   children,
   popupContents,
   popupProps,
@@ -42,9 +44,10 @@ const MarkerWithPopup = ({
       {/** TODO: adjust tooltip styling? */}
       {showTooltip && tooltipContents && (
         <Popup
+          autoOffset={autoOffset}
           // eslint-disable-next-line react/jsx-props-no-spreading
           {...popupProps}
-          anchor="right"
+          subpixelPositioning
           closeButton={false}
           closeOnClick={false}
           latitude={position[0]}

--- a/packages/base-map/src/styled.ts
+++ b/packages/base-map/src/styled.ts
@@ -1,13 +1,54 @@
 import { Popup as MapGlPopup } from "react-map-gl/maplibre";
+
 import styled from "styled-components";
 
 /**
- * Adds a box shadow and tweaks border radius to make popups easier to read.
+ * First chunk adds a box shadow and tweaks border radius to make popups easier to read.
+ * 
+ * Second chunk corrects custom border-radiuses on corner positions.
+ *
+ * Final chunk implements our "autoOffset" prop, which allows for a dynamic offset
+ * in whichever direction the popup is anchored.
+
  */
-export const Popup = styled(MapGlPopup)`
-  & > .maplibregl-popup-content {
+export const Popup = styled(MapGlPopup)<{ autoOffset?: number }>`
+  .maplibregl-popup-content {
     border-radius: 10px;
     box-shadow: 0 3px 14px 4px rgb(0 0 0 / 20%);
+  }
+
+  &.maplibregl-popup-anchor-bottom-left {
+    .maplibregl-popup-content {
+      border-bottom-left-radius: 0;
+    }
+  }
+  &.maplibregl-popup-anchor-top-left {
+    .maplibregl-popup-content {
+      border-top-left-radius: 0;
+    }
+  }
+  &.maplibregl-popup-anchor-bottom-right {
+    .maplibregl-popup-content {
+      border-bottom-right-radius: 0;
+    }
+  }
+  &.maplibregl-popup-anchor-top-right {
+    .maplibregl-popup-content {
+      border-top-right-radius: 0;
+    }
+  }
+
+  &[class$="right"] {
+    margin-left: -${props => props?.autoOffset || "0"}px;
+  }
+  &[class$="left"] {
+    margin-left: ${props => props?.autoOffset || "0"}px;
+  }
+  &[class$="bottom"] {
+    margin-top: -${props => props?.autoOffset || "0"}px;
+  }
+  &[class$="top"] {
+    margin-top: ${props => props?.autoOffset || "0"}px;
   }
 `;
 

--- a/packages/park-and-ride-overlay/src/index.tsx
+++ b/packages/park-and-ride-overlay/src/index.tsx
@@ -37,8 +37,6 @@ const ParkAndRideOverlay = (props: Props): JSX.Element => {
 
         return (
           <MarkerWithPopup
-            // TODO: find a better way to handle popupProps
-            // @ts-expect-error lat and lng aren't optional, but are being set by the child
             popupProps={{ offset: 10 }}
             popupContents={
               <BaseMapStyled.MapOverlayPopup>

--- a/packages/transit-vehicle-overlay/src/index.tsx
+++ b/packages/transit-vehicle-overlay/src/index.tsx
@@ -107,6 +107,8 @@ const TransitVehicleOverlay = ({
       key={vehicle.vehicleId}
       autoOffset={iconPixels / 2 + iconPadding + 4}
       popupProps={{
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore why is this required? Is it some pnpm packaging issue?
         padding: { left: 100, right: 100, top: 250, bottom: 250 }
       }}
       position={[vehicle.lat, vehicle.lon]}

--- a/packages/transit-vehicle-overlay/src/index.tsx
+++ b/packages/transit-vehicle-overlay/src/index.tsx
@@ -105,8 +105,10 @@ const TransitVehicleOverlay = ({
   return validVehicles?.map(vehicle => (
     <MarkerWithPopup
       key={vehicle.vehicleId}
-      // @ts-expect-error the prop override doesn't require all props to be present
-      popupProps={{ offset: [-iconPixels / 2 - iconPadding, 0] }}
+      autoOffset={iconPixels / 2 + iconPadding + 4}
+      popupProps={{
+        padding: { left: 100, right: 100, top: 250, bottom: 250 }
+      }}
       position={[vehicle.lat, vehicle.lon]}
       tooltipContents={
         (vehicle.routeShortName || vehicle.routeLongName) && (


### PR DESCRIPTION
Removing the `anchor` setting allows MapLibre to dynamically pick the direction the bubble goes. This allows it to dodge edges. 

Then, I've added some other fixes to make these popups less abrasive/buggy