### PR TITLE
Add omitCanceled option to plan query

### DIFF
--- a/packages/core-utils/src/planQuery.graphql
+++ b/packages/core-utils/src/planQuery.graphql
@@ -7,6 +7,7 @@ query Plan(
   $fromPlace: String!
   $modes: [TransportMode]
   $numItineraries: Int
+  $omitCanceled: Boolean
   $time: String
   $toPlace: String!
   $unpreferred: InputUnpreferred
@@ -24,6 +25,7 @@ query Plan(
     # Currently only supporting EN locale, used for times and text
     locale: "en"
     numItineraries: $numItineraries
+    omitCanceled: $omitCanceled
     time: $time
     toPlace: $toPlace
     transportModes: $modes

--- a/packages/core-utils/src/query-gen.ts
+++ b/packages/core-utils/src/query-gen.ts
@@ -24,15 +24,16 @@ type InputPreferred = {
 
 type OTPQueryParams = {
   arriveBy: boolean;
+  banned?: InputBanned;
   date?: string;
   from: LonLatOutput & { name?: string };
   modes: TransportMode[];
   modeSettings: ModeSetting[];
-  time?: string;
   numItineraries?: number;
-  to: LonLatOutput & { name?: string };
-  banned?: InputBanned;
+  omitCanceled?: boolean;
   preferred?: InputPreferred;
+  time?: string;
+  to: LonLatOutput & { name?: string };
   unpreferred?: InputPreferred;
 };
 


### PR DESCRIPTION
Adds support for the `omitCanceled` option on the [OTP Plan query](https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/queries/plan)