### PR TITLE
fix(location-field): better handle input reflecting address state

### DIFF
--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -570,9 +570,18 @@ const LocationField = ({
     }
   };
 
+  const onFieldBlur = () => {
+    onBlur && onBlur();
+    // Reset the input field to reflect the state onBlur
+    setValue(location?.name || "");
+  };
+
   const onTextInputChange = evt => {
     const { value } = evt.target;
     setValue(value);
+    /* If there's a location, but the user clears out the value in the input, 
+    clear the existing location */
+    location.lat && value === "" && clearLocation({ locationType });
     setMenuVisible(true);
 
     // Cancel all pending requests
@@ -1078,7 +1087,7 @@ const LocationField = ({
       className={formControlClassname}
       onChange={onTextInputChange}
       onClick={handleTextInputClick}
-      onBlur={onBlur}
+      onBlur={onFieldBlur}
       onFocus={onFocus}
       spellCheck={false}
       onKeyDown={onKeyDown}

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -571,9 +571,9 @@ const LocationField = ({
   };
 
   const onFieldBlur = () => {
-    onBlur && onBlur();
     // Reset the input field to reflect the state onBlur
     setValue(location?.name || "");
+    onBlur && onBlur();
   };
 
   const onTextInputChange = evt => {

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -581,7 +581,7 @@ const LocationField = ({
     setValue(value);
     /* If there's a location, but the user clears out the value in the input, 
     clear the existing location */
-    location.lat && value === "" && clearLocation({ locationType });
+    location?.lat && value === "" && clearLocation({ locationType });
     setMenuVisible(true);
 
     // Cancel all pending requests


### PR DESCRIPTION
Previously, the only way to clear the `location` set by the location field was to use the clear button. This meant that occasionally the location field input `value` could be out of step with the `location` which got confusing. For example, if you cleared out the `value`, you could save the place, because the `location` had not technically been changed.

This PR clears the `location` if a user deletes the `value`. It also updates the input value `onBlur` to reflect the state of the `location`

Should this be a breaking change and should `clearLocation` be a required prop?