### PR TITLE
Update location-field geocoder

### DIFF
--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -392,6 +392,7 @@ const LocationField = ({
         setAbortController([...abortControllers, newController]);
 
         getGeocoder(geocoderConfig)
+          // Other options such as headers will also be included in the autocomplete call.
           .autocomplete({ text, options: { signal: newController.signal } })
           // TODO: Better type?
           .then(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6646,7 +6646,7 @@ packages:
   git-raw-commits@3.0.0:
     resolution: {integrity: sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==}
     engines: {node: '>=14'}
-    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -6656,7 +6656,7 @@ packages:
   git-semver-tags@5.0.1:
     resolution: {integrity: sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA==}
     engines: {node: '>=14'}
-    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@6.0.0:


### PR DESCRIPTION
Patch release for the location-field package so it uses the latest geocoder, and attempts to fix pnpm.lock from previous failed releases.