### PR TITLE
feat - Add aria-disabled to location field

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,8 +124,8 @@
     "typescript": "lerna run tsc",
     "unit": "jest",
     "test-storybook": "test-storybook --url http://localhost:5555",
-    "update-snapshots": "pnpm build-storybook; npx concurrently -k -s first -n \"SB,TEST\" \"npx http-server storybook-static --port 5555 --silent\" \"npx wait-on tcp:5555 && pnpm test-storybook --url http://localhost:5555 -u\"",
-    "test-snapshots": "npx concurrently -k -s first -n \"SB,TEST\" \"npx http-server storybook-static --port 5555 --silent\" \"npx wait-on tcp:5555 && pnpm test-storybook --url http://localhost:5555\"",
+    "update-snapshots": "pnpm build-storybook; pnpx concurrently -k -s first -n \"SB,TEST\" \"pnpx http-server storybook-static --port 5555 --silent\" \"pnpx wait-on tcp:5555 && pnpm test-storybook --url http://localhost:5555 -u\"",
+    "test-snapshots": "pnpx concurrently -k -s first -n \"SB,TEST\" \"pnpx http-server storybook-static --port 5555 --silent\" \"pnpx wait-on tcp:5555 && pnpm test-storybook --url http://localhost:5555\"",
     "pack-all": "pnpm build-all && lerna exec --no-private -- sh ../../scripts/pack-and-extract-single.sh"
   },
   "eslintConfig": {

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -1129,6 +1129,7 @@ const LocationField = ({
         onClick={onDropdownToggle}
         tabIndex={-1}
         type="button"
+        aria-disabled={hasNoEnabledOptions}
       >
         <LocationIconComponent locationType={locationType} />
       </S.DropdownButton>

--- a/packages/location-field/src/stories/__snapshots__/Desktop.story.tsx.snap
+++ b/packages/location-field/src/stories/__snapshots__/Desktop.story.tsx.snap
@@ -16,6 +16,7 @@ exports[`LocationField/Desktop Context AutoFocusWithMultipleControls smoke-test 
             aria-label="Toggle displaying the list of suggested locations"
             tabindex="-1"
             type="button"
+            aria-disabled="false"
             class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
     >
       <svg viewbox="0 0 512 512"
@@ -70,6 +71,7 @@ exports[`LocationField/Desktop Context Blank smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -123,6 +125,7 @@ exports[`LocationField/Desktop Context GeocoderNoResults smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -176,6 +179,7 @@ exports[`LocationField/Desktop Context GeocoderUnreachable smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -229,6 +233,7 @@ exports[`LocationField/Desktop Context HereGeocoder smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -282,6 +287,7 @@ exports[`LocationField/Desktop Context LocationUnavailable smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -342,6 +348,7 @@ exports[`LocationField/Desktop Context NoAutoFocusWithMultipleControls smoke-tes
             aria-label="Toggle displaying the list of suggested locations"
             tabindex="-1"
             type="button"
+            aria-disabled="false"
             class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
     >
       <svg viewbox="0 0 512 512"
@@ -396,6 +403,7 @@ exports[`LocationField/Desktop Context RequiredAndInvalidState smoke-test 1`] = 
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -449,6 +457,7 @@ exports[`LocationField/Desktop Context SelectedLocation smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"
@@ -521,6 +530,7 @@ exports[`LocationField/Desktop Context SelectedLocationCustomClear smoke-test 1`
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"
@@ -593,6 +603,7 @@ exports[`LocationField/Desktop Context SlowGeocoder smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -646,6 +657,7 @@ exports[`LocationField/Desktop Context WithBadApiKeyHandlesBadAutocomplete smoke
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -699,6 +711,7 @@ exports[`LocationField/Desktop Context WithCustomResultColorsAndIcons smoke-test
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -752,6 +765,7 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -1084,6 +1098,7 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -1416,6 +1431,7 @@ exports[`LocationField/Desktop Context WithUserSettings smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"

--- a/packages/location-field/src/stories/__snapshots__/Mobile.story.tsx.snap
+++ b/packages/location-field/src/stories/__snapshots__/Mobile.story.tsx.snap
@@ -9,6 +9,7 @@ exports[`LocationField/Mobile Context Blank smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -91,6 +92,7 @@ exports[`LocationField/Mobile Context GeocoderNoResults smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -173,6 +175,7 @@ exports[`LocationField/Mobile Context GeocoderUnreachable smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -255,6 +258,7 @@ exports[`LocationField/Mobile Context LocationUnavailable smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -339,6 +343,7 @@ exports[`LocationField/Mobile Context SelectedLocation smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"
@@ -440,6 +445,7 @@ exports[`LocationField/Mobile Context SelectedLocationCustomClear smoke-test 1`]
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"
@@ -541,6 +547,7 @@ exports[`LocationField/Mobile Context SlowGeocoder smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -623,6 +630,7 @@ exports[`LocationField/Mobile Context Styled smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -705,6 +713,7 @@ exports[`LocationField/Mobile Context WithCustomIcons smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 640 512"
@@ -1019,6 +1028,7 @@ exports[`LocationField/Mobile Context WithNearbyStops smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"
@@ -1182,6 +1192,7 @@ exports[`LocationField/Mobile Context WithSessionSearches smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"
@@ -1296,6 +1307,7 @@ exports[`LocationField/Mobile Context WithUserSettings smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"


### PR DESCRIPTION
Specifically on Mac OS Safari 26.3 w/ VoiceOver and IOS Devices on 26.3 with Voiceover 

we are getting an issue with the Location Field Icon itself 

```When there are no search suggestions, the toggle element is not identified as dimmed or unavailable.```

<img width="903" height="397" alt="image" src="https://github.com/user-attachments/assets/b25fd4a4-c046-41ff-992f-053bfc9e71af" />

<img width="3026" height="2040" alt="752a5288-a3dc-44dc-895d-01ecc84078ca" src="https://github.com/user-attachments/assets/cd629a04-57e5-42a8-9490-de8d04535b74" />

By adding an aria-disabled this would help 

Also fixing the Package.json file script for update-snapshots and test-snapshots they were using npx while the Github CI was using pnpx so was asked if i could make the change 

