### PR TITLE
feat(building-blocks): Create a no-icon version of the alert

### DIFF
--- a/packages/building-blocks/src/alert/Alert.tsx
+++ b/packages/building-blocks/src/alert/Alert.tsx
@@ -15,20 +15,20 @@ interface Props {
   collapsible?: boolean;
   children?: JSX.Element | string;
   /* Icon displayed on Alert - default is Bell. "no-icon" displays no icon */
-  Icon?: StyledIcon | "no-icon";
+  Icon?: StyledIcon | null;
 }
 
 const AlertContainer = styled.div<{
   backgroundColor?: string;
   collapsible: boolean;
   expandAlert: boolean;
-  noIcon: boolean;
+  icon: boolean;
 }>`
   background-color: ${props =>
     props.backgroundColor ? props.backgroundColor : blue[50]};
   display: grid;
   grid-template-columns: ${props =>
-    props.noIcon ? "auto auto" : "50px auto auto"};
+    props.icon ? "50px auto auto" : "auto auto"};
   grid-template-rows: minmax(25px, auto) auto;
   column-gap: 1em;
   padding: 1.5em;
@@ -45,7 +45,7 @@ const AlertContainer = styled.div<{
   }
 
   .content-row {
-    grid-column: ${props => (props.noIcon ? 1 : 2)};
+    grid-column: ${props => (props.icon ? 2 : 1)};
   }
 
   .alert-body {
@@ -72,7 +72,7 @@ const AlertContainer = styled.div<{
 
   @media (max-width: 550px) {
     grid-template-columns: 40px auto auto;
-    padding: 1.25em 1.25em;
+    padding: 1.25em;
   }
 `;
 
@@ -103,15 +103,14 @@ const Alert = ({
     id: "otpUi.buildingBlocks.alert.expand",
     defaultMessage: "Expand"
   });
-  const noIcon = Icon === "no-icon";
   return (
     <AlertContainer
       backgroundColor={backgroundColor}
       expandAlert={expandAlert}
       collapsible={!!collapsible}
-      noIcon={noIcon}
+      icon={!!Icon}
     >
-      {!noIcon && <Icon size={24} />}
+      {!!Icon && <Icon size={24} />}
       <span className="header content-row">{alertHeader}</span>
       <ButtonContainer>
         {collapsible && (

--- a/packages/building-blocks/src/alert/Alert.tsx
+++ b/packages/building-blocks/src/alert/Alert.tsx
@@ -14,22 +14,43 @@ interface Props {
   /* If true, adds a toggle that expands/collapses the alert content */
   collapsible?: boolean;
   children?: JSX.Element | string;
-  /* Icon displayed on Alert - default is Bell */
-  Icon?: StyledIcon;
+  /* Icon displayed on Alert - default is Bell. "None" displays no icon */
+  Icon?: StyledIcon | "no-icon";
 }
 
 const AlertContainer = styled.div<{
-  backgroundColor: string;
+  backgroundColor?: string;
   collapsible: boolean;
   expandAlert: boolean;
+  noIcon: boolean;
 }>`
   background-color: ${props =>
     props.backgroundColor ? props.backgroundColor : blue[50]};
   display: grid;
-  grid-template-columns: 50px auto auto;
+  grid-template-columns: ${props =>
+    props.noIcon ? "auto auto" : "50px auto auto"};
   grid-template-rows: minmax(25px, auto) auto;
   column-gap: 1em;
   padding: 1.5em;
+
+  .header {
+    align-self: center;
+    font-weight: 700;
+  }
+
+  .subheader {
+    align-self: center;
+    font-weight: 400;
+    margin-top: 0.3em;
+  }
+
+  .content-row {
+    grid-column: ${props => (props.noIcon ? 1 : 2)};
+  }
+
+  .alert-body {
+    grid-row: 3;
+  }
 
   svg {
     align-self: center;
@@ -62,22 +83,6 @@ const ButtonContainer = styled.span`
   justify-self: right;
 `;
 
-const AlertHeader = styled.span`
-  align-self: center;
-  font-weight: 700;
-  grid-column: 2;
-`;
-
-const AlertSubheader = styled(AlertHeader)`
-  font-weight: 400;
-  margin-top: 0.3em;
-`;
-
-const AlertContent = styled.div`
-  grid-column: 2;
-  grid-row: 3;
-`;
-
 const ContentPadding = styled.div<{
   collapsible: boolean;
 }>`
@@ -98,14 +103,16 @@ const Alert = ({
     id: "otpUi.buildingBlocks.alert.expand",
     defaultMessage: "Expand"
   });
+  const noIcon = Icon === "no-icon";
   return (
     <AlertContainer
       backgroundColor={backgroundColor}
       expandAlert={expandAlert}
-      collapsible={collapsible}
+      collapsible={!!collapsible}
+      noIcon={noIcon}
     >
-      <Icon size={24} />
-      <AlertHeader>{alertHeader}</AlertHeader>
+      {!noIcon && <Icon size={24} />}
+      <span className="header content-row">{alertHeader}</span>
       <ButtonContainer>
         {collapsible && (
           <button
@@ -119,18 +126,20 @@ const Alert = ({
           </button>
         )}
       </ButtonContainer>
-      {alertSubheader && <AlertSubheader>{alertSubheader}</AlertSubheader>}
+      {alertSubheader && (
+        <span className="subheader content-row">{alertSubheader}</span>
+      )}
       {children && (
-        <AlertContent>
+        <div className="alert-body content-row">
           <AnimateHeight
             duration={500}
             height={collapsible ? (expandAlert ? "auto" : 0) : "auto"}
           >
-            <ContentPadding collapsible={collapsible}>
+            <ContentPadding collapsible={!!collapsible}>
               {children}
             </ContentPadding>
           </AnimateHeight>
-        </AlertContent>
+        </div>
       )}
     </AlertContainer>
   );

--- a/packages/building-blocks/src/alert/Alert.tsx
+++ b/packages/building-blocks/src/alert/Alert.tsx
@@ -31,7 +31,7 @@ const AlertContainer = styled.div<{
     props.icon ? "50px auto auto" : "auto auto"};
   grid-template-rows: minmax(25px, auto) auto;
   column-gap: 1em;
-  padding: 1.5em;
+  padding: ${props => (props.icon ? "1.5em" : "1em")};
 
   .header {
     align-self: center;

--- a/packages/building-blocks/src/alert/Alert.tsx
+++ b/packages/building-blocks/src/alert/Alert.tsx
@@ -14,7 +14,7 @@ interface Props {
   /* If true, adds a toggle that expands/collapses the alert content */
   collapsible?: boolean;
   children?: JSX.Element | string;
-  /* Icon displayed on Alert - default is Bell. "None" displays no icon */
+  /* Icon displayed on Alert - default is Bell. "no-icon" displays no icon */
   Icon?: StyledIcon | "no-icon";
 }
 

--- a/packages/building-blocks/src/alert/Alert.tsx
+++ b/packages/building-blocks/src/alert/Alert.tsx
@@ -14,7 +14,7 @@ interface Props {
   /* If true, adds a toggle that expands/collapses the alert content */
   collapsible?: boolean;
   children?: JSX.Element | string;
-  /* Icon displayed on Alert - default is Bell. "no-icon" displays no icon */
+  /* Icon displayed on Alert - default is Bell. Null displays no icon */
   Icon?: StyledIcon | null;
 }
 

--- a/packages/building-blocks/src/alert/Alert.tsx
+++ b/packages/building-blocks/src/alert/Alert.tsx
@@ -20,7 +20,7 @@ interface Props {
 
 const AlertContainer = styled.div<{
   backgroundColor?: string;
-  collapsible: boolean;
+  collapsible?: boolean;
   expandAlert: boolean;
   icon: boolean;
 }>`
@@ -71,8 +71,9 @@ const AlertContainer = styled.div<{
   }
 
   @media (max-width: 550px) {
-    grid-template-columns: 40px auto auto;
-    padding: 1.25em;
+    column-gap: 0.75em;
+    grid-template-columns: ${props => props.icon && "40px auto auto"};
+    padding: 1em;
   }
 `;
 
@@ -84,7 +85,7 @@ const ButtonContainer = styled.span`
 `;
 
 const ContentPadding = styled.div<{
-  collapsible: boolean;
+  collapsible?: boolean;
 }>`
   margin-top: ${props => (props.collapsible ? "1em" : ".5em")};
 `;
@@ -107,7 +108,7 @@ const Alert = ({
     <AlertContainer
       backgroundColor={backgroundColor}
       expandAlert={expandAlert}
-      collapsible={!!collapsible}
+      collapsible={collapsible}
       icon={!!Icon}
     >
       {!!Icon && <Icon size={24} />}
@@ -134,7 +135,7 @@ const Alert = ({
             duration={500}
             height={collapsible ? (expandAlert ? "auto" : 0) : "auto"}
           >
-            <ContentPadding collapsible={!!collapsible}>
+            <ContentPadding collapsible={collapsible}>
               {children}
             </ContentPadding>
           </AnimateHeight>

--- a/packages/building-blocks/src/stories/__snapshots__/alerts.story.tsx.snap
+++ b/packages/building-blocks/src/stories/__snapshots__/alerts.story.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Building-Blocks/Alert BasicAlert smoke-test 1`] = `
 <div class="alertsstory__AlertContainer-sc-19s77d-0 fgnBDZ">
-  <div class="Alert__AlertContainer-sc-2vlo3n-0 bVfQIo">
+  <div class="Alert__AlertContainer-sc-2vlo3n-0 hFhyUy">
     <svg viewbox="0 0 16 16"
          height="24"
          width="24"
@@ -15,21 +15,48 @@ exports[`Building-Blocks/Alert BasicAlert smoke-test 1`] = `
       <path d="M8 16a2 2 0 0 0 2-2H6a2 2 0 0 0 2 2zM8 1.918l-.797.161A4.002 4.002 0 0 0 4 6c0 .628-.134 2.197-.459 3.742-.16.767-.376 1.566-.663 2.258h10.244c-.287-.692-.502-1.49-.663-2.258C12.134 8.197 12 6.628 12 6a4.002 4.002 0 0 0-3.203-3.92L8 1.917zM14.22 12c.223.447.481.801.78 1H1c.299-.199.557-.553.78-1C2.68 10.2 3 6.88 3 6c0-2.42 1.72-4.44 4.005-4.901a1 1 0 1 1 1.99 0A5.002 5.002 0 0 1 13 6c0 .88.32 4.2 1.22 6z">
       </path>
     </svg>
-    <span class="Alert__AlertHeader-sc-2vlo3n-2 fpauiN">
+    <span class="header content-row">
       Next trip starts on Wednesday April 17th
     </span>
     <span class="Alert__ButtonContainer-sc-2vlo3n-1 cKzYKK">
     </span>
-    <span class="Alert__AlertHeader-sc-2vlo3n-2 Alert__AlertSubheader-sc-2vlo3n-3 fpauiN dYdxsJ">
+    <span class="subheader content-row">
       Trip is due to begin at 7:43 AM (Realtime monitoring will being at 7:13 AM)
     </span>
-    <div class="Alert__AlertContent-sc-2vlo3n-4 UrwUS">
+    <div class="alert-body content-row">
       <div aria-hidden="false"
            class="rah-static rah-static--height-auto "
            style="height: auto; overflow: visible;"
       >
         <div>
-          <div class="Alert__ContentPadding-sc-2vlo3n-5 isIayL">
+          <div class="Alert__ContentPadding-sc-2vlo3n-2 hzwNmc">
+            Here is more content
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Building-Blocks/Alert BasicAlertNoIcon smoke-test 1`] = `
+<div class="alertsstory__AlertContainer-sc-19s77d-0 fgnBDZ">
+  <div class="Alert__AlertContainer-sc-2vlo3n-0 dgKxcT">
+    <span class="header content-row">
+      Next trip starts on Wednesday April 17th
+    </span>
+    <span class="Alert__ButtonContainer-sc-2vlo3n-1 cKzYKK">
+    </span>
+    <span class="subheader content-row">
+      Trip is due to begin at 7:43 AM (Realtime monitoring will being at 7:13 AM)
+    </span>
+    <div class="alert-body content-row">
+      <div aria-hidden="false"
+           class="rah-static rah-static--height-auto "
+           style="height: auto; overflow: visible;"
+      >
+        <div>
+          <div class="Alert__ContentPadding-sc-2vlo3n-2 hzwNmc">
             Here is more content
           </div>
         </div>
@@ -41,7 +68,7 @@ exports[`Building-Blocks/Alert BasicAlert smoke-test 1`] = `
 
 exports[`Building-Blocks/Alert CollapsibleAlertWithTransitAlerts smoke-test 1`] = `
 <div class="alertsstory__AlertContainer-sc-19s77d-0 fgnBDZ">
-  <div class="Alert__AlertContainer-sc-2vlo3n-0 bqBujX">
+  <div class="Alert__AlertContainer-sc-2vlo3n-0 fRDRXF">
     <svg viewbox="0 0 16 16"
          height="24"
          width="24"
@@ -56,7 +83,7 @@ exports[`Building-Blocks/Alert CollapsibleAlertWithTransitAlerts smoke-test 1`] 
       <path d="M7.002 12a1 1 0 1 1 2 0 1 1 0 0 1-2 0zM7.1 5.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995z">
       </path>
     </svg>
-    <span class="Alert__AlertHeader-sc-2vlo3n-2 fpauiN">
+    <span class="header content-row">
       Your trip has alerts
     </span>
     <span class="Alert__ButtonContainer-sc-2vlo3n-1 cKzYKK">
@@ -81,13 +108,68 @@ exports[`Building-Blocks/Alert CollapsibleAlertWithTransitAlerts smoke-test 1`] 
         </svg>
       </button>
     </span>
-    <div class="Alert__AlertContent-sc-2vlo3n-4 UrwUS">
+    <div class="alert-body content-row">
       <div aria-hidden="true"
            class="rah-static rah-static--height-zero "
            style="height: 0px; overflow: hidden;"
       >
         <div style="display: none;">
-          <div class="Alert__ContentPadding-sc-2vlo3n-5 esOwtt">
+          <div class="Alert__ContentPadding-sc-2vlo3n-2 VuVxS">
+            <div>
+              1) TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
+            </div>
+            <br>
+            <div>
+              2) The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
+            </div>
+            <br>
+            <div>
+              3) The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
+            </div>
+            <br>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Building-Blocks/Alert CollapsibleAlertWithTransitAlertsNoIcon smoke-test 1`] = `
+<div class="alertsstory__AlertContainer-sc-19s77d-0 fgnBDZ">
+  <div class="Alert__AlertContainer-sc-2vlo3n-0 kwLxBQ">
+    <span class="header content-row">
+      Your trip has alerts
+    </span>
+    <span class="Alert__ButtonContainer-sc-2vlo3n-1 cKzYKK">
+      <button type="button"
+              class="toggle-btn"
+              aria-label="Expand"
+              title="Expand"
+      >
+        <svg viewbox="0 0 16 16"
+             height="16"
+             width="16"
+             aria-hidden="true"
+             focusable="false"
+             fill="currentColor"
+             xmlns="http://www.w3.org/2000/svg"
+             class="StyledIconBase-sc-ea9ulj-0 ebjPRL"
+        >
+          <path fill-rule="evenodd"
+                d="M7.646 4.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1-.708.708L8 5.707l-5.646 5.647a.5.5 0 0 1-.708-.708l6-6z"
+          >
+          </path>
+        </svg>
+      </button>
+    </span>
+    <div class="alert-body content-row">
+      <div aria-hidden="true"
+           class="rah-static rah-static--height-zero "
+           style="height: 0px; overflow: hidden;"
+      >
+        <div style="display: none;">
+          <div class="Alert__ContentPadding-sc-2vlo3n-2 VuVxS">
             <div>
               1) TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
             </div>

--- a/packages/building-blocks/src/stories/__snapshots__/alerts.story.tsx.snap
+++ b/packages/building-blocks/src/stories/__snapshots__/alerts.story.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Building-Blocks/Alert BasicAlert smoke-test 1`] = `
 <div class="alertsstory__AlertContainer-sc-19s77d-0 fgnBDZ">
-  <div class="Alert__AlertContainer-sc-2vlo3n-0 hFhyUy">
+  <div class="Alert__AlertContainer-sc-2vlo3n-0 gtXlyS">
     <svg viewbox="0 0 16 16"
          height="24"
          width="24"
@@ -41,7 +41,7 @@ exports[`Building-Blocks/Alert BasicAlert smoke-test 1`] = `
 
 exports[`Building-Blocks/Alert BasicAlertNoIcon smoke-test 1`] = `
 <div class="alertsstory__AlertContainer-sc-19s77d-0 fgnBDZ">
-  <div class="Alert__AlertContainer-sc-2vlo3n-0 dgKxcT">
+  <div class="Alert__AlertContainer-sc-2vlo3n-0 heKxCf">
     <span class="header content-row">
       Next trip starts on Wednesday April 17th
     </span>
@@ -68,7 +68,7 @@ exports[`Building-Blocks/Alert BasicAlertNoIcon smoke-test 1`] = `
 
 exports[`Building-Blocks/Alert CollapsibleAlertWithTransitAlerts smoke-test 1`] = `
 <div class="alertsstory__AlertContainer-sc-19s77d-0 fgnBDZ">
-  <div class="Alert__AlertContainer-sc-2vlo3n-0 fRDRXF">
+  <div class="Alert__AlertContainer-sc-2vlo3n-0 ekMZt">
     <svg viewbox="0 0 16 16"
          height="24"
          width="24"
@@ -137,7 +137,7 @@ exports[`Building-Blocks/Alert CollapsibleAlertWithTransitAlerts smoke-test 1`] 
 
 exports[`Building-Blocks/Alert CollapsibleAlertWithTransitAlertsNoIcon smoke-test 1`] = `
 <div class="alertsstory__AlertContainer-sc-19s77d-0 fgnBDZ">
-  <div class="Alert__AlertContainer-sc-2vlo3n-0 kwLxBQ">
+  <div class="Alert__AlertContainer-sc-2vlo3n-0 bCTzvI">
     <span class="header content-row">
       Your trip has alerts
     </span>

--- a/packages/building-blocks/src/stories/alerts.story.tsx
+++ b/packages/building-blocks/src/stories/alerts.story.tsx
@@ -76,7 +76,7 @@ export const BasicAlertNoIcon = (): ReactElement => {
       <Alert
         alertHeader="Next trip starts on Wednesday April 17th"
         alertSubheader="Trip is due to begin at 7:43 AM (Realtime monitoring will being at 7:13 AM)"
-        Icon="no-icon"
+        Icon={null}
       >
         Here is more content
       </Alert>
@@ -105,7 +105,7 @@ export const CollapsibleAlertWithTransitAlertsNoIcon = (): ReactElement => {
       <Alert
         backgroundColor={red[50]}
         collapsible
-        Icon="no-icon"
+        Icon={null}
         alertHeader="Your trip has alerts"
       >
         <AlertContent />

--- a/packages/building-blocks/src/stories/alerts.story.tsx
+++ b/packages/building-blocks/src/stories/alerts.story.tsx
@@ -70,6 +70,20 @@ export const BasicAlert = (): ReactElement => {
   );
 };
 
+export const BasicAlertNoIcon = (): ReactElement => {
+  return (
+    <AlertContainer>
+      <Alert
+        alertHeader="Next trip starts on Wednesday April 17th"
+        alertSubheader="Trip is due to begin at 7:43 AM (Realtime monitoring will being at 7:13 AM)"
+        Icon="no-icon"
+      >
+        Here is more content
+      </Alert>
+    </AlertContainer>
+  );
+};
+
 export const CollapsibleAlertWithTransitAlerts = (): ReactElement => {
   return (
     <AlertContainer>
@@ -77,6 +91,21 @@ export const CollapsibleAlertWithTransitAlerts = (): ReactElement => {
         backgroundColor={red[50]}
         collapsible
         Icon={ExclamationTriangle}
+        alertHeader="Your trip has alerts"
+      >
+        <AlertContent />
+      </Alert>
+    </AlertContainer>
+  );
+};
+
+export const CollapsibleAlertWithTransitAlertsNoIcon = (): ReactElement => {
+  return (
+    <AlertContainer>
+      <Alert
+        backgroundColor={red[50]}
+        collapsible
+        Icon="no-icon"
         alertHeader="Your trip has alerts"
       >
         <AlertContent />

--- a/packages/building-blocks/src/stories/alerts.story.tsx
+++ b/packages/building-blocks/src/stories/alerts.story.tsx
@@ -57,59 +57,51 @@ const AlertContent = () => {
   );
 };
 
-export const BasicAlert = (): ReactElement => {
-  return (
-    <AlertContainer>
-      <Alert
-        alertHeader="Next trip starts on Wednesday April 17th"
-        alertSubheader="Trip is due to begin at 7:43 AM (Realtime monitoring will being at 7:13 AM)"
-      >
-        Here is more content
-      </Alert>
-    </AlertContainer>
-  );
-};
+export const BasicAlert = (): ReactElement => (
+  <AlertContainer>
+    <Alert
+      alertHeader="Next trip starts on Wednesday April 17th"
+      alertSubheader="Trip is due to begin at 7:43 AM (Realtime monitoring will being at 7:13 AM)"
+    >
+      Here is more content
+    </Alert>
+  </AlertContainer>
+);
 
-export const BasicAlertNoIcon = (): ReactElement => {
-  return (
-    <AlertContainer>
-      <Alert
-        alertHeader="Next trip starts on Wednesday April 17th"
-        alertSubheader="Trip is due to begin at 7:43 AM (Realtime monitoring will being at 7:13 AM)"
-        Icon={null}
-      >
-        Here is more content
-      </Alert>
-    </AlertContainer>
-  );
-};
+export const BasicAlertNoIcon = (): ReactElement => (
+  <AlertContainer>
+    <Alert
+      alertHeader="Next trip starts on Wednesday April 17th"
+      alertSubheader="Trip is due to begin at 7:43 AM (Realtime monitoring will being at 7:13 AM)"
+      Icon={null}
+    >
+      Here is more content
+    </Alert>
+  </AlertContainer>
+);
 
-export const CollapsibleAlertWithTransitAlerts = (): ReactElement => {
-  return (
-    <AlertContainer>
-      <Alert
-        backgroundColor={red[50]}
-        collapsible
-        Icon={ExclamationTriangle}
-        alertHeader="Your trip has alerts"
-      >
-        <AlertContent />
-      </Alert>
-    </AlertContainer>
-  );
-};
+export const CollapsibleAlertWithTransitAlerts = (): ReactElement => (
+  <AlertContainer>
+    <Alert
+      backgroundColor={red[50]}
+      collapsible
+      Icon={ExclamationTriangle}
+      alertHeader="Your trip has alerts"
+    >
+      <AlertContent />
+    </Alert>
+  </AlertContainer>
+);
 
-export const CollapsibleAlertWithTransitAlertsNoIcon = (): ReactElement => {
-  return (
-    <AlertContainer>
-      <Alert
-        backgroundColor={red[50]}
-        collapsible
-        Icon={null}
-        alertHeader="Your trip has alerts"
-      >
-        <AlertContent />
-      </Alert>
-    </AlertContainer>
-  );
-};
+export const CollapsibleAlertWithTransitAlertsNoIcon = (): ReactElement => (
+  <AlertContainer>
+    <Alert
+      backgroundColor={red[50]}
+      collapsible
+      Icon={null}
+      alertHeader="Your trip has alerts"
+    >
+      <AlertContent />
+    </Alert>
+  </AlertContainer>
+);


### PR DESCRIPTION
Now passing the string "no-icon" to the `icon` prop will render an alert with no icon

with icon
<img width="700" height="123" alt="image" src="https://github.com/user-attachments/assets/b4305d46-f526-4f3b-be54-4b690f71a578" />

without icon: 
<img width="700" height="123" alt="image" src="https://github.com/user-attachments/assets/43f1717f-eb7f-4568-9d57-db77d36bc980" />
