### PR TITLE
Fix core-utils location parsing

### DIFF
--- a/packages/core-utils/src/__tests__/__snapshots__/query.js.snap
+++ b/packages/core-utils/src/__tests__/__snapshots__/query.js.snap
@@ -263,6 +263,10 @@ exports[`query parseLocationString should return location with coordinates as na
 
 exports[`query parseLocationString should return null for null input 1`] = `null`;
 
+exports[`query parseLocationString should return null with name as name with no coords (but with commas) for input 1`] = `null`;
+
+exports[`query parseLocationString should return null with name as name with no coords for input 1`] = `null`;
+
 exports[`query planParamsToQuery should parse a depart at query 1`] = `
 {
   "bannedRoutes": "897ABC",

--- a/packages/core-utils/src/__tests__/query.js
+++ b/packages/core-utils/src/__tests__/query.js
@@ -218,6 +218,13 @@ describe("query", () => {
         parseLocationString("33.983929829,-87.3892387982")
       ).toMatchSnapshot();
     });
+
+    it("should return null with name as name with no coords for input", () => {
+      expect(parseLocationString("1 cool street")).toMatchSnapshot();
+    });
+    it("should return null with name as name with no coords (but with commas) for input", () => {
+      expect(parseLocationString("148, se street")).toMatchSnapshot();
+    });
   });
 
   describe("planParamsToQuery", () => {

--- a/packages/core-utils/src/query.js
+++ b/packages/core-utils/src/query.js
@@ -247,7 +247,7 @@ async function getFirstGeocodeResult(
     if (firstResult) {
       return geocoder.getLocationFromGeocodedFeature(firstResult);
     }
-    return null;
+    return { name: `(Geocoder failure) ${text}` };
   });
 }
 

--- a/packages/core-utils/src/query.js
+++ b/packages/core-utils/src/query.js
@@ -265,7 +265,7 @@ export function parseLocationString(value) {
     ? stringToCoords(parts[1])
     : stringToCoords(parts[0]);
   const name = parts[1] ? parts[0] : coordsToString(coordinates);
-  return coordinates.length === 2
+  return coordinates.length === 2 && coordinates.every(c => !!c)
     ? {
         name: name || null,
         lat: coordinates[0] || null,


### PR DESCRIPTION
This bug stayed in impressively long! 

But we now make sure that if we are parsing a comma, it's actually a coordinate