### PR TITLE
fix: use workspace:^ instead of workspace:* for internal deps

### DIFF
--- a/packages/base-map/package.json
+++ b/packages/base-map/package.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "maplibre-gl": "catalog:",
     "react-map-gl": "catalog:",
-    "@opentripplanner/building-blocks": "workspace:*"
+    "@opentripplanner/building-blocks": "workspace:^"
   },
   "peerDependencies": {
     "react": "catalog:",
-    "@opentripplanner/types": "workspace:*",
+    "@opentripplanner/types": "workspace:^",
     "styled-components": "catalog:"
   },
   "repository": {

--- a/packages/building-blocks/package.json
+++ b/packages/building-blocks/package.json
@@ -9,8 +9,8 @@
   "module": "esm/index.js",
   "private": false,
   "devDependencies": {
-    "@opentripplanner/types": "workspace:*",
-    "@opentripplanner/core-utils": "workspace:*"
+    "@opentripplanner/types": "workspace:^",
+    "@opentripplanner/core-utils": "workspace:^"
   },
   "peerDependencies": {
     "react": "catalog:",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@conveyal/lonlat": "^1.4.1",
     "@mapbox/polyline": "catalog:",
-    "@opentripplanner/geocoder": "workspace:*",
+    "@opentripplanner/geocoder": "workspace:^",
     "@styled-icons/foundation": "catalog:",
     "@turf/along": "^7.3.1",
     "chroma-js": "^3.2.0",
@@ -29,7 +29,7 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "@opentripplanner/types": "workspace:*",
+    "@opentripplanner/types": "workspace:^",
     "@types/chroma-js": "^3.1.2",
     "@types/mapbox__polyline": "^1.0.5"
   }

--- a/packages/endpoints-overlay/package.json
+++ b/packages/endpoints-overlay/package.json
@@ -19,15 +19,15 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "workspace:*",
-    "@opentripplanner/location-icon": "workspace:*",
-    "@opentripplanner/core-utils": "workspace:*",
+    "@opentripplanner/base-map": "workspace:^",
+    "@opentripplanner/location-icon": "workspace:^",
+    "@opentripplanner/core-utils": "workspace:^",
     "flat": "catalog:",
     "@styled-icons/fa-solid": "catalog:",
-    "@opentripplanner/building-blocks": "workspace:*"
+    "@opentripplanner/building-blocks": "workspace:^"
   },
   "devDependencies": {
-    "@opentripplanner/types": "workspace:*",
+    "@opentripplanner/types": "workspace:^",
     "@types/flat": "catalog:"
   },
   "peerDependencies": {

--- a/packages/from-to-location-picker/package.json
+++ b/packages/from-to-location-picker/package.json
@@ -9,11 +9,11 @@
   "module": "esm/index.js",
   "private": false,
   "dependencies": {
-    "@opentripplanner/location-icon": "workspace:*",
+    "@opentripplanner/location-icon": "workspace:^",
     "flat": "catalog:"
   },
   "devDependencies": {
-    "@opentripplanner/types": "workspace:*"
+    "@opentripplanner/types": "workspace:^"
   },
   "peerDependencies": {
     "react": "catalog:",

--- a/packages/humanize-distance/package.json
+++ b/packages/humanize-distance/package.json
@@ -14,7 +14,7 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "@opentripplanner/types": "workspace:*"
+    "@opentripplanner/types": "workspace:^"
   },
   "peerDependencies": {
     "react": "catalog:",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "workspace:*",
+    "@opentripplanner/core-utils": "workspace:^",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/itinerary-body/package.json
+++ b/packages/itinerary-body/package.json
@@ -10,11 +10,11 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/building-blocks": "workspace:*",
-    "@opentripplanner/core-utils": "workspace:*",
-    "@opentripplanner/humanize-distance": "workspace:*",
-    "@opentripplanner/icons": "workspace:*",
-    "@opentripplanner/location-icon": "workspace:*",
+    "@opentripplanner/building-blocks": "workspace:^",
+    "@opentripplanner/core-utils": "workspace:^",
+    "@opentripplanner/humanize-distance": "workspace:^",
+    "@opentripplanner/icons": "workspace:^",
+    "@opentripplanner/location-icon": "workspace:^",
     "@styled-icons/fa-solid": "catalog:",
     "@styled-icons/foundation": "catalog:",
     "date-fns": "catalog:",
@@ -25,7 +25,7 @@
     "string-similarity": "^4.0.4"
   },
   "devDependencies": {
-    "@opentripplanner/types": "workspace:*",
+    "@opentripplanner/types": "workspace:^",
     "@types/flat": "catalog:"
   },
   "peerDependencies": {

--- a/packages/location-field/package.json
+++ b/packages/location-field/package.json
@@ -10,16 +10,16 @@
   "private": false,
   "dependencies": {
     "@conveyal/geocoder-arcgis-geojson": "^0.0.3",
-    "@opentripplanner/core-utils": "workspace:*",
-    "@opentripplanner/geocoder": "workspace:*",
-    "@opentripplanner/humanize-distance": "workspace:*",
-    "@opentripplanner/location-icon": "workspace:*",
+    "@opentripplanner/core-utils": "workspace:^",
+    "@opentripplanner/geocoder": "workspace:^",
+    "@opentripplanner/humanize-distance": "workspace:^",
+    "@opentripplanner/location-icon": "workspace:^",
     "@styled-icons/fa-solid": "catalog:",
     "@tanstack/react-pacer": "^0.8.0",
     "flat": "catalog:"
   },
   "devDependencies": {
-    "@opentripplanner/types": "workspace:*"
+    "@opentripplanner/types": "workspace:^"
   },
   "peerDependencies": {
     "react": "catalog:",

--- a/packages/map-popup/package.json
+++ b/packages/map-popup/package.json
@@ -11,14 +11,14 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/base-map": "workspace:*",
-    "@opentripplanner/building-blocks": "workspace:*",
-    "@opentripplanner/core-utils": "workspace:*",
-    "@opentripplanner/from-to-location-picker": "workspace:*",
+    "@opentripplanner/base-map": "workspace:^",
+    "@opentripplanner/building-blocks": "workspace:^",
+    "@opentripplanner/core-utils": "workspace:^",
+    "@opentripplanner/from-to-location-picker": "workspace:^",
     "flat": "catalog:"
   },
   "devDependencies": {
-    "@opentripplanner/types": "workspace:*"
+    "@opentripplanner/types": "workspace:^"
   },
   "peerDependencies": {
     "react": "catalog:",

--- a/packages/otp2-tile-overlay/package.json
+++ b/packages/otp2-tile-overlay/package.json
@@ -16,11 +16,11 @@
     "react-map-gl": "catalog:"
   },
   "dependencies": {
-    "@opentripplanner/map-popup": "workspace:*"
+    "@opentripplanner/map-popup": "workspace:^"
   },
   "devDependencies": {
-    "@opentripplanner/base-map": "workspace:*",
-    "@opentripplanner/types": "workspace:*",
+    "@opentripplanner/base-map": "workspace:^",
+    "@opentripplanner/types": "workspace:^",
     "maplibre-gl": "catalog:"
   }
 }

--- a/packages/park-and-ride-overlay/package.json
+++ b/packages/park-and-ride-overlay/package.json
@@ -19,9 +19,9 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "workspace:*",
-    "@opentripplanner/from-to-location-picker": "workspace:*",
-    "@opentripplanner/types": "workspace:*"
+    "@opentripplanner/base-map": "workspace:^",
+    "@opentripplanner/from-to-location-picker": "workspace:^",
+    "@opentripplanner/types": "workspace:^"
   },
   "peerDependencies": {
     "react": "catalog:",

--- a/packages/printable-itinerary/package.json
+++ b/packages/printable-itinerary/package.json
@@ -10,13 +10,13 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "workspace:*",
-    "@opentripplanner/itinerary-body": "workspace:*",
+    "@opentripplanner/core-utils": "workspace:^",
+    "@opentripplanner/itinerary-body": "workspace:^",
     "flat": "catalog:"
   },
   "devDependencies": {
-    "@opentripplanner/icons": "workspace:*",
-    "@opentripplanner/types": "workspace:*"
+    "@opentripplanner/icons": "workspace:^",
+    "@opentripplanner/types": "workspace:^"
   },
   "peerDependencies": {
     "react": "catalog:",

--- a/packages/route-viewer-overlay/package.json
+++ b/packages/route-viewer-overlay/package.json
@@ -20,12 +20,12 @@
   },
   "dependencies": {
     "@mapbox/polyline": "catalog:",
-    "@opentripplanner/base-map": "workspace:*",
-    "@opentripplanner/core-utils": "workspace:*",
+    "@opentripplanner/base-map": "workspace:^",
+    "@opentripplanner/core-utils": "workspace:^",
     "point-in-polygon": "^1.1.0"
   },
   "devDependencies": {
-    "@opentripplanner/types": "workspace:*",
+    "@opentripplanner/types": "workspace:^",
     "point-in-polygon": "^1.1.0"
   },
   "peerDependencies": {

--- a/packages/stop-viewer-overlay/package.json
+++ b/packages/stop-viewer-overlay/package.json
@@ -19,11 +19,11 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "workspace:*",
-    "@opentripplanner/core-utils": "workspace:*"
+    "@opentripplanner/base-map": "workspace:^",
+    "@opentripplanner/core-utils": "workspace:^"
   },
   "devDependencies": {
-    "@opentripplanner/types": "workspace:*"
+    "@opentripplanner/types": "workspace:^"
   },
   "peerDependencies": {
     "react": "catalog:",

--- a/packages/stops-overlay/package.json
+++ b/packages/stops-overlay/package.json
@@ -19,13 +19,13 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "workspace:*",
-    "@opentripplanner/from-to-location-picker": "workspace:*",
-    "@opentripplanner/map-popup": "workspace:*",
+    "@opentripplanner/base-map": "workspace:^",
+    "@opentripplanner/from-to-location-picker": "workspace:^",
+    "@opentripplanner/map-popup": "workspace:^",
     "flat": "catalog:"
   },
   "devDependencies": {
-    "@opentripplanner/types": "workspace:*",
+    "@opentripplanner/types": "workspace:^",
     "styled-icons": "catalog:"
   },
   "peerDependencies": {

--- a/packages/transit-vehicle-overlay/package.json
+++ b/packages/transit-vehicle-overlay/package.json
@@ -9,14 +9,14 @@
   "module": "esm/index.js",
   "private": false,
   "dependencies": {
-    "@opentripplanner/base-map": "workspace:*",
-    "@opentripplanner/core-utils": "workspace:*",
-    "@opentripplanner/icons": "workspace:*",
+    "@opentripplanner/base-map": "workspace:^",
+    "@opentripplanner/core-utils": "workspace:^",
+    "@opentripplanner/icons": "workspace:^",
     "flat": "catalog:",
     "lodash.memoize": "^4.1.2"
   },
   "devDependencies": {
-    "@opentripplanner/types": "workspace:*"
+    "@opentripplanner/types": "workspace:^"
   },
   "peerDependencies": {
     "react": "catalog:",

--- a/packages/transitive-overlay/package.json
+++ b/packages/transitive-overlay/package.json
@@ -20,9 +20,9 @@
   },
   "dependencies": {
     "@mapbox/polyline": "catalog:",
-    "@opentripplanner/building-blocks": "workspace:*",
-    "@opentripplanner/core-utils": "workspace:*",
-    "@opentripplanner/itinerary-body": "workspace:*",
+    "@opentripplanner/building-blocks": "workspace:^",
+    "@opentripplanner/core-utils": "workspace:^",
+    "@opentripplanner/itinerary-body": "workspace:^",
     "@turf/bbox": "^6.5.0",
     "@turf/bearing": "^6.5.0",
     "@turf/destination": "^6.5.0",
@@ -32,12 +32,12 @@
     "lodash.isequal": "^4.5.0"
   },
   "devDependencies": {
-    "@opentripplanner/endpoints-overlay": "workspace:*",
-    "@opentripplanner/types": "workspace:*",
+    "@opentripplanner/endpoints-overlay": "workspace:^",
+    "@opentripplanner/types": "workspace:^",
     "maplibre-gl": "catalog:"
   },
   "peerDependencies": {
-    "@opentripplanner/base-map": "workspace:*",
+    "@opentripplanner/base-map": "workspace:^",
     "react": "catalog:",
     "react-map-gl": "catalog:"
   }

--- a/packages/trip-details/package.json
+++ b/packages/trip-details/package.json
@@ -11,14 +11,14 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@opentripplanner/core-utils": "workspace:*",
+    "@opentripplanner/core-utils": "workspace:^",
     "@styled-icons/boxicons-regular": "^10.47.0",
     "@styled-icons/fa-solid": "catalog:",
     "flat": "catalog:",
     "react-animate-height": "catalog:"
   },
   "devDependencies": {
-    "@opentripplanner/types": "workspace:*"
+    "@opentripplanner/types": "workspace:^"
   },
   "peerDependencies": {
     "react": "catalog:",

--- a/packages/trip-form/package.json
+++ b/packages/trip-form/package.json
@@ -10,9 +10,9 @@
   "types": "lib/index.d.ts",
   "private": false,
   "dependencies": {
-    "@opentripplanner/building-blocks": "workspace:*",
-    "@opentripplanner/core-utils": "workspace:*",
-    "@opentripplanner/icons": "workspace:*",
+    "@opentripplanner/building-blocks": "workspace:^",
+    "@opentripplanner/core-utils": "workspace:^",
+    "@opentripplanner/icons": "workspace:^",
     "@styled-icons/bootstrap": "catalog:",
     "@styled-icons/boxicons-regular": "^10.38.0",
     "@styled-icons/fa-regular": "^10.37.0",
@@ -25,7 +25,7 @@
     "react-inlinesvg": "^2.3.0"
   },
   "devDependencies": {
-    "@opentripplanner/types": "workspace:*",
+    "@opentripplanner/types": "workspace:^",
     "@types/flat": "catalog:",
     "lodash.clonedeep": "^4.5.0"
   },

--- a/packages/trip-viewer-overlay/package.json
+++ b/packages/trip-viewer-overlay/package.json
@@ -20,10 +20,10 @@
   },
   "dependencies": {
     "@mapbox/polyline": "catalog:",
-    "@opentripplanner/core-utils": "workspace:*"
+    "@opentripplanner/core-utils": "workspace:^"
   },
   "peerDependencies": {
-    "@opentripplanner/base-map": "workspace:*",
+    "@opentripplanner/base-map": "workspace:^",
     "react": "catalog:",
     "react-map-gl": "catalog:"
   },

--- a/packages/vehicle-rental-overlay/package.json
+++ b/packages/vehicle-rental-overlay/package.json
@@ -19,16 +19,16 @@
     "url": "git+https://github.com/opentripplanner/otp-ui.git"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "workspace:*",
-    "@opentripplanner/core-utils": "workspace:*",
-    "@opentripplanner/from-to-location-picker": "workspace:*",
-    "@opentripplanner/map-popup": "workspace:*",
+    "@opentripplanner/base-map": "workspace:^",
+    "@opentripplanner/core-utils": "workspace:^",
+    "@opentripplanner/from-to-location-picker": "workspace:^",
+    "@opentripplanner/map-popup": "workspace:^",
     "@styled-icons/fa-solid": "catalog:",
     "flat": "catalog:",
     "lodash.memoize": "^4.1.2"
   },
   "devDependencies": {
-    "@opentripplanner/types": "workspace:*"
+    "@opentripplanner/types": "workspace:^"
   },
   "peerDependencies": {
     "react": "catalog:",

--- a/packages/zoom-based-markers/package.json
+++ b/packages/zoom-based-markers/package.json
@@ -19,13 +19,13 @@
     "url": "https://github.com/opentripplanner/otp-ui/issues"
   },
   "dependencies": {
-    "@opentripplanner/base-map": "workspace:*",
-    "@opentripplanner/core-utils": "workspace:*",
-    "@opentripplanner/icons": "workspace:*",
+    "@opentripplanner/base-map": "workspace:^",
+    "@opentripplanner/core-utils": "workspace:^",
+    "@opentripplanner/icons": "workspace:^",
     "lodash.clonedeep": "^4.5.0"
   },
   "devDependencies": {
-    "@opentripplanner/types": "workspace:*"
+    "@opentripplanner/types": "workspace:^"
   },
   "peerDependencies": {
     "react": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,10 +328,10 @@ importers:
   packages/base-map:
     dependencies:
       '@opentripplanner/building-blocks':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../building-blocks
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
       maplibre-gl:
         specifier: 'catalog:'
@@ -362,10 +362,10 @@ importers:
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
     devDependencies:
       '@opentripplanner/core-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core-utils
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
 
   packages/core-utils:
@@ -377,7 +377,7 @@ importers:
         specifier: 'catalog:'
         version: 1.2.1
       '@opentripplanner/geocoder':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../geocoder
       '@styled-icons/foundation':
         specifier: 'catalog:'
@@ -405,7 +405,7 @@ importers:
         version: 6.14.0
     devDependencies:
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
       '@types/chroma-js':
         specifier: ^3.1.2
@@ -417,16 +417,16 @@ importers:
   packages/endpoints-overlay:
     dependencies:
       '@opentripplanner/base-map':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../base-map
       '@opentripplanner/building-blocks':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../building-blocks
       '@opentripplanner/core-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core-utils
       '@opentripplanner/location-icon':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../location-icon
       '@styled-icons/fa-solid':
         specifier: 'catalog:'
@@ -451,7 +451,7 @@ importers:
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
     devDependencies:
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
       '@types/flat':
         specifier: 'catalog:'
@@ -460,7 +460,7 @@ importers:
   packages/from-to-location-picker:
     dependencies:
       '@opentripplanner/location-icon':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../location-icon
       flat:
         specifier: 'catalog:'
@@ -476,7 +476,7 @@ importers:
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
     devDependencies:
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
 
   packages/geocoder:
@@ -507,13 +507,13 @@ importers:
         version: 6.8.4(react@18.2.0)(typescript@5.9.3)
     devDependencies:
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
 
   packages/icons:
     dependencies:
       '@opentripplanner/core-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core-utils
       prop-types:
         specifier: ^15.7.2
@@ -525,19 +525,19 @@ importers:
   packages/itinerary-body:
     dependencies:
       '@opentripplanner/building-blocks':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../building-blocks
       '@opentripplanner/core-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core-utils
       '@opentripplanner/humanize-distance':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../humanize-distance
       '@opentripplanner/icons':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../icons
       '@opentripplanner/location-icon':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../location-icon
       '@styled-icons/fa-solid':
         specifier: 'catalog:'
@@ -571,7 +571,7 @@ importers:
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
     devDependencies:
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
       '@types/flat':
         specifier: 'catalog:'
@@ -583,16 +583,16 @@ importers:
         specifier: ^0.0.3
         version: 0.0.3(eslint-plugin-react@7.14.3(eslint@7.32.0))(eslint@7.32.0)
       '@opentripplanner/core-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core-utils
       '@opentripplanner/geocoder':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../geocoder
       '@opentripplanner/humanize-distance':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../humanize-distance
       '@opentripplanner/location-icon':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../location-icon
       '@styled-icons/fa-solid':
         specifier: 'catalog:'
@@ -614,7 +614,7 @@ importers:
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
     devDependencies:
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
 
   packages/location-icon:
@@ -635,16 +635,16 @@ importers:
   packages/map-popup:
     dependencies:
       '@opentripplanner/base-map':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../base-map
       '@opentripplanner/building-blocks':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../building-blocks
       '@opentripplanner/core-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core-utils
       '@opentripplanner/from-to-location-picker':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../from-to-location-picker
       flat:
         specifier: 'catalog:'
@@ -660,13 +660,13 @@ importers:
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
     devDependencies:
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
 
   packages/otp2-tile-overlay:
     dependencies:
       '@opentripplanner/map-popup':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../map-popup
       react:
         specifier: 'catalog:'
@@ -676,10 +676,10 @@ importers:
         version: 8.0.4(maplibre-gl@5.6.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@opentripplanner/base-map':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../base-map
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
       maplibre-gl:
         specifier: 'catalog:'
@@ -688,13 +688,13 @@ importers:
   packages/park-and-ride-overlay:
     dependencies:
       '@opentripplanner/base-map':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../base-map
       '@opentripplanner/from-to-location-picker':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../from-to-location-picker
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
       react:
         specifier: 'catalog:'
@@ -712,10 +712,10 @@ importers:
   packages/printable-itinerary:
     dependencies:
       '@opentripplanner/core-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core-utils
       '@opentripplanner/itinerary-body':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../itinerary-body
       flat:
         specifier: 'catalog:'
@@ -728,10 +728,10 @@ importers:
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
     devDependencies:
       '@opentripplanner/icons':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../icons
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
 
   packages/route-viewer-overlay:
@@ -740,10 +740,10 @@ importers:
         specifier: 'catalog:'
         version: 1.2.1
       '@opentripplanner/base-map':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../base-map
       '@opentripplanner/core-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core-utils
       point-in-polygon:
         specifier: ^1.1.0
@@ -753,7 +753,7 @@ importers:
         version: 18.2.0
     devDependencies:
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
 
   packages/scripts:
@@ -777,10 +777,10 @@ importers:
   packages/stop-viewer-overlay:
     dependencies:
       '@opentripplanner/base-map':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../base-map
       '@opentripplanner/core-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core-utils
       react:
         specifier: 'catalog:'
@@ -790,19 +790,19 @@ importers:
         version: 8.0.4(maplibre-gl@5.6.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
 
   packages/stops-overlay:
     dependencies:
       '@opentripplanner/base-map':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../base-map
       '@opentripplanner/from-to-location-picker':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../from-to-location-picker
       '@opentripplanner/map-popup':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../map-popup
       flat:
         specifier: 'catalog:'
@@ -821,7 +821,7 @@ importers:
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
     devDependencies:
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
       styled-icons:
         specifier: 'catalog:'
@@ -830,13 +830,13 @@ importers:
   packages/transit-vehicle-overlay:
     dependencies:
       '@opentripplanner/base-map':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../base-map
       '@opentripplanner/core-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core-utils
       '@opentripplanner/icons':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../icons
       flat:
         specifier: 'catalog:'
@@ -858,7 +858,7 @@ importers:
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
     devDependencies:
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
 
   packages/transitive-overlay:
@@ -867,16 +867,16 @@ importers:
         specifier: 'catalog:'
         version: 1.2.1
       '@opentripplanner/base-map':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../base-map
       '@opentripplanner/building-blocks':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../building-blocks
       '@opentripplanner/core-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core-utils
       '@opentripplanner/itinerary-body':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../itinerary-body
       '@turf/bbox':
         specifier: ^6.5.0
@@ -907,10 +907,10 @@ importers:
         version: 8.0.4(maplibre-gl@5.6.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@opentripplanner/endpoints-overlay':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../endpoints-overlay
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
       maplibre-gl:
         specifier: 'catalog:'
@@ -919,7 +919,7 @@ importers:
   packages/trip-details:
     dependencies:
       '@opentripplanner/core-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core-utils
       '@styled-icons/boxicons-regular':
         specifier: ^10.47.0
@@ -944,19 +944,19 @@ importers:
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
     devDependencies:
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
 
   packages/trip-form:
     dependencies:
       '@opentripplanner/building-blocks':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../building-blocks
       '@opentripplanner/core-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core-utils
       '@opentripplanner/icons':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../icons
       '@styled-icons/bootstrap':
         specifier: 'catalog:'
@@ -999,7 +999,7 @@ importers:
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
     devDependencies:
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
       '@types/flat':
         specifier: 'catalog:'
@@ -1014,10 +1014,10 @@ importers:
         specifier: 'catalog:'
         version: 1.2.1
       '@opentripplanner/base-map':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../base-map
       '@opentripplanner/core-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core-utils
       react:
         specifier: 'catalog:'
@@ -1031,16 +1031,16 @@ importers:
   packages/vehicle-rental-overlay:
     dependencies:
       '@opentripplanner/base-map':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../base-map
       '@opentripplanner/core-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core-utils
       '@opentripplanner/from-to-location-picker':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../from-to-location-picker
       '@opentripplanner/map-popup':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../map-popup
       '@styled-icons/fa-solid':
         specifier: 'catalog:'
@@ -1068,19 +1068,19 @@ importers:
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
     devDependencies:
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
 
   packages/zoom-based-markers:
     dependencies:
       '@opentripplanner/base-map':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../base-map
       '@opentripplanner/core-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core-utils
       '@opentripplanner/icons':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../icons
       lodash.clonedeep:
         specifier: ^4.5.0
@@ -1096,7 +1096,7 @@ importers:
         version: 5.3.11(react-dom@18.3.1(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
     devDependencies:
       '@opentripplanner/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
 
 packages:


### PR DESCRIPTION
This changes all internal dependencies to use workspace:^ instead of *, which will allow them more flexibility in the version number they use for better deduplication. 