### PR TITLE
fix(map-popup): Only render "view stop" link if setViewedStop exists

### DIFF
--- a/packages/map-popup/src/MapPopup.story.tsx
+++ b/packages/map-popup/src/MapPopup.story.tsx
@@ -151,7 +151,7 @@ export const StopEntityWithEntityPrefix = (): JSX.Element => (
 );
 
 export const StopEntityNoHandlers = (): JSX.Element => (
-  <MapPopupContents entity={STOP_WITH_CODE} />
+  <MapPopupContents entity={STOP_NO_CODE} />
 );
 
 export const StopEntityNoStopCode = (): JSX.Element => (

--- a/packages/map-popup/src/MapPopup.story.tsx
+++ b/packages/map-popup/src/MapPopup.story.tsx
@@ -162,6 +162,15 @@ export const StopEntityNoStopCode = (): JSX.Element => (
   />
 );
 
+export const StopEntityNoViewedStopHandler = (): JSX.Element => (
+  <MapPopupContents
+    entity={STOP_WITH_CODE}
+    feeds={SAMPLE_FEEDS}
+    setLocation={action("setLocation")}
+    setViewedStop={undefined}
+  />
+);
+
 export const StationEntity = (): JSX.Element => (
   <MapPopupContents
     entity={VEHICLE_RENTAL_STATION}

--- a/packages/map-popup/src/__snapshots__/MapPopup.story.tsx.snap
+++ b/packages/map-popup/src/__snapshots__/MapPopup.story.tsx.snap
@@ -318,6 +318,68 @@ exports[`Map Popup StopEntityNoStopCode smoke-test 1`] = `
 </div>
 `;
 
+exports[`Map Popup StopEntityNoViewedStopHandler smoke-test 1`] = `
+<div class="styled__MapOverlayPopup-sc-12kjso7-1 cPqJxe">
+  <div id="focus-9526-popup-focus-trap"
+       role="presentation"
+  >
+    <header class="styled__PopupTitle-sc-12kjso7-3 jRNaQh">
+      W Burnside &amp; SW 2nd
+    </header>
+    <p class="styled__PopupRow-sc-12kjso7-2 ckOOWr">
+      <strong>
+        Stop ID: 9526
+      </strong>
+    </p>
+    <p class="styled__PopupRow-sc-12kjso7-2 ckOOWr">
+      <strong>
+        Plan a trip:
+      </strong>
+      <span class="styled__FromToPickerSpan-sc-vb4790-1 giBPod">
+        <span class="styled__LocationPickerSpan-sc-vb4790-0 gsVfXo">
+          <svg viewbox="0 0 512 512"
+               height="0.9em"
+               width="0.9em"
+               aria-hidden="true"
+               focusable="false"
+               fill="currentColor"
+               xmlns="http://www.w3.org/2000/svg"
+               class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__FromIcon-sc-n5xcvc-0 dDqEuj"
+          >
+            <path fill="currentColor"
+                  d="M160 256c0-53.9 42.1-96 96-96 53 0 96 42.1 96 96 0 53-43 96-96 96-53.9 0-96-43-96-96zm352 0c0 141.4-114.6 256-256 256S0 397.4 0 256 114.6 0 256 0s256 114.6 256 256zM256 48C141.1 48 48 141.1 48 256s93.1 208 208 208 208-93.1 208-208S370.9 48 256 48z"
+            >
+            </path>
+          </svg>
+          <button class="styled__Button-sc-vb4790-2 ekklXB">
+            From here
+          </button>
+        </span>
+        <span class="styled__LocationPickerSpan-sc-vb4790-0 gsVfXo">
+          <svg viewbox="0 0 384 512"
+               height="0.9em"
+               width="0.9em"
+               aria-hidden="true"
+               focusable="false"
+               fill="currentColor"
+               xmlns="http://www.w3.org/2000/svg"
+               class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__ToIcon-sc-n5xcvc-2 gZxRwk"
+          >
+            <path fill="currentColor"
+                  d="M215.7 499.2C267 435 384 279.4 384 192 384 86 298 0 192 0S0 86 0 192c0 87.4 117 243 168.3 307.2 12.3 15.3 35.1 15.3 47.4 0zM192 256c-35.3 0-64-28.7-64-64s28.7-64 64-64 64 28.7 64 64-28.7 64-64 64z"
+            >
+            </path>
+          </svg>
+          <button class="styled__Button-sc-vb4790-2 ekklXB">
+            To here
+          </button>
+        </span>
+      </span>
+    </p>
+  </div>
+</div>
+`;
+
 exports[`Map Popup StopEntityWithEntityPrefix smoke-test 1`] = `
 <div class="styled__MapOverlayPopup-sc-12kjso7-1 cPqJxe">
   <div id="focus-9526-popup-focus-trap"

--- a/packages/map-popup/src/index.tsx
+++ b/packages/map-popup/src/index.tsx
@@ -75,7 +75,7 @@ const StationHubDetails = ({ availableVehicles, availableSpaces }: { availableVe
   )
 }
 
-const StopDetails = ({ id, feedName, setViewedStop }: { id: string, feedName?: string, setViewedStop: () => void; }) => {
+const StopDetails = ({ id, feedName, setViewedStop }: { id?: string, feedName?: string, setViewedStop?: () => void; }) => {
   return (
     <Styled.PopupRow>
       {id &&
@@ -90,13 +90,13 @@ const StopDetails = ({ id, feedName, setViewedStop }: { id: string, feedName?: s
             }}
           />
         </strong>}
-      <ViewStopButton onClick={setViewedStop} stopId={id}> 
+      {setViewedStop && <ViewStopButton onClick={setViewedStop} stopId={id}> 
         <FormattedMessage
           defaultMessage={defaultMessages["otpUi.MapPopup.stopViewer"]}
           description="Text for link that opens the stop viewer"
           id="otpUi.MapPopup.stopViewer"
         />
-      </ViewStopButton>
+      </ViewStopButton>}
     </Styled.PopupRow>
   )
 }
@@ -168,12 +168,12 @@ export function MapPopup({
       {/* render dock info if it is available */}
       {entityIsStationHub && <StationHubDetails availableSpaces={entity.availableSpaces?.total} availableVehicles={entity.availableVehicles?.total} />}
 
-      {/* render stop viewer link if available */}
-      {setViewedStop && entityIsStop(entity) && (
+      {/* Show stop details if any are available */}
+      {entityIsStop(entity) && (!!stopId || !!setViewedStop) && (
         <StopDetails
           id={stopId}
           feedName={feedName}
-          setViewedStop={useCallback(() => setViewedStop(entity as Stop), [entity])}
+          setViewedStop={setViewedStop && useCallback(() => setViewedStop(entity as Stop), [entity])}
         />
       )}
 


### PR DESCRIPTION
If there's no `setViewedStop` handler, we shouldn't render the link! Simple as that. Should allow a little flexibility for anyone who doesn't want that link (for example - running the trip planner in iframe without nearby view) to just not pass the function. 