### PR TITLE
Add packageManager to package.json for corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -294,5 +294,6 @@
   "dependencies": {
     "@storybook/icons": "^1.6.0",
     "@styled-icons/styled-icon": "catalog:"
-  }
+  },
+  "packageManager": "pnpm@10.12.1+sha1.4bd977ce548dc9fcd1ca0c62838c55646cea6847"
 }


### PR DESCRIPTION
It appears that corepack requires a `packageManager` field in `package.json` to lock the version of pnpm that gets used. This gets auto-generated upon running `pnpm install`, but I had been reverting the change before pushing. I'm pretty sure this is what causes the [deployment pipeline to fail](https://github.com/opentripplanner/otp-ui/actions/runs/29433093010/job/87412793261) with a "working tree must be clean" message; the pipeline runs `pnpm install` and then this gets added and there's an uncommitted change.