### PR TITLE
feat(itinerary-body): Add leg prop to PlaceName

### DIFF
--- a/packages/itinerary-body/src/ItineraryBody/place-row.tsx
+++ b/packages/itinerary-body/src/ItineraryBody/place-row.tsx
@@ -26,7 +26,7 @@ function getLegPlaceName(
   const interline = !!(!isDestination && leg.interlineWithPreviousLeg);
   const place = isDestination ? { ...leg.to } : { ...leg.from };
   const placeName = (
-    <PlaceName config={config} interline={interline} place={place} />
+    <PlaceName config={config} interline={interline} leg={leg} place={place} />
   );
 
   return {
@@ -95,7 +95,7 @@ export default function PlaceRow({
     placeName: nextPlaceName = undefined
   } = nextLeg ? getLegPlaceName(nextLeg, false, PlaceName, config) : {};
   const legDestination = nextPlaceName || (
-    <PlaceName config={config} place={leg.to} />
+    <PlaceName config={config} leg={leg} place={leg.to} />
   );
 
   // OTP2 marks both bikes and scooters as BIKESHARE in the vertextype

--- a/packages/itinerary-body/src/defaults/place-name.tsx
+++ b/packages/itinerary-body/src/defaults/place-name.tsx
@@ -10,11 +10,17 @@ import BasicPlaceName from "./basic-place-name";
 export default function PlaceName({
   config,
   interline,
+  leg,
   place
 }: PlaceNameProps): ReactElement {
   return (
     <>
-      <BasicPlaceName config={config} interline={interline} place={place} />
+      <BasicPlaceName
+        config={config}
+        interline={interline}
+        leg={leg}
+        place={place}
+      />
 
       {/* TODO: take another pass on this when working the Transit Leg */}
       {/* Place subheading: Transit stop */}

--- a/packages/itinerary-body/src/types.ts
+++ b/packages/itinerary-body/src/types.ts
@@ -64,6 +64,7 @@ export interface LineColumnContentProps extends LegSharedProps {
 export interface PlaceNameProps {
   config: Config;
   interline?: boolean;
+  leg: Leg;
   place: Place;
 }
 


### PR DESCRIPTION
Add `leg` as a required prop to the `PlaceName` component, which is accepted as a prop by `ItineraryBody`

Including `leg` provides additional context about the place being rendered and enables more flexibility in how `PlaceName` determines its output

For example, when an itinerary includes a same-stop transfer, an identical value is passed to `PlaceName` under its `place` prop for the transfer walking leg and the subsequent transit leg. Passing the `leg` provides a way to differentiate what should be displayed for each case