### PR TITLE
Pass map layer fonts to transitive

### DIFF
--- a/packages/base-map/src/index.tsx
+++ b/packages/base-map/src/index.tsx
@@ -41,6 +41,7 @@ type Props = React.ComponentPropsWithoutRef<React.ElementType> & {
   center?: [number, number];
   /** A unique identifier for the map (useful when using MapProvider) */
   id?: string;
+  /** Ref to pass so that map can be accessed by the consumer  */
   innerRef?: LegacyRef<MapRef>;
   /** An object of props which should be passed down to MapLibre */
   mapLibreProps?: MapProps;

--- a/packages/base-map/src/index.tsx
+++ b/packages/base-map/src/index.tsx
@@ -2,8 +2,13 @@ import maplibregl, {
   MapLayerMouseEvent,
   MapLayerTouchEvent
 } from "maplibre-gl";
-import React, { useCallback, useState } from "react";
-import { Map, MapProps, ViewStateChangeEvent } from "react-map-gl/maplibre";
+import React, { LegacyRef, useCallback, useState } from "react";
+import {
+  Map,
+  MapProps,
+  MapRef,
+  ViewStateChangeEvent
+} from "react-map-gl/maplibre";
 
 import { useIntl } from "react-intl";
 
@@ -36,6 +41,7 @@ type Props = React.ComponentPropsWithoutRef<React.ElementType> & {
   center?: [number, number];
   /** A unique identifier for the map (useful when using MapProvider) */
   id?: string;
+  innerRef?: LegacyRef<MapRef>;
   /** An object of props which should be passed down to MapLibre */
   mapLibreProps?: MapProps;
   /** The maximum zoom level the map should allow */
@@ -68,6 +74,7 @@ const BaseMap = ({
   center,
   children,
   id,
+  innerRef,
   mapLibreProps,
   maxZoom,
   onClick,
@@ -167,6 +174,7 @@ const BaseMap = ({
       onTouchCancel={clearLongPressTimer}
       onTouchEnd={clearLongPressTimer}
       onZoom={handleViewportChange}
+      ref={innerRef}
       style={style}
     >
       {(toggleableLayers.length > 0 ||

--- a/packages/transitive-overlay/src/index.tsx
+++ b/packages/transitive-overlay/src/index.tsx
@@ -109,6 +109,9 @@ const defaultTextPaintParams = {
   "text-halo-width": 2
 };
 
+const DEFAULT_REGULAR_FONTS = ["Open Sans Regular", "Arial Unicode MS Regular"];
+const DEFAULT_BOLD_FONTS = ["Open Sans Bold", "Arial Unicode MS Bold"];
+
 /**
  * Common text settings.
  */
@@ -122,10 +125,7 @@ const commonTextLayoutParams = (
     "text-justify": "auto",
     "text-radial-offset": 1,
     "text-size": 15,
-    "text-font": vectorTileFonts?.regular || [
-      "Open Sans Regular",
-      "Arial Unicode MS Regular"
-    ]
+    "text-font": vectorTileFonts?.regular || DEFAULT_REGULAR_FONTS
   };
 };
 
@@ -437,7 +437,7 @@ const TransitiveCanvasOverlay = ({
   const boldFonts =
     vectorTileFonts?.bold.length && vectorTileFonts?.bold.length > 0
       ? vectorTileFonts.bold
-      : ["Open Sans Bold", "Arial Unicode MS Bold"];
+      : DEFAULT_BOLD_FONTS;
 
   // Generally speaking, text/symbol layers placed first will be rendered in a lower layer
   // (or, if it is text, rendered with a lower priority or not at all if higher-priority text overlaps).

--- a/packages/transitive-overlay/src/index.tsx
+++ b/packages/transitive-overlay/src/index.tsx
@@ -107,9 +107,9 @@ const defaultTextPaintParams = {
  * Common text settings.
  */
 const commonTextLayoutParams = (
-  mapLayerFonts: string[]
+  mapLayerFonts?: string[]
 ): SymbolLayerSpecification["layout"] => {
-  const regularFonts = mapLayerFonts.filter(font => font.includes("Regular"));
+  const regularFonts = mapLayerFonts?.filter(font => font.includes("Regular"));
   return {
     "symbol-placement": "point",
     "text-allow-overlap": false,
@@ -151,7 +151,10 @@ const defaultBoldTextLayoutParams = (
   return {
     ...commonTextLayoutParams,
     // FIXME: find a better way to set a bold font
-    "text-font": boldFonts || ["Open Sans Bold", "Arial Unicode MS Bold"],
+    "text-font":
+      boldFonts?.length && boldFonts.length > 0
+        ? boldFonts
+        : ["Open Sans Bold", "Arial Unicode MS Bold"],
     "text-overlap": "never"
   };
 };

--- a/packages/transitive-overlay/src/index.tsx
+++ b/packages/transitive-overlay/src/index.tsx
@@ -145,9 +145,8 @@ const defaultTextLayoutParams: SymbolLayerSpecification["layout"] = {
  * Default text + bold default fonts
  */
 const defaultBoldTextLayoutParams = (
-  mapLayerFonts?: string[]
+  boldFonts?: string[]
 ): SymbolLayerSpecification["layout"] => {
-  const boldFonts = mapLayerFonts?.filter(font => font.includes("Bold"));
   return {
     ...commonTextLayoutParams,
     // FIXME: find a better way to set a bold font
@@ -174,7 +173,7 @@ type Props = {
   accessLegColorOverride?: string;
   boundsFitting?: boolean;
   /* If applicable, pass a list of fonts supported by the custom base map layer */
-  mapLayerFonts?: string[];
+  vectorTileFonts?: string[];
   showRouteArrows?: boolean;
   transitiveData?: TransitiveData;
 };
@@ -206,7 +205,7 @@ const TransitiveCanvasOverlay = ({
   activeLeg,
   accessLegColorOverride,
   boundsFitting = true,
-  mapLayerFonts,
+  vectorTileFonts,
   showRouteArrows,
   transitiveData
 }: Props): JSX.Element => {
@@ -421,6 +420,8 @@ const TransitiveCanvasOverlay = ({
 
   const { fromAnchor, toAnchor } = getFromToAnchors(transitiveData);
 
+  const boldFonts = vectorTileFonts?.filter(font => font.includes("Bold"));
+
   // Generally speaking, text/symbol layers placed first will be rendered in a lower layer
   // (or, if it is text, rendered with a lower priority or not at all if higher-priority text overlaps).
   return (
@@ -544,7 +545,7 @@ const TransitiveCanvasOverlay = ({
         // This layer renders transit route names (foreground).
         filter={routeFilter}
         id="routes-labels"
-        layout={getRouteLayerLayout("name", mapLayerFonts)}
+        layout={getRouteLayerLayout("name", boldFonts)}
         paint={{
           "icon-color": ["get", "color"],
           "text-color": ["get", "textColor"]
@@ -555,7 +556,7 @@ const TransitiveCanvasOverlay = ({
         filter={["==", "type", "from"]}
         id="from-label"
         layout={{
-          ...defaultBoldTextLayoutParams(mapLayerFonts),
+          ...defaultBoldTextLayoutParams(boldFonts),
           "text-anchor": fromAnchor
         }}
         paint={defaultTextPaintParams}

--- a/packages/transitive-overlay/src/index.tsx
+++ b/packages/transitive-overlay/src/index.tsx
@@ -106,13 +106,22 @@ const defaultTextPaintParams = {
 /**
  * Common text settings.
  */
-const commonTextLayoutParams: SymbolLayerSpecification["layout"] = {
-  "symbol-placement": "point",
-  "text-allow-overlap": false,
-  "text-field": ["get", "name"],
-  "text-justify": "auto",
-  "text-radial-offset": 1,
-  "text-size": 15
+const commonTextLayoutParams = (
+  mapLayerFonts: string[]
+): SymbolLayerSpecification["layout"] => {
+  const regularFonts = mapLayerFonts.filter(font => font.includes("Regular"));
+  return {
+    "symbol-placement": "point",
+    "text-allow-overlap": false,
+    "text-field": ["get", "name"],
+    "text-justify": "auto",
+    "text-radial-offset": 1,
+    "text-size": 15,
+    "text-font": regularFonts || [
+      "Open Sans Regular",
+      "Arial Unicode MS Regular"
+    ]
+  };
 };
 
 /**
@@ -135,11 +144,16 @@ const defaultTextLayoutParams: SymbolLayerSpecification["layout"] = {
 /**
  * Default text + bold default fonts
  */
-const defaultBoldTextLayoutParams: SymbolLayerSpecification["layout"] = {
-  ...commonTextLayoutParams,
-  // FIXME: find a better way to set a bold font
-  "text-font": ["Open Sans Bold", "Arial Unicode MS Bold"],
-  "text-overlap": "never"
+const defaultBoldTextLayoutParams = (
+  mapLayerFonts?: string[]
+): SymbolLayerSpecification["layout"] => {
+  const boldFonts = mapLayerFonts?.filter(font => font.includes("Bold"));
+  return {
+    ...commonTextLayoutParams,
+    // FIXME: find a better way to set a bold font
+    "text-font": boldFonts || ["Open Sans Bold", "Arial Unicode MS Bold"],
+    "text-overlap": "never"
+  };
 };
 
 const routeFilter: FilterSpecification = ["==", "type", "route"];
@@ -156,6 +170,8 @@ type Props = {
   activeLeg?: Leg;
   accessLegColorOverride?: string;
   boundsFitting?: boolean;
+  /* If applicable, pass a list of fonts supported by the custom base map layer */
+  mapLayerFonts?: string[];
   showRouteArrows?: boolean;
   transitiveData?: TransitiveData;
 };
@@ -187,6 +203,7 @@ const TransitiveCanvasOverlay = ({
   activeLeg,
   accessLegColorOverride,
   boundsFitting = true,
+  mapLayerFonts,
   showRouteArrows,
   transitiveData
 }: Props): JSX.Element => {
@@ -524,7 +541,7 @@ const TransitiveCanvasOverlay = ({
         // This layer renders transit route names (foreground).
         filter={routeFilter}
         id="routes-labels"
-        layout={getRouteLayerLayout("name")}
+        layout={getRouteLayerLayout("name", mapLayerFonts)}
         paint={{
           "icon-color": ["get", "color"],
           "text-color": ["get", "textColor"]
@@ -535,7 +552,7 @@ const TransitiveCanvasOverlay = ({
         filter={["==", "type", "from"]}
         id="from-label"
         layout={{
-          ...defaultBoldTextLayoutParams,
+          ...defaultBoldTextLayoutParams(mapLayerFonts),
           "text-anchor": fromAnchor
         }}
         paint={defaultTextPaintParams}

--- a/packages/transitive-overlay/src/index.tsx
+++ b/packages/transitive-overlay/src/index.tsx
@@ -115,7 +115,6 @@ const defaultTextPaintParams = {
 const commonTextLayoutParams = (
   vectorTileFonts?: SortedFonts
 ): SymbolLayerSpecification["layout"] => {
-  const regularFonts = vectorTileFonts?.regular;
   return {
     "symbol-placement": "point",
     "text-allow-overlap": false,
@@ -123,7 +122,7 @@ const commonTextLayoutParams = (
     "text-justify": "auto",
     "text-radial-offset": 1,
     "text-size": 15,
-    "text-font": regularFonts || [
+    "text-font": vectorTileFonts?.regular || [
       "Open Sans Regular",
       "Arial Unicode MS Regular"
     ]

--- a/packages/transitive-overlay/src/index.tsx
+++ b/packages/transitive-overlay/src/index.tsx
@@ -1,6 +1,6 @@
 import { FilterSpecification, SymbolLayerSpecification } from "maplibre-gl";
 import { util } from "@opentripplanner/base-map";
-import React, { useEffect } from "react";
+import React, { RefObject, useEffect, useState } from "react";
 import { Layer, MapRef, Source, useMap } from "react-map-gl/maplibre";
 import polyline from "@mapbox/polyline";
 import {
@@ -21,7 +21,13 @@ import {
   LineString
 } from "geojson";
 import { getRouteLayerLayout, patternToRouteFeature } from "./route-layers";
-import { drawArc, getFromToAnchors, itineraryToTransitive } from "./util";
+import {
+  drawArc,
+  getFromToAnchors,
+  itineraryToTransitive,
+  getFontsFromVectorTiles,
+  SortedFonts
+} from "./util";
 import routeArrow from "./images/route_arrow.png";
 import capsule1 from "./images/01.png";
 import capsule3 from "./images/03.png";
@@ -107,9 +113,9 @@ const defaultTextPaintParams = {
  * Common text settings.
  */
 const commonTextLayoutParams = (
-  mapLayerFonts?: string[]
+  vectorTileFonts?: SortedFonts
 ): SymbolLayerSpecification["layout"] => {
-  const regularFonts = mapLayerFonts?.filter(font => font.includes("Regular"));
+  const regularFonts = vectorTileFonts?.regular;
   return {
     "symbol-placement": "point",
     "text-allow-overlap": false,
@@ -172,8 +178,8 @@ type Props = {
   activeLeg?: Leg;
   accessLegColorOverride?: string;
   boundsFitting?: boolean;
-  /* If applicable, pass a list of fonts supported by the custom base map layer */
-  vectorTileFonts?: string[];
+  /* Reference to the map you're rendering the transitive layer onto */
+  mapRef?: RefObject<MapRef>;
   showRouteArrows?: boolean;
   transitiveData?: TransitiveData;
 };
@@ -205,11 +211,23 @@ const TransitiveCanvasOverlay = ({
   activeLeg,
   accessLegColorOverride,
   boundsFitting = true,
-  vectorTileFonts,
+  mapRef,
   showRouteArrows,
   transitiveData
 }: Props): JSX.Element => {
   const { current: map } = useMap();
+  const [mapLoaded, setMapLoaded] = useState(false);
+  const [vectorTileFonts, setVectorTileFonts] = useState<
+    SortedFonts | undefined
+  >(undefined);
+
+  mapRef?.current?.on("load", () => setMapLoaded(true));
+
+  useEffect(() => {
+    const fonts =
+      mapRef?.current && mapLoaded && getFontsFromVectorTiles(mapRef?.current);
+    setVectorTileFonts(fonts || undefined);
+  }, [map, mapLoaded]);
 
   const mapImages: MapImage[] = [];
   // This is used to render arrows along the route
@@ -420,7 +438,7 @@ const TransitiveCanvasOverlay = ({
 
   const { fromAnchor, toAnchor } = getFromToAnchors(transitiveData);
 
-  const boldFonts = vectorTileFonts?.filter(font => font.includes("Bold"));
+  const boldFonts = vectorTileFonts?.bold;
 
   // Generally speaking, text/symbol layers placed first will be rendered in a lower layer
   // (or, if it is text, rendered with a lower priority or not at all if higher-priority text overlaps).

--- a/packages/transitive-overlay/src/index.tsx
+++ b/packages/transitive-overlay/src/index.tsx
@@ -156,10 +156,7 @@ const defaultBoldTextLayoutParams = (
   return {
     ...commonTextLayoutParams,
     // FIXME: find a better way to set a bold font
-    "text-font":
-      boldFonts?.length && boldFonts.length > 0
-        ? boldFonts
-        : ["Open Sans Bold", "Arial Unicode MS Bold"],
+    "text-font": boldFonts,
     "text-overlap": "never"
   };
 };
@@ -438,7 +435,10 @@ const TransitiveCanvasOverlay = ({
 
   const { fromAnchor, toAnchor } = getFromToAnchors(transitiveData);
 
-  const boldFonts = vectorTileFonts?.bold;
+  const boldFonts =
+    vectorTileFonts?.bold.length && vectorTileFonts?.bold.length > 0
+      ? vectorTileFonts.bold
+      : ["Open Sans Bold", "Arial Unicode MS Bold"];
 
   // Generally speaking, text/symbol layers placed first will be rendered in a lower layer
   // (or, if it is text, rendered with a lower priority or not at all if higher-priority text overlaps).

--- a/packages/transitive-overlay/src/route-layers.ts
+++ b/packages/transitive-overlay/src/route-layers.ts
@@ -95,7 +95,10 @@ export function getRouteLayerLayout(
     ] as ExpressionSpecification,
     "text-allow-overlap": true,
     "text-field": ["get", textField],
-    "text-font": boldFonts || ["Open Sans Bold", "Arial Unicode MS Bold"],
+    "text-font":
+      boldFonts?.length && boldFonts.length > 0
+        ? boldFonts
+        : ["Open Sans Bold", "Arial Unicode MS Bold"],
     "text-ignore-placement": true,
     "text-justify": "left",
     "text-line-height": 0.5,

--- a/packages/transitive-overlay/src/route-layers.ts
+++ b/packages/transitive-overlay/src/route-layers.ts
@@ -94,10 +94,7 @@ export function getRouteLayerLayout(
     ] as ExpressionSpecification,
     "text-allow-overlap": true,
     "text-field": ["get", textField],
-    "text-font":
-      boldFonts?.length && boldFonts.length > 0
-        ? boldFonts
-        : ["Open Sans Bold", "Arial Unicode MS Bold"],
+    "text-font": boldFonts,
     "text-ignore-placement": true,
     "text-justify": "left",
     "text-line-height": 0.5,

--- a/packages/transitive-overlay/src/route-layers.ts
+++ b/packages/transitive-overlay/src/route-layers.ts
@@ -54,7 +54,8 @@ export function patternToRouteFeature(
  * Obtains common layout options for route label layers.
  */
 export function getRouteLayerLayout(
-  textField: string
+  textField: string,
+  mapLayerFonts?: string[]
 ): SymbolLayerSpecification["layout"] {
   // Generates a single icon based on the string length
   function generateIcon(length: number) {
@@ -71,6 +72,7 @@ export function getRouteLayerLayout(
     "rect"
   ];
 
+  const boldFonts = mapLayerFonts?.filter(font => font.includes("Bold"));
   // TODO: Tweak shape of roundels for perfect circle
   return {
     "icon-image": iconImage as ExpressionSpecification,
@@ -93,7 +95,7 @@ export function getRouteLayerLayout(
     ] as ExpressionSpecification,
     "text-allow-overlap": true,
     "text-field": ["get", textField],
-    "text-font": ["Open Sans Bold", "Arial Unicode MS Bold"],
+    "text-font": boldFonts || ["Open Sans Bold", "Arial Unicode MS Bold"],
     "text-ignore-placement": true,
     "text-justify": "left",
     "text-line-height": 0.5,

--- a/packages/transitive-overlay/src/route-layers.ts
+++ b/packages/transitive-overlay/src/route-layers.ts
@@ -55,7 +55,7 @@ export function patternToRouteFeature(
  */
 export function getRouteLayerLayout(
   textField: string,
-  mapLayerFonts?: string[]
+  boldFonts?: string[]
 ): SymbolLayerSpecification["layout"] {
   // Generates a single icon based on the string length
   function generateIcon(length: number) {
@@ -72,7 +72,6 @@ export function getRouteLayerLayout(
     "rect"
   ];
 
-  const boldFonts = mapLayerFonts?.filter(font => font.includes("Bold"));
   // TODO: Tweak shape of roundels for perfect circle
   return {
     "icon-image": iconImage as ExpressionSpecification,

--- a/packages/transitive-overlay/src/util.ts
+++ b/packages/transitive-overlay/src/util.ts
@@ -549,13 +549,16 @@ const getFontsFromVectorTiles = (map: MapRef): SortedFonts => {
   });
   // Once we have a list of unique fonts, sort them into bold and regular buckets
   fonts.forEach(f => {
-    const font = f.toLowerCase();
-    if (font.includes("italic")) {
-      sortedFonts.italic.push(f);
-    } else if (font.includes("bold")) {
-      sortedFonts.bold.push(f);
-    } else {
-      sortedFonts.regular.push(f);
+    const fontLowerCase = f.toLowerCase();
+    switch (true) {
+      case fontLowerCase.includes("italic"):
+        sortedFonts.italic.push(f);
+        break;
+      case fontLowerCase.includes("bold"):
+        sortedFonts.bold.push(f);
+        break;
+      default:
+        sortedFonts.regular.push(f);
     }
   });
 

--- a/packages/transitive-overlay/src/util.ts
+++ b/packages/transitive-overlay/src/util.ts
@@ -22,6 +22,7 @@ import {
 import { PositionAnchor } from "maplibre-gl";
 import { IntlShape } from "react-intl";
 import { LineString } from "geojson";
+import { MapRef } from "react-map-gl/maplibre";
 
 const {
   getLegBounds,
@@ -33,6 +34,12 @@ const {
 } = coreUtils.itinerary;
 
 const CAR_PARK_ITIN_PREFIX = "itin_car_";
+
+export type SortedFonts = {
+  bold: string[];
+  regular: string[];
+  italic: string[];
+};
 
 /**
  * Helper function to convert a stop from an itinerary leg
@@ -527,5 +534,33 @@ const drawArc = (straight: LineString) => {
   ).geometry;
 };
 
-export { drawArc };
+const getFontsFromVectorTiles = (map: MapRef): SortedFonts => {
+  const fonts: string[] = [];
+  const sortedFonts: SortedFonts = {
+    bold: [],
+    regular: [],
+    italic: []
+  };
+
+  map.getStyle()?.layers?.forEach((l: any) => {
+    const fontLayers = l.layout && l.layout["text-font"];
+    // There are often duplicates so first filter those out.
+    fontLayers?.forEach((f: string) => !fonts.includes(f) && fonts.push(f));
+  });
+  // Once we have a list of unique fonts, sort them into bold and regular buckets
+  fonts.forEach(f => {
+    const font = f.toLowerCase();
+    if (font.includes("italic")) {
+      sortedFonts.italic.push(f);
+    } else if (font.includes("bold")) {
+      sortedFonts.bold.push(f);
+    } else {
+      sortedFonts.regular.push(f);
+    }
+  });
+
+  return sortedFonts;
+};
+
+export { drawArc, getFontsFromVectorTiles };
 export default { itineraryToTransitive };

--- a/packages/transitive-overlay/src/util.ts
+++ b/packages/transitive-overlay/src/util.ts
@@ -535,7 +535,7 @@ const drawArc = (straight: LineString) => {
 };
 
 const getFontsFromVectorTiles = (map: MapRef): SortedFonts => {
-  const fonts: string[] = [];
+  const fonts: Set<string> = new Set();
   const sortedFonts: SortedFonts = {
     bold: [],
     regular: [],
@@ -545,7 +545,7 @@ const getFontsFromVectorTiles = (map: MapRef): SortedFonts => {
   map.getStyle()?.layers?.forEach((l: any) => {
     const fontLayers = l.layout && l.layout["text-font"];
     // There are often duplicates so first filter those out.
-    fontLayers?.forEach((f: string) => !fonts.includes(f) && fonts.push(f));
+    fontLayers?.forEach((f: string) => fonts.add(f));
   });
   // Once we have a list of unique fonts, sort them into bold and regular buckets
   fonts.forEach(f => {


### PR DESCRIPTION
Using custom vector tiles can sometimes break the transitive overlay. This is because our custom `Layer` code requests certain fonts that are not always available in the tiles, resulting in an error. To provide a way to handle this, the followings changes are made to the following packages:

Base map:
- Map `ref` is exposed to the consumer

Transitive Overlay:
- Overlay now accepts the `vectorTileFonts<string[]>` as a prop. If users know which fonts are supported in their map layers, the can pass all the fonts at once to the overlay.

