### PR TITLE
Fix canceled trip screenreader text

### DIFF
--- a/packages/itinerary-body/src/ItineraryBody/place-row.tsx
+++ b/packages/itinerary-body/src/ItineraryBody/place-row.tsx
@@ -138,9 +138,11 @@ export default function PlaceRow({
       } ${leg.rentedBike ? "rented-bike" : ""}`}
       key={legIndex || "destination-place"}
     >
-      <S.InvisibleAdditionalDetails>
-        {canceledInvisibleMessage}
-      </S.InvisibleAdditionalDetails>
+      {canceled && (
+        <S.InvisibleAdditionalDetails>
+          {canceledInvisibleMessage}
+        </S.InvisibleAdditionalDetails>
+      )}
       <S.LineColumn>
         <LineColumnContent
           interline={interline}

--- a/packages/itinerary-body/src/stories/__snapshots__/OtpRrItineraryBody.story.tsx.snap
+++ b/packages/itinerary-body/src/stories/__snapshots__/OtpRrItineraryBody.story.tsx.snap
@@ -3,9 +3,6 @@
 exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -228,9 +225,6 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 jA-dKKm leg-line">
       </div>
@@ -598,9 +592,6 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -908,9 +899,6 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -966,9 +954,6 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
 exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -1191,9 +1176,6 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 jA-dKKm leg-line">
       </div>
@@ -1564,9 +1546,6 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -1874,9 +1853,6 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -1932,9 +1908,6 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
 exports[`ItineraryBody/otp-react-redux BikeOnlyItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 dncEaQ leg-line">
       </div>
@@ -2220,9 +2193,6 @@ exports[`ItineraryBody/otp-react-redux BikeOnlyItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -2278,9 +2248,6 @@ exports[`ItineraryBody/otp-react-redux BikeOnlyItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-react-redux BikeRentalItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -2503,9 +2470,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   rented-bike">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 dncEaQ leg-line">
       </div>
@@ -2818,9 +2782,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -3067,9 +3028,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -3125,9 +3083,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -3388,9 +3343,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   rented-bike">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 dncEaQ leg-line">
       </div>
@@ -3817,9 +3769,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -4066,9 +4015,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kFSmkR leg-line">
       </div>
@@ -4461,9 +4407,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -4695,9 +4638,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   rented-bike">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 dncEaQ leg-line">
       </div>
@@ -5010,9 +4950,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -5221,9 +5158,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -5279,9 +5213,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
 exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -5466,9 +5397,6 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 dncEaQ leg-line">
       </div>
@@ -5764,9 +5692,6 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -5952,9 +5877,6 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 jA-dKKm leg-line">
       </div>
@@ -6255,9 +6177,6 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -6451,9 +6370,6 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 dncEaQ leg-line">
       </div>
@@ -6711,9 +6627,6 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -6769,9 +6682,6 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
 exports[`ItineraryBody/otp-react-redux CustomTimeColumn smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fiFXVo leg-line">
       </div>
@@ -6896,9 +6806,6 @@ exports[`ItineraryBody/otp-react-redux CustomTimeColumn smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -6992,9 +6899,6 @@ exports[`ItineraryBody/otp-react-redux CustomTimeColumn smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kFSmkR leg-line">
       </div>
@@ -7206,9 +7110,6 @@ exports[`ItineraryBody/otp-react-redux CustomTimeColumn smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -7324,9 +7225,6 @@ exports[`ItineraryBody/otp-react-redux CustomTimeColumn smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fiFXVo leg-line">
       </div>
@@ -7446,9 +7344,6 @@ exports[`ItineraryBody/otp-react-redux CustomTimeColumn smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -7524,9 +7419,6 @@ exports[`ItineraryBody/otp-react-redux CustomTimeColumn smoke-test 1`] = `
 exports[`ItineraryBody/otp-react-redux EScooterRentalItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -7749,9 +7641,6 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalItinerary smoke-test 1`] = 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kBTBwI leg-line">
       </div>
@@ -7958,9 +7847,6 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalItinerary smoke-test 1`] = 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -8016,9 +7902,6 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalItinerary smoke-test 1`] = 
 exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -8346,9 +8229,6 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kBTBwI leg-line">
       </div>
@@ -8812,9 +8692,6 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -8891,9 +8768,6 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kFSmkR leg-line">
       </div>
@@ -9143,9 +9017,6 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -9444,9 +9315,6 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kBTBwI leg-line">
       </div>
@@ -9796,9 +9664,6 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -9854,9 +9719,6 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
 exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fiFXVo leg-line">
       </div>
@@ -9968,9 +9830,6 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -10255,9 +10114,6 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 jA-dKKm leg-line">
       </div>
@@ -10614,9 +10470,6 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -10962,9 +10815,6 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -11020,9 +10870,6 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
 exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -11645,9 +11492,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 khbgHP leg-line">
       </div>
@@ -11870,9 +11714,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -12066,9 +11907,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 drgNNC leg-line">
       </div>
@@ -12279,9 +12117,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -12475,9 +12310,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 drgNNC leg-line">
       </div>
@@ -12704,9 +12536,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -12900,9 +12729,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kFSmkR leg-line">
       </div>
@@ -13161,9 +12987,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -13491,9 +13314,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -13549,9 +13369,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
 exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -13870,9 +13687,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kUZrSU leg-line">
       </div>
@@ -14142,9 +13956,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -14376,9 +14187,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fsbJne leg-line">
       </div>
@@ -14616,9 +14424,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -14850,9 +14655,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 guGJVk leg-line">
       </div>
@@ -14985,9 +14787,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -15043,9 +14842,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-react-redux OTP2ScooterItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -15306,9 +15102,6 @@ exports[`ItineraryBody/otp-react-redux OTP2ScooterItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   rented-bike">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kBTBwI leg-line">
       </div>
@@ -15801,9 +15594,6 @@ exports[`ItineraryBody/otp-react-redux OTP2ScooterItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   rented-bike">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -15859,9 +15649,6 @@ exports[`ItineraryBody/otp-react-redux OTP2ScooterItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -16303,9 +16090,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 cSQuqh leg-line">
       </div>
@@ -16570,9 +16354,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -16918,9 +16699,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 jA-dKKm leg-line">
       </div>
@@ -17364,9 +17142,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -17703,9 +17478,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -17761,9 +17533,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fiFXVo leg-line">
       </div>
@@ -18285,9 +18054,6 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -18572,9 +18338,6 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 jA-dKKm leg-line">
       </div>
@@ -18931,9 +18694,6 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -19279,9 +19039,6 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -19337,9 +19094,6 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 giaaKO leg-line">
       </div>
@@ -19573,9 +19327,6 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit interline ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kZUAHe leg-line">
       </div>
@@ -19785,9 +19536,6 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -19843,9 +19591,6 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -20068,9 +19813,6 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 jA-dKKm leg-line">
       </div>
@@ -20440,9 +20182,6 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -20750,9 +20489,6 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -20808,9 +20544,6 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
 exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -21033,9 +20766,6 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 jA-dKKm leg-line">
       </div>
@@ -21406,9 +21136,6 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -21716,9 +21443,6 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -21774,9 +21498,6 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
 exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -21999,9 +21720,6 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 jA-dKKm leg-line">
       </div>
@@ -22372,9 +22090,6 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -22682,9 +22397,6 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -22740,9 +22452,6 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
 exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -22965,9 +22674,6 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 jA-dKKm leg-line">
       </div>
@@ -23338,9 +23044,6 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -23648,9 +23351,6 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -23706,9 +23406,6 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
 exports[`ItineraryBody/otp-react-redux TncTransitItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fiFXVo leg-line">
       </div>
@@ -23813,9 +23510,6 @@ exports[`ItineraryBody/otp-react-redux TncTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -23892,9 +23586,6 @@ exports[`ItineraryBody/otp-react-redux TncTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kFSmkR leg-line">
       </div>
@@ -24092,9 +23783,6 @@ exports[`ItineraryBody/otp-react-redux TncTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -24194,9 +23882,6 @@ exports[`ItineraryBody/otp-react-redux TncTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fiFXVo leg-line">
       </div>
@@ -24296,9 +23981,6 @@ exports[`ItineraryBody/otp-react-redux TncTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -24354,9 +24036,6 @@ exports[`ItineraryBody/otp-react-redux TncTransitItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -24865,9 +24544,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 jLWJnR leg-line">
       </div>
@@ -25075,9 +24751,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -25174,9 +24847,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 jLWJnR leg-line">
       </div>
@@ -25560,9 +25230,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -26080,9 +25747,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -26138,9 +25802,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fiFXVo leg-line">
       </div>
@@ -26662,9 +26323,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -26949,9 +26607,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 jA-dKKm leg-line">
       </div>
@@ -27329,9 +26984,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -27677,9 +27329,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -27735,9 +27384,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
 exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fiFXVo leg-line">
       </div>
@@ -28259,9 +27905,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -28546,9 +28189,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 jA-dKKm leg-line">
       </div>
@@ -28905,9 +28545,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -29253,9 +28890,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -29311,9 +28945,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
 exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fiFXVo leg-line">
       </div>
@@ -29835,9 +29466,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -30122,9 +29750,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 jA-dKKm leg-line">
       </div>
@@ -30481,9 +30106,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -30829,9 +30451,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -30887,9 +30506,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
 exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -31264,9 +30880,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fmJnmR leg-line">
       </div>
@@ -31484,9 +31097,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -31586,9 +31196,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kFSmkR leg-line">
       </div>
@@ -31822,9 +31429,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -32094,9 +31698,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kFSmkR leg-line">
       </div>
@@ -32402,9 +32003,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -32636,9 +32234,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -32694,9 +32289,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
 exports[`ItineraryBody/otp-react-redux WalkOnlyItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -32913,9 +32505,6 @@ exports[`ItineraryBody/otp-react-redux WalkOnlyItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -32971,9 +32560,6 @@ exports[`ItineraryBody/otp-react-redux WalkOnlyItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -33196,9 +32782,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kFSmkR leg-line">
       </div>
@@ -33416,9 +32999,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -33688,9 +33268,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kFSmkR leg-line">
       </div>
@@ -33908,9 +33485,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -34180,9 +33754,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -34238,9 +33809,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
 exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -34494,9 +34062,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kFSmkR leg-line">
       </div>
@@ -34745,9 +34310,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -35017,9 +34579,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kFSmkR leg-line">
       </div>
@@ -35268,9 +34827,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -35571,9 +35127,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -35629,9 +35182,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
 exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -35854,9 +35404,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 jA-dKKm leg-line">
       </div>
@@ -36227,9 +35774,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -36537,9 +36081,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -36595,9 +36136,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
 exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -37198,9 +36736,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -37508,9 +37043,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -37566,9 +37098,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
 exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -37791,9 +37320,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 jA-dKKm leg-line">
       </div>
@@ -38164,9 +37690,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -38474,9 +37997,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -38532,9 +38052,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
 exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -38909,9 +38426,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fmJnmR leg-line">
       </div>
@@ -39129,9 +38643,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -39231,9 +38742,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kFSmkR leg-line">
       </div>
@@ -39467,9 +38975,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -39739,9 +39244,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kFSmkR leg-line">
       </div>
@@ -40047,9 +39549,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -40281,9 +39780,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -40339,9 +39835,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
 exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -40716,9 +40209,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fmJnmR leg-line">
       </div>
@@ -40936,9 +40426,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -41038,9 +40525,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kFSmkR leg-line">
       </div>
@@ -41274,9 +40758,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -41546,9 +41027,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kFSmkR leg-line">
       </div>
@@ -41854,9 +41332,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -42088,9 +41563,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"
@@ -42146,9 +41618,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
 exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 hMkZBu">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -42523,9 +41992,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fmJnmR leg-line">
       </div>
@@ -42743,9 +42209,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -42845,9 +42308,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kFSmkR leg-line">
       </div>
@@ -43081,9 +42541,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -43353,9 +42810,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kFSmkR leg-line">
       </div>
@@ -43661,9 +43115,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
       </div>
@@ -43895,9 +43346,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
         <svg viewbox="0 0 512 512"

--- a/packages/itinerary-body/src/stories/__snapshots__/OtpUiItineraryBody.story.tsx.snap
+++ b/packages/itinerary-body/src/stories/__snapshots__/OtpUiItineraryBody.story.tsx.snap
@@ -3,9 +3,6 @@
 exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="CAR"
@@ -530,9 +527,6 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -824,9 +818,6 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="TRAM"
@@ -1151,9 +1142,6 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -1489,9 +1477,6 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -1555,9 +1540,6 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui BikeOnlyItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BICYCLE"
@@ -1842,9 +1824,6 @@ exports[`ItineraryBody/otp-ui BikeOnlyItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -1908,9 +1887,6 @@ exports[`ItineraryBody/otp-ui BikeOnlyItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui BikeRentalItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -2126,9 +2102,6 @@ exports[`ItineraryBody/otp-ui BikeRentalItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   rented-bike">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BICYCLE"
@@ -2480,9 +2453,6 @@ exports[`ItineraryBody/otp-ui BikeRentalItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -2736,9 +2706,6 @@ exports[`ItineraryBody/otp-ui BikeRentalItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -2802,9 +2769,6 @@ exports[`ItineraryBody/otp-ui BikeRentalItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -3058,9 +3022,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   rented-bike">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BICYCLE"
@@ -3526,9 +3487,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -3782,9 +3740,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -4141,9 +4096,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -4365,9 +4317,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   rented-bike">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BICYCLE"
@@ -4719,9 +4668,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -4937,9 +4883,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -5003,9 +4946,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -5183,9 +5123,6 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BICYCLE"
@@ -5479,9 +5416,6 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -5659,9 +5593,6 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="TRAM"
@@ -5930,9 +5861,6 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -6116,9 +6044,6 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BICYCLE"
@@ -6374,9 +6299,6 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -6440,9 +6362,6 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -6658,9 +6577,6 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="TRAM"
@@ -6999,9 +6915,6 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -7299,9 +7212,6 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -7365,9 +7275,6 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui EScooterRentalItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -7583,9 +7490,6 @@ exports[`ItineraryBody/otp-ui EScooterRentalItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="MICROMOBILITY"
@@ -7804,9 +7708,6 @@ exports[`ItineraryBody/otp-ui EScooterRentalItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -7870,9 +7771,6 @@ exports[`ItineraryBody/otp-ui EScooterRentalItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -8193,9 +8091,6 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="MICROMOBILITY"
@@ -8671,9 +8566,6 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -8757,9 +8649,6 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -8973,9 +8862,6 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -9264,9 +9150,6 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="MICROMOBILITY"
@@ -9628,9 +9511,6 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -9694,9 +9574,6 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="CAR"
@@ -9811,9 +9688,6 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -10105,9 +9979,6 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="TRAM"
@@ -10432,9 +10303,6 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -10770,9 +10638,6 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -10836,9 +10701,6 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -11454,9 +11316,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -11631,9 +11490,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -11811,9 +11667,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -11976,9 +11829,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -12156,9 +12006,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -12337,9 +12184,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -12517,9 +12361,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -12729,9 +12570,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -13043,9 +12881,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -13109,9 +12944,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -13423,9 +13255,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -13663,9 +13492,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -13887,9 +13713,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -14095,9 +13918,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -14319,9 +14139,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -14433,9 +14250,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -14505,9 +14319,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui OTP2ScooterItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -14761,9 +14572,6 @@ exports[`ItineraryBody/otp-ui OTP2ScooterItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   rented-bike">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="SCOOTER"
@@ -15269,9 +15077,6 @@ exports[`ItineraryBody/otp-ui OTP2ScooterItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   rented-bike">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -15335,9 +15140,6 @@ exports[`ItineraryBody/otp-ui OTP2ScooterItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="CAR"
@@ -15862,9 +15664,6 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -16156,9 +15955,6 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="TRAM"
@@ -16483,9 +16279,6 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -16821,9 +16614,6 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -16887,9 +16677,6 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf demos__StyledItineraryBody-sc-1ckuiy0-0 fTPffU">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -17105,9 +16892,6 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="TRAM"
@@ -17446,9 +17230,6 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -17746,9 +17527,6 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -17812,9 +17590,6 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -18030,9 +17805,6 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="TRAM"
@@ -18371,9 +18143,6 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -18671,9 +18440,6 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -18737,9 +18503,6 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -18955,9 +18718,6 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="TRAM"
@@ -19296,9 +19056,6 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -19596,9 +19353,6 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -19662,9 +19416,6 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -19880,9 +19631,6 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="TRAM"
@@ -20221,9 +19969,6 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -20521,9 +20266,6 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -20587,9 +20329,6 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
 exports[`ItineraryBody/otp-ui TncTransitItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="CAR"
@@ -20697,9 +20436,6 @@ exports[`ItineraryBody/otp-ui TncTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -20780,9 +20516,6 @@ exports[`ItineraryBody/otp-ui TncTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -20935,9 +20668,6 @@ exports[`ItineraryBody/otp-ui TncTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -21018,9 +20748,6 @@ exports[`ItineraryBody/otp-ui TncTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="CAR"
@@ -21137,9 +20864,6 @@ exports[`ItineraryBody/otp-ui TncTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -21203,9 +20927,6 @@ exports[`ItineraryBody/otp-ui TncTransitItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -21707,9 +21428,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -21881,9 +21599,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -21970,9 +21685,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -22320,9 +22032,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -22830,9 +22539,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -22896,9 +22602,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="CAR"
@@ -23423,9 +23126,6 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -23717,9 +23417,6 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="TRAM"
@@ -24044,9 +23741,6 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -24382,9 +24076,6 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -24448,9 +24139,6 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="CAR"
@@ -24975,9 +24663,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -25269,9 +24954,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="TRAM"
@@ -25617,9 +25299,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -25955,9 +25634,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -26021,9 +25697,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="CAR"
@@ -26548,9 +26221,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -26842,9 +26512,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="TRAM"
@@ -27169,9 +26836,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -27507,9 +27171,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -27573,9 +27234,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -27943,9 +27601,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -28131,9 +27786,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -28223,9 +27875,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -28426,9 +28075,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -28688,9 +28334,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -28963,9 +28606,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -29187,9 +28827,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -29253,9 +28890,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui WalkOnlyItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -29465,9 +29099,6 @@ exports[`ItineraryBody/otp-ui WalkOnlyItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -29531,9 +29162,6 @@ exports[`ItineraryBody/otp-ui WalkOnlyItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -29749,9 +29377,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -29933,9 +29558,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -30195,9 +29817,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -30379,9 +29998,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -30641,9 +30257,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -30707,9 +30320,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -30956,9 +30566,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -31174,9 +30781,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -31436,9 +31040,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -31654,9 +31255,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -31947,9 +31545,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -32013,9 +31608,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
 exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -32231,9 +31823,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="TRAM"
@@ -32575,9 +32164,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -32875,9 +32461,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -32941,9 +32524,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -33508,9 +33088,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -33808,9 +33385,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -33874,9 +33448,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
 exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -34095,9 +33666,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="TRAM"
@@ -34436,9 +34004,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -34739,9 +34304,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -34805,9 +34367,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
 exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -35023,9 +34582,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="TRAM"
@@ -35378,9 +34934,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -35678,9 +35231,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -35744,9 +35294,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
 exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameComponent smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -35962,9 +35509,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameCompone
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="TRAM"
@@ -36294,9 +35838,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameCompone
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -36588,9 +36129,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameCompone
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -36654,9 +36192,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameCompone
 exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummaryComponent smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -36872,9 +36407,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="TRAM"
@@ -37215,9 +36747,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -37515,9 +37044,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -37581,9 +37107,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
 exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonActivatedAndCustomRouteAbbreviation smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -37799,9 +37322,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="TRAM"
@@ -38144,9 +37664,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -38444,9 +37961,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -38510,9 +38024,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
 exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -38728,9 +38239,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="TRAM"
@@ -39072,9 +38580,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -39372,9 +38877,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -39438,9 +38940,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
 exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -39808,9 +39307,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -39996,9 +39492,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -40088,9 +39581,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -40291,9 +39781,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -40553,9 +40040,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -40828,9 +40312,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -41052,9 +40533,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -41118,9 +40596,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -41488,9 +40963,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -41676,9 +41148,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -41768,9 +41237,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -41971,9 +41437,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -42233,9 +41696,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -42508,9 +41968,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -42732,9 +42189,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">
@@ -42798,9 +42252,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
 exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-22 hOYEJf">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -43168,9 +42619,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -43356,9 +42804,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -43448,9 +42893,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -43651,9 +43093,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -43913,9 +43352,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper transit  ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="BUS"
@@ -44188,9 +43624,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div mode="WALK"
@@ -44412,9 +43845,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
     </div>
   </li>
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-41 hmBdjd place-row-wrapper   ">
-    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-28 fYRzeA invisible-additional-details">
-      The following trip has been canceled
-    </span>
     <div class="styled__LineColumn-sc-1q8npbl-39 bxYGTg">
       <div class="styled__LegLine-sc-1q8npbl-37 eWEzno">
         <div class="styled__LineBadgeContainer-sc-1q8npbl-38 lbsiJt">


### PR DESCRIPTION
Place the screenreader text for canceled trips behind the `canceled` boolean flag, as it should be