### PR TITLE
feat(location-field): Option to associate custom label to input

### DIFF
--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -298,6 +298,7 @@ const LocationField = ({
   ],
   getCurrentPosition,
   hideExistingValue = false,
+  idForInputLabel,
   initialSearchResults = null,
   inputPlaceholder = null,
   isRequired = false,
@@ -1062,8 +1063,11 @@ const LocationField = ({
   let menuItemCount = indexedOptionLookup.length;
 
   /** the text input element * */
-  // Use this text for aria-label below.
-  const defaultPlaceholder = inputPlaceholder || locationType;
+  // Use this text for aria-label below if no user-provided label.
+  const defaultPlaceholder = idForInputLabel
+    ? inputPlaceholder || undefined
+    : inputPlaceholder || locationType;
+  const ariaLabel = idForInputLabel ? undefined : defaultPlaceholder;
   const placeholder =
     currentPosition && currentPosition.fetching
       ? intl.formatMessage({ id: "otpUi.LocationField.fetchingLocation" })
@@ -1081,10 +1085,11 @@ const LocationField = ({
       aria-expanded={isExpanded}
       aria-haspopup="listbox"
       aria-invalid={!isValid}
-      aria-label={defaultPlaceholder}
+      aria-label={ariaLabel}
       aria-required={isRequired}
       autoFocus={autoFocus}
       className={formControlClassname}
+      id={idForInputLabel}
       onChange={onTextInputChange}
       onClick={handleTextInputClick}
       onBlur={onFieldBlur}

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -298,7 +298,7 @@ const LocationField = ({
   ],
   getCurrentPosition,
   hideExistingValue = false,
-  inputIdForCustomLabel,
+  customLabelInputId,
   initialSearchResults = null,
   inputPlaceholder = null,
   isRequired = false,
@@ -1065,8 +1065,8 @@ const LocationField = ({
   /** the text input element * */
   // Use this text for aria-label below if no user-provided label.
   const defaultPlaceholder =
-    inputPlaceholder || (inputIdForCustomLabel ? undefined : locationType);
-  const ariaLabel = inputIdForCustomLabel ? undefined : defaultPlaceholder;
+    inputPlaceholder || (customLabelInputId ? undefined : locationType);
+  const ariaLabel = customLabelInputId ? undefined : defaultPlaceholder;
   const placeholder =
     currentPosition && currentPosition.fetching
       ? intl.formatMessage({ id: "otpUi.LocationField.fetchingLocation" })
@@ -1088,7 +1088,7 @@ const LocationField = ({
       aria-required={isRequired}
       autoFocus={autoFocus}
       className={formControlClassname}
-      id={inputIdForCustomLabel}
+      id={customLabelInputId}
       onChange={onTextInputChange}
       onClick={handleTextInputClick}
       onBlur={onFieldBlur}

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -298,7 +298,7 @@ const LocationField = ({
   ],
   getCurrentPosition,
   hideExistingValue = false,
-  idForInputLabel,
+  inputIdForCustomLabel,
   initialSearchResults = null,
   inputPlaceholder = null,
   isRequired = false,
@@ -1064,10 +1064,9 @@ const LocationField = ({
 
   /** the text input element * */
   // Use this text for aria-label below if no user-provided label.
-  const defaultPlaceholder = idForInputLabel
-    ? inputPlaceholder || undefined
-    : inputPlaceholder || locationType;
-  const ariaLabel = idForInputLabel ? undefined : defaultPlaceholder;
+  const defaultPlaceholder =
+    inputPlaceholder || (inputIdForCustomLabel ? undefined : locationType);
+  const ariaLabel = inputIdForCustomLabel ? undefined : defaultPlaceholder;
   const placeholder =
     currentPosition && currentPosition.fetching
       ? intl.formatMessage({ id: "otpUi.LocationField.fetchingLocation" })
@@ -1089,7 +1088,7 @@ const LocationField = ({
       aria-required={isRequired}
       autoFocus={autoFocus}
       className={formControlClassname}
-      id={idForInputLabel}
+      id={inputIdForCustomLabel}
       onChange={onTextInputChange}
       onClick={handleTextInputClick}
       onBlur={onFieldBlur}

--- a/packages/location-field/src/stories/Desktop.story.tsx
+++ b/packages/location-field/src/stories/Desktop.story.tsx
@@ -280,3 +280,19 @@ export const WithCustomResultsOrder = {
 
   parameters: a11yOverrideParameters
 };
+
+export const WithCustomLabel = (): JSX.Element => (
+  <>
+    {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+    <label htmlFor="location-field-1">Search location</label>
+    <LocationField
+      currentPosition={currentPosition}
+      geocoderConfig={geocoderConfig}
+      getCurrentPosition={getCurrentPosition}
+      idForInputLabel="location-field-1"
+      inputPlaceholder="Select from location"
+      locationType="from"
+      onLocationSelected={onLocationSelected}
+    />
+  </>
+);

--- a/packages/location-field/src/stories/Desktop.story.tsx
+++ b/packages/location-field/src/stories/Desktop.story.tsx
@@ -289,7 +289,7 @@ export const WithCustomLabel = (): JSX.Element => (
       currentPosition={currentPosition}
       geocoderConfig={geocoderConfig}
       getCurrentPosition={getCurrentPosition}
-      inputIdForCustomLabel="location-field-1"
+      customLabelInputId="location-field-1"
       inputPlaceholder="Select from location"
       locationType="from"
       onLocationSelected={onLocationSelected}

--- a/packages/location-field/src/stories/Desktop.story.tsx
+++ b/packages/location-field/src/stories/Desktop.story.tsx
@@ -289,7 +289,7 @@ export const WithCustomLabel = (): JSX.Element => (
       currentPosition={currentPosition}
       geocoderConfig={geocoderConfig}
       getCurrentPosition={getCurrentPosition}
-      idForInputLabel="location-field-1"
+      inputIdForCustomLabel="location-field-1"
       inputPlaceholder="Select from location"
       locationType="from"
       onLocationSelected={onLocationSelected}

--- a/packages/location-field/src/stories/__snapshots__/Desktop.story.tsx.snap
+++ b/packages/location-field/src/stories/__snapshots__/Desktop.story.tsx.snap
@@ -702,6 +702,62 @@ exports[`LocationField/Desktop Context WithBadApiKeyHandlesBadAutocomplete smoke
 </div>
 `;
 
+exports[`LocationField/Desktop Context WithCustomLabel smoke-test 1`] = `
+<label for="location-field-1">
+  Search location
+</label>
+<div class="styled__InputGroup-sc-xahsq2-7 erfoji"
+     role="group"
+>
+  <button aria-controls="from-listbox"
+          aria-expanded="false"
+          aria-label="Toggle displaying the list of suggested locations"
+          tabindex="-1"
+          type="button"
+          class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
+  >
+    <svg viewbox="0 0 512 512"
+         height="13"
+         width="13"
+         aria-hidden="true"
+         focusable="false"
+         fill="currentColor"
+         xmlns="http://www.w3.org/2000/svg"
+         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__FromIcon-sc-n5xcvc-0 dDqEuj"
+    >
+      <path fill="currentColor"
+            d="M160 256c0-53.9 42.1-96 96-96 53 0 96 42.1 96 96 0 53-43 96-96 96-53.9 0-96-43-96-96zm352 0c0 141.4-114.6 256-256 256S0 397.4 0 256 114.6 0 256 0s256 114.6 256 256zM256 48C141.1 48 48 141.1 48 256s93.1 208 208 208 208-93.1 208-208S370.9 48 256 48z"
+      >
+      </path>
+    </svg>
+  </button>
+  <input aria-autocomplete="list"
+         aria-controls="from-listbox"
+         aria-expanded="false"
+         aria-haspopup="listbox"
+         aria-invalid="false"
+         aria-required="false"
+         class="styled__Input-sc-xahsq2-6 axlAP from-form-control"
+         id="location-field-1"
+         spellcheck="false"
+         placeholder="Select from location"
+         role="combobox"
+         value
+  >
+  <span role="status"
+        class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
+  >
+  </span>
+  <ul aria-hidden="true"
+      aria-label="Suggested locations"
+      id="from-listbox"
+      role="listbox"
+      class="styled__MenuItemList-sc-xahsq2-5 eCrJvo"
+  >
+  </ul>
+</div>
+`;
+
 exports[`LocationField/Desktop Context WithCustomResultColorsAndIcons smoke-test 1`] = `
 <div class="styled__InputGroup-sc-xahsq2-7 erfoji"
      role="group"

--- a/packages/location-field/src/stories/__snapshots__/Desktop.story.tsx.snap
+++ b/packages/location-field/src/stories/__snapshots__/Desktop.story.tsx.snap
@@ -714,6 +714,7 @@ exports[`LocationField/Desktop Context WithCustomLabel smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
+          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"

--- a/packages/location-field/src/types.ts
+++ b/packages/location-field/src/types.ts
@@ -130,9 +130,11 @@ export interface LocationFieldProps {
    */
   hideExistingValue?: boolean;
   /**
-   * Id for input so that custom label can be applied to location field
+   * Id for input so that a custom label can be applied to location field
+   * If this prop is provided, no aria-label will be applied to the field, 
+   * so you must provide a custom label in order for the input to have an accessible name
    */
-  idForInputLabel?: string;
+  inputIdForCustomLabel?: string;
   /**
    * Allows the component to be rendered with pre-filled results
    */

--- a/packages/location-field/src/types.ts
+++ b/packages/location-field/src/types.ts
@@ -134,7 +134,7 @@ export interface LocationFieldProps {
    * If this prop is provided, no aria-label will be applied to the field, 
    * so you must provide a custom label in order for the input to have an accessible name
    */
-  inputIdForCustomLabel?: string;
+  customLabelInputId?: string;
   /**
    * Allows the component to be rendered with pre-filled results
    */

--- a/packages/location-field/src/types.ts
+++ b/packages/location-field/src/types.ts
@@ -130,6 +130,10 @@ export interface LocationFieldProps {
    */
   hideExistingValue?: boolean;
   /**
+   * Id for input so that custom label can be applied to location field
+   */
+  idForInputLabel?: string;
+  /**
    * Allows the component to be rendered with pre-filled results
    */
   initialSearchResults?: {


### PR DESCRIPTION
This PR adds the option to pass an id to the `LocationField` component to allow associating a label to the input. In cases where this id is passed, the `aria-label` that is usually automatically applied using the `placeholder` text is not added in order to prevent violations of [2.5.3 Label in Name](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html).

This change is fully backwards compatible, and anyone not opting in to using the `idForInputLabel` prop will experience no change in behavior. This change is proposed in support of the TriMet code base, where we had longer placeholder text which was cut off when text spacing is adjusted in violation of [1.4.12 Text Spacing](https://www.w3.org/WAI/WCAG22/Understanding/text-spacing.html); this also supports meeting [3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html) as placeholders are not sufficient to act as labels for this SC.


As a side note, it looks to me like you're using the Airbnb eslint preset rules, which is why I had to disable `jsx-a11y/label-has-associated-control` even though the label was correctly associated (y'all have several other places in the codebase with this same rule disabled with a correct association). The Airbnb presets require labels be associated both explicitly AND implicitly, which is why this flags even on a correct explicit association. IMO this is overkill and I override their rule; I prefer for explicit labels though you can also set it to either. Anyway this is just a heads up cause I think the Airbnb setting is unfortunate in a way that encourages people to disable the otherwise good linting rule. 