### PR TITLE
Fix Pelias Options

### DIFF
--- a/packages/geocoder/src/geocoders/pelias.ts
+++ b/packages/geocoder/src/geocoders/pelias.ts
@@ -32,18 +32,22 @@ export default class PeliasGeocoder extends Geocoder {
       options,
       sources
     } = this.geocoderConfig;
+    const combinedOptions = {
+      ...options,
+      ...query.options
+    }
     return {
       apiKey,
       boundary,
       focusPoint,
       layers,
-      options,
       // explicitly send over null for sources if provided sources is not truthy
       // in order to avoid default isomorphic-mapzen-search sources form being
       // applied
       sources: sources || null,
       url: baseUrl ? `${baseUrl}/autocomplete` : undefined,
-      ...query
+      ...query,
+      options: combinedOptions
     };
   }
 

--- a/packages/geocoder/src/geocoders/pelias.ts
+++ b/packages/geocoder/src/geocoders/pelias.ts
@@ -67,19 +67,23 @@ export default class PeliasGeocoder extends Geocoder {
       options,
       sources
     } = this.geocoderConfig;
+    const combinedOptions = {
+      ...options,
+      ...query.options
+    }
     return {
       apiKey,
       boundary,
       layers,
       focusPoint,
-      options,
       // explicitly send over null for sources if provided sources is not truthy
       // in order to avoid default isomorphic-mapzen-search sources form being
       // applied
       sources: sources || null,
       url: baseUrl ? `${baseUrl}/search` : undefined,
       format: false, // keep as returned GeoJSON,
-      ...query
+      ...query,
+      options: combinedOptions
     };
   }
 

--- a/packages/geocoder/src/geocoders/types.ts
+++ b/packages/geocoder/src/geocoders/types.ts
@@ -48,7 +48,7 @@ export type AutocompleteQuery = {
   layers?: string;
   options?: RequestInit;
   size?: number;
-  sources?: string;
+  sources?: string | null;
   text?: string;
   url?: string;
 };
@@ -63,7 +63,7 @@ export type SearchQuery = {
   size?: number;
   text?: string;
   url?: string;
-  sources?: string;
+  sources?: string | null;
 };
 
 export type AnyGeocoderQuery = SearchQuery & AutocompleteQuery & ReverseQuery;

--- a/packages/geocoder/src/index.test.js
+++ b/packages/geocoder/src/index.test.js
@@ -310,6 +310,26 @@ describe("geocoder", () => {
           });
           pelias.search({ text: "Mill Ends" });
         });
+        // Forward headers defined in config
+        it("should forward headers defined in config", () => {
+          // create mock API to check query
+          const mockPeliasAPI = {
+            autocomplete: query => {
+              expect(query.options.headers).not.toBeFalsy();
+              expect(query.options.headers["x-api-key"]).toEqual("key12345");
+              return Promise.resolve();
+            }
+          };
+          const pelias = new PeliasGeocoder(mockPeliasAPI, {
+            ...geocoder,
+            options: {
+              headers: {
+                "x-api-key": "key12345"
+              }
+            }
+          });
+          pelias.autocomplete({ options: { signal: {} }, text: "Mill Ends" });
+        });
       }
     });
   });

--- a/packages/geocoder/src/index.test.js
+++ b/packages/geocoder/src/index.test.js
@@ -312,13 +312,16 @@ describe("geocoder", () => {
         });
         // Forward headers defined in config
         it("should forward headers defined in config", () => {
+          const headerCheck = query => {
+            const { headers } = query.options;
+            expect(headers).not.toBeFalsy();
+            expect(headers["x-api-key"]).toEqual("key12345");
+            return Promise.resolve();
+          };
           // create mock API to check query
           const mockPeliasAPI = {
-            autocomplete: query => {
-              expect(query.options.headers).not.toBeFalsy();
-              expect(query.options.headers["x-api-key"]).toEqual("key12345");
-              return Promise.resolve();
-            }
+            autocomplete: headerCheck,
+            search: headerCheck
           };
           const pelias = new PeliasGeocoder(mockPeliasAPI, {
             ...geocoder,
@@ -328,7 +331,9 @@ describe("geocoder", () => {
               }
             }
           });
-          pelias.autocomplete({ options: { signal: {} }, text: "Mill Ends" });
+          const query = { options: { signal: {} }, text: "Mill Ends" };
+          pelias.autocomplete(query);
+          pelias.search(query);
         });
       }
     });


### PR DESCRIPTION
This PR forwards the options (specifically, custom HTTP headers) defined in config to Pelias. I suppose that feature broke when we added the abort signal.
Should we attempt to refactor the autocomplete and search functions? (e.g. extract the common body)?