### PR TITLE
Timetable: add closed stops

### DIFF
--- a/packages/timetable/src/index.tsx
+++ b/packages/timetable/src/index.tsx
@@ -15,9 +15,10 @@ const TBody = styled.tbody`
   white-space: nowrap;
 `;
 
-const TH = styled.th`
+const TH = styled.th<{ closed?: boolean }>`
   min-width: ${COLUMN_WIDTH};
   padding: 1rem;
+  text-decoration: ${props => (props.closed ? "line-through" : "")};
 `;
 
 const TR = styled.tr`
@@ -25,8 +26,9 @@ const TR = styled.tr`
   vertical-align: middle;
 `;
 
-const TD = styled.td`
+const TD = styled.td<{ closed?: boolean }>`
   padding: 1rem;
+  text-decoration: ${props => (props.closed ? "line-through" : "")};
 `;
 
 interface PatternStop {
@@ -176,6 +178,8 @@ interface TimeTableProps {
   route: Route;
   /** Whether to show only timepoint stops in the timetable */
   timepointsOnly: boolean;
+  /** A set of gtfsId values for stops that are closed and should be shown with strikethrough */
+  closedStops?: Set<string>;
   /** If the topological sort of the stop IDs fails for any reason, a `false` value here
    * will cause the timetable to use a fallback "naive" stop sorting
    */
@@ -194,6 +198,7 @@ interface TimeTableProps {
 
 const TimeTable = (props: TimeTableProps): JSX.Element => {
   const {
+    closedStops,
     directionId,
     errorOnStopSorting,
     includeDwellStops,
@@ -321,7 +326,12 @@ const TimeTable = (props: TimeTableProps): JSX.Element => {
             .concat(filteredPatternStops)
             .map((s, index) => {
               return (
-                <TH className="timetable-th" key={index} scope="col">
+                <TH
+                  className="timetable-th"
+                  key={index}
+                  scope="col"
+                  closed={closedStops && closedStops.has(s.id)}
+                >
                   {s.name}
                 </TH>
               );
@@ -330,11 +340,14 @@ const TimeTable = (props: TimeTableProps): JSX.Element => {
       </thead>
       <TBody className="timetable-tbody">
         {timetableTrips.map((t, index) => {
-          const rowValues: string[] = showBlockId ? [t.blockId] : [];
+          const rowValues: { closed: boolean; value: string }[] = showBlockId
+            ? [{ closed: false, value: t.blockId }]
+            : [];
           filteredPatternStops.forEach(patternStop => {
             const stopDetail = t.stops.get(patternStop.id);
-            rowValues.push(
-              stopDetail
+            rowValues.push({
+              closed: closedStops?.has(patternStop.id) || false,
+              value: stopDetail
                 ? intl
                   ? intl.formatTime(stopDetail.time)
                   : stopDetail.time.toLocaleTimeString("en-us", {
@@ -344,14 +357,14 @@ const TimeTable = (props: TimeTableProps): JSX.Element => {
                       minute: "2-digit"
                     })
                 : "-"
-            );
+            });
           });
 
           return (
             <TR className="timetable-tr" key={index}>
               {rowValues.map((r, rowIndex) => (
-                <TD className="timetable-td" key={rowIndex}>
-                  {r}
+                <TD className="timetable-td" key={rowIndex} closed={r.closed}>
+                  {r.value}
                 </TD>
               ))}
             </TR>

--- a/packages/timetable/src/stories/Timetable.story.tsx
+++ b/packages/timetable/src/stories/Timetable.story.tsx
@@ -1,5 +1,6 @@
 // eslint-disable-next-line prettier/prettier
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import React from "react";
 
 import TimeTable from ".."
 
@@ -7,13 +8,33 @@ import twinCitiesRouteMock from "../../__mocks__/route-mock.json"
 
 const meta = {
     component: TimeTable,
-    title: "Timetable"
+    title: "Timetable",
+    argTypes: {
+        closedStops: {
+            options: ["Grand St NE & 29th Ave NE (Direction: 1)", "46th St & I-35W (Direction: 0)"],
+            control: { type: "check" },
+            mapping: {
+                "Grand St NE & 29th Ave NE (Direction: 1)": "2:14634",
+                "46th St & I-35W (Direction: 0)": "2:53545"
+            }
+        },
+        directionId: {
+            control: { type: "radio" },
+            options: [0, 1]
+        }
+    }
 } satisfies Meta<typeof TimeTable>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+    // eslint-disable-next-line react/display-name
+    render: (args) => {
+        const { closedStops } = args;
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        return <TimeTable {...args} closedStops={new Set(closedStops)} />
+    },
     args: {
         directionId: 0,
         route: twinCitiesRouteMock.data.route,

--- a/packages/timetable/src/stories/__snapshots__/Timetable.story.tsx.snap
+++ b/packages/timetable/src/stories/__snapshots__/Timetable.story.tsx.snap
@@ -6,67 +6,67 @@ exports[`Timetable Default smoke-test 1`] = `
 >
   <thead class="timetable-thead">
     <tr>
-      <th class="src__TH-sc-1glc48y-2 AWHaq timetable-th"
+      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
           scope="col"
       >
         Pleasant Ave &amp; 50th St / Busch Terrace
       </th>
-      <th class="src__TH-sc-1glc48y-2 AWHaq timetable-th"
+      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
           scope="col"
       >
         Nicollet Ave S &amp; 46th St E
       </th>
-      <th class="src__TH-sc-1glc48y-2 AWHaq timetable-th"
+      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
           scope="col"
       >
         46th St &amp; I-35W
       </th>
-      <th class="src__TH-sc-1glc48y-2 AWHaq timetable-th"
+      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
           scope="col"
       >
         4th Ave S &amp; 38th St E
       </th>
-      <th class="src__TH-sc-1glc48y-2 AWHaq timetable-th"
+      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
           scope="col"
       >
         4th Ave S &amp; Lake St E
       </th>
-      <th class="src__TH-sc-1glc48y-2 AWHaq timetable-th"
+      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
           scope="col"
       >
         3rd Ave S &amp; Franklin Ave E
       </th>
-      <th class="src__TH-sc-1glc48y-2 AWHaq timetable-th"
+      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
           scope="col"
       >
         Nicollet Mall &amp; Alice Rainville Pl
       </th>
-      <th class="src__TH-sc-1glc48y-2 AWHaq timetable-th"
+      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
           scope="col"
       >
         Nicollet Mall &amp; 7th St S
       </th>
-      <th class="src__TH-sc-1glc48y-2 AWHaq timetable-th"
+      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
           scope="col"
       >
         Nicollet Mall &amp; 3rd St S
       </th>
-      <th class="src__TH-sc-1glc48y-2 AWHaq timetable-th"
+      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
           scope="col"
       >
         Hennepin Ave E &amp; Wilder St
       </th>
-      <th class="src__TH-sc-1glc48y-2 AWHaq timetable-th"
+      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
           scope="col"
       >
         Lowry Ave NE &amp; 2nd St / 1st St NE
       </th>
-      <th class="src__TH-sc-1glc48y-2 AWHaq timetable-th"
+      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
           scope="col"
       >
         Grand St NE &amp; 29th Ave NE
       </th>
-      <th class="src__TH-sc-1glc48y-2 AWHaq timetable-th"
+      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
           scope="col"
       >
         Columbia Heights Transit Center C
@@ -75,125 +75,125 @@ exports[`Timetable Default smoke-test 1`] = `
   </thead>
   <tbody class="src__TBody-sc-1glc48y-1 bZEJyp timetable-tbody">
     <tr class="src__TR-sc-1glc48y-3 kosclq timetable-tr">
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         06:00
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         06:02
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         06:06
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         06:11
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         06:16
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         06:20
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         06:24
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         06:28
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         06:31
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         06:39
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         06:42
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         06:52
       </td>
     </tr>
     <tr class="src__TR-sc-1glc48y-3 kosclq timetable-tr">
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         16:10
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         16:26
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         16:31
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         16:36
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         -
       </td>
     </tr>
     <tr class="src__TR-sc-1glc48y-3 kosclq timetable-tr">
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         01:37
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         01:39
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         01:43
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         01:47
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         01:52
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         01:56
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         02:00
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         02:13
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         02:15
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         02:23
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         02:26
       </td>
-      <td class="src__TD-sc-1glc48y-4 knlMQh timetable-td">
+      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
         02:36
       </td>
     </tr>


### PR DESCRIPTION
This update allows consumers to pass a set of gtfsId values to the Timetable component to indicate which stops are closed. Closed stops are displayed with strikethrough formatting on the stop name and the stop time.