### PR TITLE
Update dependency array to incorporate closedStops

### DIFF
--- a/packages/otp2-tile-overlay/src/index.tsx
+++ b/packages/otp2-tile-overlay/src/index.tsx
@@ -165,7 +165,7 @@ const OTP2TileLayerWithPopup = ({
       map?.off("mouseleave", `${id}-secondary`, onLayerLeave);
       map?.off("click", `${id}-secondary`, onMapClick || defaultClickHandler);
     };
-  }, [id, map]);
+  }, [closedStops, id, map]);
 
   let filter: FilterSpecification = ["all"];
   if (network) {


### PR DESCRIPTION
The lack of `closedStops` in the dependency array for a `useEffect` was causing the click handler to hold onto an `undefined` value for `closedStops` instead of the updated value once the query is completed.