### PR TITLE
fix(offline gecoder): support unicode

### DIFF
--- a/packages/geocoder/src/apis/offline/index.test.js
+++ b/packages/geocoder/src/apis/offline/index.test.js
@@ -15,15 +15,40 @@ const baseItems = [
   },
   { label: "Pioneer Courthouse Square", lat: 45.5189, lon: -122.6798 },
   {
-    label: "Portland State University",
+    label: "Portland State Üniversity",
     lat: 45.5118,
     lon: -122.6825,
-    synonyms: ["PSU"]
+    synonyms: ["PSÜ"]
   },
   { label: "Multnomah Falls", lat: 45.5762, lon: -122.1156, synonyms: [] }
 ];
 
 describe("offline geocoder", () => {
+  describe("unicode support", () => {
+    it("should find item that has unicode in its synonym", async () => {
+      const result = await autocomplete({ items: baseItems, text: "PSÜ" });
+      expect(result).toContainEqual(baseItems[3]);
+    });
+    it("should find item that has unicode in its synonym with non unicode search", async () => {
+      const result = await autocomplete({ items: baseItems, text: "PSU" });
+      expect(result).toContainEqual(baseItems[3]);
+    });
+
+    it("should find item that has unicode in its title", async () => {
+      const result = await autocomplete({
+        items: baseItems,
+        text: "Üniversity"
+      });
+      expect(result).toContainEqual(baseItems[3]);
+    });
+    it("should find item that has unicode in its title with non unicode search", async () => {
+      const result = await autocomplete({
+        items: baseItems,
+        text: "University"
+      });
+      expect(result).toContainEqual(baseItems[3]);
+    });
+  });
   describe("synonym support", () => {
     it("should find item by synonym", async () => {
       const result = await autocomplete({ items: baseItems, text: "PDX" });

--- a/packages/geocoder/src/apis/offline/index.test.js
+++ b/packages/geocoder/src/apis/offline/index.test.js
@@ -11,7 +11,7 @@ const baseItems = [
     label: "Union Station",
     lat: 45.528,
     lon: -122.673,
-    synonyms: ["Train Station"]
+    synonyms: ["Train Station", "عُود"]
   },
   { label: "Pioneer Courthouse Square", lat: 45.5189, lon: -122.6798 },
   {
@@ -47,6 +47,19 @@ describe("offline geocoder", () => {
         text: "University"
       });
       expect(result).toContainEqual(baseItems[3]);
+    });
+    it("should find item that has non-latinizable string in its synonyms", async () => {
+      const resultWithUnicodeOff = await autocomplete({
+        items: baseItems,
+        text: "عُود"
+      });
+      const resultWithUnicodeOn = await autocomplete({
+        items: baseItems,
+        text: "عُود",
+        enableSlowFullUnicodeSupport: true
+      });
+      expect(resultWithUnicodeOff).toEqual([]);
+      expect(resultWithUnicodeOn).toContainEqual(baseItems[1]);
     });
   });
   describe("synonym support", () => {

--- a/packages/geocoder/src/apis/offline/index.ts
+++ b/packages/geocoder/src/apis/offline/index.ts
@@ -35,11 +35,11 @@ async function autocomplete({
   // Add synonyms to full list
   // TODO: can this be done in a cleaner way?
   items.forEach((item, idx) => {
-    itemsWithSynonyms.push(item.label);
+    itemsWithSynonyms.push(uFuzzy.latinize(item.label));
     synonymIndicies.push(idx);
     if (item?.synonyms) {
       item.synonyms.forEach(synonym => {
-        itemsWithSynonyms.push(synonym);
+        itemsWithSynonyms.push(uFuzzy.latinize(synonym));
         synonymIndicies.push(idx);
       });
     }
@@ -48,7 +48,7 @@ async function autocomplete({
   // eslint-disable-next-line new-cap
   const u = new uFuzzy();
 
-  const idxs = u.filter(itemsWithSynonyms, text);
+  const idxs = u.filter(itemsWithSynonyms, uFuzzy.latinize(text));
 
   return Array.from(new Set(idxs.map(index => items[synonymIndicies[index]])));
 }

--- a/packages/geocoder/src/apis/offline/index.ts
+++ b/packages/geocoder/src/apis/offline/index.ts
@@ -14,6 +14,7 @@ export type OfflineResponse = {
 type OfflineQuery = {
   items: OfflineResponse;
   text?: string;
+  enableSlowFullUnicodeSupport?: boolean;
 };
 /**
  * Search for an address using offline geocoder
@@ -25,7 +26,8 @@ type OfflineQuery = {
  */
 async function autocomplete({
   items,
-  text
+  text,
+  enableSlowFullUnicodeSupport
 }: OfflineQuery): Promise<OfflineResponse> {
   if (!text) return [];
 
@@ -46,11 +48,22 @@ async function autocomplete({
   });
 
   // eslint-disable-next-line new-cap
-  const u = new uFuzzy();
+  const u = new uFuzzy(
+    enableSlowFullUnicodeSupport
+      ? {
+          unicode: true,
+          interSplit: "[^\\p{L}\\d']+",
+          intraSplit: "\\p{Ll}\\p{Lu}",
+          intraBound: "\\p{L}\\d|\\d\\p{L}|\\p{Ll}\\p{Lu}",
+          intraChars: "[\\p{L}\\d']",
+          intraContr: "'\\p{L}{1,2}\\b"
+        }
+      : {}
+  );
 
   const idxs = u.filter(itemsWithSynonyms, uFuzzy.latinize(text));
 
-  return Array.from(new Set(idxs.map(index => items[synonymIndicies[index]])));
+  return Array.from(new Set(idxs?.map(index => items[synonymIndicies[index]])));
 }
 
 function search(args: OfflineQuery): Promise<OfflineResponse> {

--- a/packages/geocoder/src/geocoders/offline.ts
+++ b/packages/geocoder/src/geocoders/offline.ts
@@ -5,21 +5,25 @@ import type { AutocompleteQuery, SearchQuery } from "..";
 import { MultiGeocoderResponse } from "./types";
 import { OfflineResponse } from "../apis/offline";
 
+type OfflineQueryExtras = { enableSlowFullUnicodeSupport?: boolean }
+
 /**
  * Geocoder implementation for an offline geocoder.
  *
  * @extends Geocoder
  */
 export default class OfflineGeocoder extends Geocoder {
-  getAutocompleteQuery(query: AutocompleteQuery): AutocompleteQuery {
+  getAutocompleteQuery(query: AutocompleteQuery): AutocompleteQuery & OfflineQueryExtras  {
     return {
-      ...query
+      ...query,
+      enableSlowFullUnicodeSupport: this.geocoderConfig.enableSlowFullUnicodeSupport
     };
   }
 
-  getSearchQuery(query: SearchQuery): SearchQuery {
+  getSearchQuery(query: SearchQuery): SearchQuery & OfflineQueryExtras {
     return {
-      ...query
+      ...query,
+      enableSlowFullUnicodeSupport: this.geocoderConfig.enableSlowFullUnicodeSupport
     };
   }
 

--- a/packages/geocoder/src/geocoders/types.ts
+++ b/packages/geocoder/src/geocoders/types.ts
@@ -27,6 +27,7 @@ export type GeocoderConfig = {
   sources?: string;
   size?: number;
   reverseUseFeatureCollection?: boolean;
+  enableSlowFullUnicodeSupport?: boolean
 };
 
 export type ReverseQuery = {

--- a/packages/geocoder/src/geocoders/types.ts
+++ b/packages/geocoder/src/geocoders/types.ts
@@ -27,7 +27,7 @@ export type GeocoderConfig = {
   sources?: string;
   size?: number;
   reverseUseFeatureCollection?: boolean;
-  enableSlowFullUnicodeSupport?: boolean
+  enableSlowFullUnicodeSupport?: boolean;
 };
 
 export type ReverseQuery = {


### PR DESCRIPTION
Latinizes both search strings and data. This is because uFuzzy is much faster with latin characters only.