### PR TITLE
fix: Location Field Aria Disabled Fix Logic 

### DIFF
--- a/.changeset/location-field-aria-disabled.md
+++ b/.changeset/location-field-aria-disabled.md
@@ -1,0 +1,5 @@
+---
+"@opentripplanner/location-field": patch
+---
+
+Fix `aria-disabled` and `aria-expanded` on the location field dropdown toggle when there are no selectable suggestions.

--- a/.changeset/location-field-aria-disabled.md
+++ b/.changeset/location-field-aria-disabled.md
@@ -2,4 +2,4 @@
 "@opentripplanner/location-field": patch
 ---
 
-Fix `aria-disabled` and `aria-expanded` on the location field dropdown toggle when there are no selectable suggestions.
+Fix location field ARIA when there are no selectable options: stop counting disabled current-location in the selectable lookup, set `aria-expanded="false"` when nothing is selectable, set `aria-disabled` only when the menu is completely empty, and include unavailable status in the toggle and combobox accessible names for screen readers.

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -1000,7 +1000,7 @@ const LocationField = ({
   let optionTitle;
   let positionUnavailable;
 
-  if (currentPosition && !currentPosition.error) {
+  if (currentPosition?.coords && !currentPosition.error) {
     // current position detected successfully
     locationSelected = useCurrentLocation;
     optionIcon = currentPositionIcon;
@@ -1029,10 +1029,12 @@ const LocationField = ({
 
   const optionId = `current-position`;
 
-  // Add to the selection handler lookup (for use in onKeyDown)
-  pushToIndexedOptions(locationSelected, optionId);
-
   if (!suppressNearby) {
+    if (!positionUnavailable) {
+      // Add to the selection handler lookup (for use in onKeyDown)
+      pushToIndexedOptions(locationSelected, optionId);
+    }
+
     // Create and add the option item to the menu items array
     menuItems.push(
       <Option
@@ -1059,9 +1061,8 @@ const LocationField = ({
     }
     statusMessages.push(message);
   }
-
   // Store the number of location-associated items for reference in the onKeyDown method
-  let menuItemCount = indexedOptionLookup.length;
+  const menuItemCount = indexedOptionLookup.length;
 
   /** the text input element * */
   // Use this text for aria-label below if no user-provided label.
@@ -1072,8 +1073,19 @@ const LocationField = ({
     currentPosition && currentPosition.fetching
       ? intl.formatMessage({ id: "otpUi.LocationField.fetchingLocation" })
       : defaultPlaceholder;
-  const hasNoEnabledOptions = menuItemCount === 0;
-  const isExpanded = isStatic || menuVisible;
+
+  // Disable the toggle when the only menu item is "Current location not available".
+  // Disabled rows are not added to indexedOptionLookup, so the lookup is empty here.
+  const toggleDisabled =
+    menuItemCount === 0 &&
+    (menuItems.length === 0 ||
+      (positionUnavailable && !suppressNearby && menuItems.length === 1));
+
+  const isMenuOpen = isStatic || menuVisible;
+  const isExpanded = isMenuOpen && !toggleDisabled;
+  const ariaDisabled = toggleDisabled ? "true" : undefined;
+  const showMenuList = isStatic || menuItems.length > 0;
+  const listBoxControls = showMenuList ? listBoxId : undefined;
 
   const textControl = (
     <S.Input
@@ -1081,7 +1093,7 @@ const LocationField = ({
         activeIndex !== null ? indexedOptionLookup[activeIndex]?.id : null
       }
       aria-autocomplete="list"
-      aria-controls={listBoxId}
+      aria-controls={listBoxControls}
       aria-expanded={isExpanded}
       aria-haspopup="listbox"
       aria-invalid={!isValid}
@@ -1123,7 +1135,8 @@ const LocationField = ({
   return (
     <S.InputGroup className={className} onBlur={onBlurFormGroup} role="group">
       <S.DropdownButton
-        aria-controls={listBoxId}
+        aria-controls={listBoxControls}
+        aria-disabled={ariaDisabled}
         aria-expanded={isExpanded}
         aria-label={intl.formatMessage({
           defaultMessage: "Open the list of location suggestions",
@@ -1134,7 +1147,6 @@ const LocationField = ({
         onClick={onDropdownToggle}
         tabIndex={-1}
         type="button"
-        aria-disabled={hasNoEnabledOptions}
       >
         <LocationIconComponent locationType={locationType} />
       </S.DropdownButton>
@@ -1145,7 +1157,7 @@ const LocationField = ({
       <S.HiddenContent role="status">
         {/* However, only render the status if the menu is expanded, so that
             assistive technology reminds user on how to navigate the options. */}
-        {isExpanded && (
+        {isMenuOpen && (
           <FormattedList
             // eslint-disable-next-line react/style-prop-object
             style="narrow"
@@ -1154,35 +1166,38 @@ const LocationField = ({
           />
         )}
       </S.HiddenContent>
-      <ItemList
-        // Hide the list from screen readers if no enabled options are shown.
-        aria-hidden={hasNoEnabledOptions || !menuVisible}
-        aria-label={intl.formatMessage({
-          defaultMessage: "Suggested locations",
-          description:
-            "Text to show as a label for the dropdown list of locations",
-          id: "otpUi.LocationField.suggestedLocations"
-        })}
-        id={listBoxId}
-      >
-        {isStatic ? (
-          menuItems.length > 0 ? ( // Show typing prompt to avoid empty screen
-            menuItems
+      {showMenuList && (
+        <ItemList
+          $menuOpen={isMenuOpen}
+          // Hide the list from screen readers if no enabled options are shown.
+          aria-hidden={toggleDisabled || !isMenuOpen}
+          aria-label={intl.formatMessage({
+            defaultMessage: "Suggested locations",
+            description:
+              "Text to show as a label for the dropdown list of locations",
+            id: "otpUi.LocationField.suggestedLocations"
+          })}
+          id={listBoxId}
+        >
+          {isStatic ? (
+            menuItems.length > 0 ? ( // Show typing prompt to avoid empty screen
+              menuItems
+            ) : (
+              <S.MenuGroupHeader as="div">
+                <FormattedMessage
+                  defaultMessage={
+                    defaultMessages["otpUi.LocationField.beginTypingPrompt"]
+                  }
+                  description="Text to show as initial placeholder in location search field"
+                  id="otpUi.LocationField.beginTypingPrompt"
+                />
+              </S.MenuGroupHeader>
+            )
           ) : (
-            <S.MenuGroupHeader as="div">
-              <FormattedMessage
-                defaultMessage={
-                  defaultMessages["otpUi.LocationField.beginTypingPrompt"]
-                }
-                description="Text to show as initial placeholder in location search field"
-                id="otpUi.LocationField.beginTypingPrompt"
-              />
-            </S.MenuGroupHeader>
-          )
-        ) : (
-          menuVisible && menuItems
-        )}
-      </ItemList>
+            menuVisible && menuItems
+          )}
+        </ItemList>
+      )}
     </S.InputGroup>
   );
 };

--- a/packages/location-field/src/index.tsx
+++ b/packages/location-field/src/index.tsx
@@ -1013,6 +1013,7 @@ const LocationField = ({
     // If there is an error, concatenate the error message in parentheses.
     optionIcon = currentPositionUnavailableIcon;
     const locationUnavailableText = intl.formatMessage({
+      defaultMessage: "Current location not available",
       description: "Current location unavailable status",
       id: "otpUi.LocationField.currentLocationUnavailable"
     });
@@ -1064,28 +1065,56 @@ const LocationField = ({
   // Store the number of location-associated items for reference in the onKeyDown method
   const menuItemCount = indexedOptionLookup.length;
 
+  // Visual open state (CSS $menuOpen) is separate from aria-expanded.
+  const isMenuOpen = isStatic || menuVisible;
+
+  // Report expanded only when there are selectable options (keyboard + assistive technology).
+  const isExpanded = isMenuOpen && menuItemCount > 0;
+
+  // Disable the toggle only when there is nothing to show (e.g. suppressNearby with
+  // no other results). Informational rows such as "Current location not available"
+  // still count as menu content, so the toggle stays enabled in that case.
+  const toggleDisabled = menuItems.length === 0;
+  const ariaDisabled = toggleDisabled ? "true" : undefined;
+
+  // Avoid rendering an empty listbox shell when there are no menu rows.
+  const showMenuList = isStatic || menuItems.length > 0;
+  const listBoxControls = showMenuList ? listBoxId : undefined;
+
+  const statusAnnouncementText = statusMessages.filter(Boolean).join(". ");
+
+  // Assertive status when the menu is open but has no selectable options.
+  const hasStatusOnlyMenu =
+    isMenuOpen && menuItemCount === 0 && statusAnnouncementText.length > 0;
+
+  // Include status text in the accessible name when nothing is selectable
+  // (Mac VoiceOver does not reliably read aria-describedby on pin focus).
+  const showStatusDescription =
+    menuItemCount === 0 && statusAnnouncementText.length > 0;
+
+  const suggestedLocationsToggleLabel = intl.formatMessage({
+    defaultMessage: "Toggle displaying the list of suggested locations",
+    description:
+      "Text to show as a a11y label for the button that opens the dropdown list of locations",
+    id: "otpUi.LocationField.suggestedLocationsLong"
+  });
+  const toggleAriaLabel = showStatusDescription
+    ? `${suggestedLocationsToggleLabel}. ${statusAnnouncementText}`
+    : suggestedLocationsToggleLabel;
+
   /** the text input element * */
   // Use this text for aria-label below if no user-provided label.
   const defaultPlaceholder =
     inputPlaceholder || (customLabelInputId ? undefined : locationType);
   const ariaLabel = customLabelInputId ? undefined : defaultPlaceholder;
+  const comboboxAriaLabel =
+    showStatusDescription && ariaLabel
+      ? `${ariaLabel}. ${statusAnnouncementText}`
+      : ariaLabel;
   const placeholder =
     currentPosition && currentPosition.fetching
       ? intl.formatMessage({ id: "otpUi.LocationField.fetchingLocation" })
       : defaultPlaceholder;
-
-  // Disable the toggle when the only menu item is "Current location not available".
-  // Disabled rows are not added to indexedOptionLookup, so the lookup is empty here.
-  const toggleDisabled =
-    menuItemCount === 0 &&
-    (menuItems.length === 0 ||
-      (positionUnavailable && !suppressNearby && menuItems.length === 1));
-
-  const isMenuOpen = isStatic || menuVisible;
-  const isExpanded = isMenuOpen && !toggleDisabled;
-  const ariaDisabled = toggleDisabled ? "true" : undefined;
-  const showMenuList = isStatic || menuItems.length > 0;
-  const listBoxControls = showMenuList ? listBoxId : undefined;
 
   const textControl = (
     <S.Input
@@ -1097,7 +1126,7 @@ const LocationField = ({
       aria-expanded={isExpanded}
       aria-haspopup="listbox"
       aria-invalid={!isValid}
-      aria-label={ariaLabel}
+      aria-label={comboboxAriaLabel}
       aria-required={isRequired}
       autoFocus={autoFocus}
       className={formControlClassname}
@@ -1138,12 +1167,7 @@ const LocationField = ({
         aria-controls={listBoxControls}
         aria-disabled={ariaDisabled}
         aria-expanded={isExpanded}
-        aria-label={intl.formatMessage({
-          defaultMessage: "Open the list of location suggestions",
-          description:
-            "Text to show as a a11y label for the button that opens the dropdown list of locations",
-          id: "otpUi.LocationField.suggestedLocationsLong"
-        })}
+        aria-label={toggleAriaLabel}
         onClick={onDropdownToggle}
         tabIndex={-1}
         type="button"
@@ -1152,12 +1176,12 @@ const LocationField = ({
       </S.DropdownButton>
       {textControl}
       {clearButton}
-      {/* Note: always render this status tag regardless of the open state,
-          so that assistive technologies correctly set up status monitoring. */}
-      <S.HiddenContent role="status">
-        {/* However, only render the status if the menu is expanded, so that
-            assistive technology reminds user on how to navigate the options. */}
-        {isMenuOpen && (
+      {/* Live status when the menu is open (assertive when nothing is selectable). */}
+      <S.HiddenContent
+        aria-live={hasStatusOnlyMenu ? "assertive" : "polite"}
+        role="status"
+      >
+        {isMenuOpen && statusMessages.length > 0 && (
           <FormattedList
             // eslint-disable-next-line react/style-prop-object
             style="narrow"
@@ -1169,8 +1193,7 @@ const LocationField = ({
       {showMenuList && (
         <ItemList
           $menuOpen={isMenuOpen}
-          // Hide the list from screen readers if no enabled options are shown.
-          aria-hidden={toggleDisabled || !isMenuOpen}
+          aria-hidden={!isMenuOpen}
           aria-label={intl.formatMessage({
             defaultMessage: "Suggested locations",
             description:

--- a/packages/location-field/src/stories/Desktop.story.tsx
+++ b/packages/location-field/src/stories/Desktop.story.tsx
@@ -296,3 +296,15 @@ export const WithCustomLabel = (): JSX.Element => (
     />
   </>
 );
+
+export const SupressNearby = (): JSX.Element => (
+  <LocationField
+    currentPosition={currentPosition}
+    geocoderConfig={geocoderConfig}
+    getCurrentPosition={getCurrentPosition}
+    inputPlaceholder="Select from location"
+    locationType="from"
+    onLocationSelected={onLocationSelected}
+    suppressNearby
+  />
+);

--- a/packages/location-field/src/stories/Mobile.story.tsx
+++ b/packages/location-field/src/stories/Mobile.story.tsx
@@ -88,6 +88,19 @@ const StyledLocationField = styled(LocationField)`
   }
 `;
 
+const a11yOverrideParameters = {
+  a11y: {
+    config: {
+      rules: [
+        // This is a story issue, not a production issue
+        { id: "label", enabled: false },
+        // Group headers inside the listbox are not role="option" elements
+        { id: "aria-required-children", enabled: false }
+      ]
+    }
+  }
+};
+
 export default {
   component: LocationField,
   parameters: {
@@ -96,7 +109,8 @@ export default {
     controls: {
       hideNoControlsWarning: true,
       include: []
-    }
+    },
+    ...a11yOverrideParameters
   },
   title: "LocationField/Mobile Context",
 } as Meta<typeof LocationField>;

--- a/packages/location-field/src/stories/__snapshots__/Desktop.story.tsx.snap
+++ b/packages/location-field/src/stories/__snapshots__/Desktop.story.tsx.snap
@@ -16,7 +16,6 @@ exports[`LocationField/Desktop Context AutoFocusWithMultipleControls smoke-test 
             aria-label="Toggle displaying the list of suggested locations"
             tabindex="-1"
             type="button"
-            aria-disabled="false"
             class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
     >
       <svg viewbox="0 0 512 512"
@@ -55,7 +54,7 @@ exports[`LocationField/Desktop Context AutoFocusWithMultipleControls smoke-test 
         aria-label="Suggested locations"
         id="from-listbox"
         role="listbox"
-        class="styled__MenuItemList-sc-xahsq2-5 eCrJvo"
+        class="styled__MenuItemList-sc-xahsq2-5 fdpjmo"
     >
     </ul>
   </div>
@@ -71,7 +70,6 @@ exports[`LocationField/Desktop Context Blank smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -110,7 +108,7 @@ exports[`LocationField/Desktop Context Blank smoke-test 1`] = `
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 eCrJvo"
+      class="styled__MenuItemList-sc-xahsq2-5 fdpjmo"
   >
   </ul>
 </div>
@@ -125,7 +123,6 @@ exports[`LocationField/Desktop Context GeocoderNoResults smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -164,7 +161,7 @@ exports[`LocationField/Desktop Context GeocoderNoResults smoke-test 1`] = `
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 eCrJvo"
+      class="styled__MenuItemList-sc-xahsq2-5 fdpjmo"
   >
   </ul>
 </div>
@@ -179,7 +176,6 @@ exports[`LocationField/Desktop Context GeocoderUnreachable smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -218,7 +214,7 @@ exports[`LocationField/Desktop Context GeocoderUnreachable smoke-test 1`] = `
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 eCrJvo"
+      class="styled__MenuItemList-sc-xahsq2-5 fdpjmo"
   >
   </ul>
 </div>
@@ -233,7 +229,6 @@ exports[`LocationField/Desktop Context HereGeocoder smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -272,7 +267,7 @@ exports[`LocationField/Desktop Context HereGeocoder smoke-test 1`] = `
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 eCrJvo"
+      class="styled__MenuItemList-sc-xahsq2-5 fdpjmo"
   >
   </ul>
 </div>
@@ -283,11 +278,11 @@ exports[`LocationField/Desktop Context LocationUnavailable smoke-test 1`] = `
      role="group"
 >
   <button aria-controls="from-listbox"
+          aria-disabled="true"
           aria-expanded="false"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -326,7 +321,7 @@ exports[`LocationField/Desktop Context LocationUnavailable smoke-test 1`] = `
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 eCrJvo"
+      class="styled__MenuItemList-sc-xahsq2-5 fdpjmo"
   >
   </ul>
 </div>
@@ -348,7 +343,6 @@ exports[`LocationField/Desktop Context NoAutoFocusWithMultipleControls smoke-tes
             aria-label="Toggle displaying the list of suggested locations"
             tabindex="-1"
             type="button"
-            aria-disabled="false"
             class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
     >
       <svg viewbox="0 0 512 512"
@@ -387,7 +381,7 @@ exports[`LocationField/Desktop Context NoAutoFocusWithMultipleControls smoke-tes
         aria-label="Suggested locations"
         id="from-listbox"
         role="listbox"
-        class="styled__MenuItemList-sc-xahsq2-5 eCrJvo"
+        class="styled__MenuItemList-sc-xahsq2-5 fdpjmo"
     >
     </ul>
   </div>
@@ -403,7 +397,6 @@ exports[`LocationField/Desktop Context RequiredAndInvalidState smoke-test 1`] = 
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -442,7 +435,7 @@ exports[`LocationField/Desktop Context RequiredAndInvalidState smoke-test 1`] = 
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 eCrJvo"
+      class="styled__MenuItemList-sc-xahsq2-5 fdpjmo"
   >
   </ul>
 </div>
@@ -457,7 +450,6 @@ exports[`LocationField/Desktop Context SelectedLocation smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"
@@ -515,7 +507,7 @@ exports[`LocationField/Desktop Context SelectedLocation smoke-test 1`] = `
       aria-label="Suggested locations"
       id="to-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 eCrJvo"
+      class="styled__MenuItemList-sc-xahsq2-5 fdpjmo"
   >
   </ul>
 </div>
@@ -530,7 +522,6 @@ exports[`LocationField/Desktop Context SelectedLocationCustomClear smoke-test 1`
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"
@@ -588,7 +579,7 @@ exports[`LocationField/Desktop Context SelectedLocationCustomClear smoke-test 1`
       aria-label="Suggested locations"
       id="to-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 eCrJvo"
+      class="styled__MenuItemList-sc-xahsq2-5 fdpjmo"
   >
   </ul>
 </div>
@@ -603,7 +594,6 @@ exports[`LocationField/Desktop Context SlowGeocoder smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -642,9 +632,54 @@ exports[`LocationField/Desktop Context SlowGeocoder smoke-test 1`] = `
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 eCrJvo"
+      class="styled__MenuItemList-sc-xahsq2-5 fdpjmo"
   >
   </ul>
+</div>
+`;
+
+exports[`LocationField/Desktop Context SupressNearby smoke-test 1`] = `
+<div class="styled__InputGroup-sc-xahsq2-7 erfoji"
+     role="group"
+>
+  <button aria-disabled="true"
+          aria-expanded="false"
+          aria-label="Toggle displaying the list of suggested locations"
+          tabindex="-1"
+          type="button"
+          class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
+  >
+    <svg viewbox="0 0 512 512"
+         height="13"
+         width="13"
+         aria-hidden="true"
+         focusable="false"
+         fill="currentColor"
+         xmlns="http://www.w3.org/2000/svg"
+         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__FromIcon-sc-n5xcvc-0 dDqEuj"
+    >
+      <path fill="currentColor"
+            d="M160 256c0-53.9 42.1-96 96-96 53 0 96 42.1 96 96 0 53-43 96-96 96-53.9 0-96-43-96-96zm352 0c0 141.4-114.6 256-256 256S0 397.4 0 256 114.6 0 256 0s256 114.6 256 256zM256 48C141.1 48 48 141.1 48 256s93.1 208 208 208 208-93.1 208-208S370.9 48 256 48z"
+      >
+      </path>
+    </svg>
+  </button>
+  <input aria-autocomplete="list"
+         aria-expanded="false"
+         aria-haspopup="listbox"
+         aria-invalid="false"
+         aria-label="Select from location"
+         aria-required="false"
+         class="styled__Input-sc-xahsq2-6 axlAP from-form-control"
+         spellcheck="false"
+         placeholder="Select from location"
+         role="combobox"
+         value
+  >
+  <span role="status"
+        class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
+  >
+  </span>
 </div>
 `;
 
@@ -657,7 +692,6 @@ exports[`LocationField/Desktop Context WithBadApiKeyHandlesBadAutocomplete smoke
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -696,7 +730,7 @@ exports[`LocationField/Desktop Context WithBadApiKeyHandlesBadAutocomplete smoke
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 eCrJvo"
+      class="styled__MenuItemList-sc-xahsq2-5 fdpjmo"
   >
   </ul>
 </div>
@@ -714,7 +748,6 @@ exports[`LocationField/Desktop Context WithCustomLabel smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -753,7 +786,7 @@ exports[`LocationField/Desktop Context WithCustomLabel smoke-test 1`] = `
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 eCrJvo"
+      class="styled__MenuItemList-sc-xahsq2-5 fdpjmo"
   >
   </ul>
 </div>
@@ -768,7 +801,6 @@ exports[`LocationField/Desktop Context WithCustomResultColorsAndIcons smoke-test
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -807,7 +839,7 @@ exports[`LocationField/Desktop Context WithCustomResultColorsAndIcons smoke-test
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 eCrJvo"
+      class="styled__MenuItemList-sc-xahsq2-5 fdpjmo"
   >
   </ul>
 </div>
@@ -822,7 +854,6 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -861,7 +892,7 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 eCrJvo"
+      class="styled__MenuItemList-sc-xahsq2-5 cwdAZq"
   >
     <h2 class="styled__MenuGroupHeader-sc-xahsq2-8 iDacNN">
       Other
@@ -1155,7 +1186,6 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -1194,7 +1224,7 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 eCrJvo"
+      class="styled__MenuItemList-sc-xahsq2-5 cwdAZq"
   >
     <h2 class="styled__MenuGroupHeader-sc-xahsq2-8 iCLOrV">
       Stations
@@ -1488,7 +1518,6 @@ exports[`LocationField/Desktop Context WithUserSettings smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -1527,7 +1556,7 @@ exports[`LocationField/Desktop Context WithUserSettings smoke-test 1`] = `
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 eCrJvo"
+      class="styled__MenuItemList-sc-xahsq2-5 fdpjmo"
   >
   </ul>
 </div>

--- a/packages/location-field/src/stories/__snapshots__/Desktop.story.tsx.snap
+++ b/packages/location-field/src/stories/__snapshots__/Desktop.story.tsx.snap
@@ -46,7 +46,8 @@ exports[`LocationField/Desktop Context AutoFocusWithMultipleControls smoke-test 
            role="combobox"
            value
     >
-    <span role="status"
+    <span aria-live="polite"
+          role="status"
           class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
     >
     </span>
@@ -100,7 +101,8 @@ exports[`LocationField/Desktop Context Blank smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -153,7 +155,8 @@ exports[`LocationField/Desktop Context GeocoderNoResults smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -206,7 +209,8 @@ exports[`LocationField/Desktop Context GeocoderUnreachable smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -259,7 +263,8 @@ exports[`LocationField/Desktop Context HereGeocoder smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -278,9 +283,8 @@ exports[`LocationField/Desktop Context LocationUnavailable smoke-test 1`] = `
      role="group"
 >
   <button aria-controls="from-listbox"
-          aria-disabled="true"
           aria-expanded="false"
-          aria-label="Toggle displaying the list of suggested locations"
+          aria-label="Toggle displaying the list of suggested locations. Current location not available"
           tabindex="-1"
           type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
@@ -305,7 +309,7 @@ exports[`LocationField/Desktop Context LocationUnavailable smoke-test 1`] = `
          aria-expanded="false"
          aria-haspopup="listbox"
          aria-invalid="false"
-         aria-label="Select from location"
+         aria-label="Select from location. Current location not available"
          aria-required="false"
          class="styled__Input-sc-xahsq2-6 axlAP from-form-control"
          spellcheck="false"
@@ -313,7 +317,8 @@ exports[`LocationField/Desktop Context LocationUnavailable smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -373,7 +378,8 @@ exports[`LocationField/Desktop Context NoAutoFocusWithMultipleControls smoke-tes
            role="combobox"
            value
     >
-    <span role="status"
+    <span aria-live="polite"
+          role="status"
           class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
     >
     </span>
@@ -427,7 +433,8 @@ exports[`LocationField/Desktop Context RequiredAndInvalidState smoke-test 1`] = 
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -499,7 +506,8 @@ exports[`LocationField/Desktop Context SelectedLocation smoke-test 1`] = `
       </path>
     </svg>
   </button>
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -571,7 +579,8 @@ exports[`LocationField/Desktop Context SelectedLocationCustomClear smoke-test 1`
       </path>
     </svg>
   </button>
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -624,7 +633,8 @@ exports[`LocationField/Desktop Context SlowGeocoder smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -676,7 +686,8 @@ exports[`LocationField/Desktop Context SupressNearby smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -722,7 +733,8 @@ exports[`LocationField/Desktop Context WithBadApiKeyHandlesBadAutocomplete smoke
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -778,7 +790,8 @@ exports[`LocationField/Desktop Context WithCustomLabel smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -831,7 +844,8 @@ exports[`LocationField/Desktop Context WithCustomResultColorsAndIcons smoke-test
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -884,7 +898,8 @@ exports[`LocationField/Desktop Context WithCustomResultsOrder smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -1216,7 +1231,8 @@ exports[`LocationField/Desktop Context WithPrefilledSearch smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -1548,7 +1564,8 @@ exports[`LocationField/Desktop Context WithUserSettings smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>

--- a/packages/location-field/src/stories/__snapshots__/Mobile.story.tsx.snap
+++ b/packages/location-field/src/stories/__snapshots__/Mobile.story.tsx.snap
@@ -39,7 +39,8 @@ exports[`LocationField/Mobile Context Blank smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -121,7 +122,8 @@ exports[`LocationField/Mobile Context GeocoderNoResults smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -203,7 +205,8 @@ exports[`LocationField/Mobile Context GeocoderUnreachable smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -251,9 +254,8 @@ exports[`LocationField/Mobile Context LocationUnavailable smoke-test 1`] = `
      role="group"
 >
   <button aria-controls="from-listbox"
-          aria-disabled="true"
           aria-expanded="false"
-          aria-label="Toggle displaying the list of suggested locations"
+          aria-label="Toggle displaying the list of suggested locations. Current location not available"
           tabindex="-1"
           type="button"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
@@ -278,7 +280,7 @@ exports[`LocationField/Mobile Context LocationUnavailable smoke-test 1`] = `
          aria-expanded="false"
          aria-haspopup="listbox"
          aria-invalid="false"
-         aria-label="from"
+         aria-label="from. Current location not available"
          aria-required="false"
          class="styled__Input-sc-xahsq2-6 axlAP from-form-control"
          spellcheck="false"
@@ -286,12 +288,13 @@ exports[`LocationField/Mobile Context LocationUnavailable smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="assertive"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
     Current location not available
   </span>
-  <ul aria-hidden="true"
+  <ul aria-hidden="false"
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
@@ -389,7 +392,8 @@ exports[`LocationField/Mobile Context SelectedLocation smoke-test 1`] = `
       </path>
     </svg>
   </button>
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -490,7 +494,8 @@ exports[`LocationField/Mobile Context SelectedLocationCustomClear smoke-test 1`]
       </path>
     </svg>
   </button>
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -572,7 +577,8 @@ exports[`LocationField/Mobile Context SlowGeocoder smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -654,7 +660,8 @@ exports[`LocationField/Mobile Context Styled smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -736,7 +743,8 @@ exports[`LocationField/Mobile Context WithCustomIcons smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -1050,7 +1058,8 @@ exports[`LocationField/Mobile Context WithNearbyStops smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -1213,7 +1222,8 @@ exports[`LocationField/Mobile Context WithSessionSearches smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
@@ -1327,7 +1337,8 @@ exports[`LocationField/Mobile Context WithUserSettings smoke-test 1`] = `
          role="combobox"
          value
   >
-  <span role="status"
+  <span aria-live="polite"
+        role="status"
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>

--- a/packages/location-field/src/stories/__snapshots__/Mobile.story.tsx.snap
+++ b/packages/location-field/src/stories/__snapshots__/Mobile.story.tsx.snap
@@ -9,7 +9,6 @@ exports[`LocationField/Mobile Context Blank smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -44,11 +43,11 @@ exports[`LocationField/Mobile Context Blank smoke-test 1`] = `
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
-  <ul aria-hidden="true"
+  <ul aria-hidden="false"
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 eCrJvo GkRdl"
+      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 cwdAZq gGwGIV"
   >
     <li aria-live="off"
         id="current-position"
@@ -92,7 +91,6 @@ exports[`LocationField/Mobile Context GeocoderNoResults smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -127,11 +125,11 @@ exports[`LocationField/Mobile Context GeocoderNoResults smoke-test 1`] = `
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
-  <ul aria-hidden="true"
+  <ul aria-hidden="false"
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 eCrJvo GkRdl"
+      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 cwdAZq gGwGIV"
   >
     <li aria-live="off"
         id="current-position"
@@ -175,7 +173,6 @@ exports[`LocationField/Mobile Context GeocoderUnreachable smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -210,11 +207,11 @@ exports[`LocationField/Mobile Context GeocoderUnreachable smoke-test 1`] = `
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
-  <ul aria-hidden="true"
+  <ul aria-hidden="false"
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 eCrJvo GkRdl"
+      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 cwdAZq gGwGIV"
   >
     <li aria-live="off"
         id="current-position"
@@ -254,11 +251,11 @@ exports[`LocationField/Mobile Context LocationUnavailable smoke-test 1`] = `
      role="group"
 >
   <button aria-controls="from-listbox"
-          aria-expanded="true"
+          aria-disabled="true"
+          aria-expanded="false"
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -278,7 +275,7 @@ exports[`LocationField/Mobile Context LocationUnavailable smoke-test 1`] = `
   </button>
   <input aria-autocomplete="list"
          aria-controls="from-listbox"
-         aria-expanded="true"
+         aria-expanded="false"
          aria-haspopup="listbox"
          aria-invalid="false"
          aria-label="from"
@@ -298,7 +295,7 @@ exports[`LocationField/Mobile Context LocationUnavailable smoke-test 1`] = `
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 eCrJvo GkRdl"
+      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 cwdAZq gGwGIV"
   >
     <li aria-hidden="true"
         aria-live="off"
@@ -343,7 +340,6 @@ exports[`LocationField/Mobile Context SelectedLocation smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"
@@ -397,11 +393,11 @@ exports[`LocationField/Mobile Context SelectedLocation smoke-test 1`] = `
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
-  <ul aria-hidden="true"
+  <ul aria-hidden="false"
       aria-label="Suggested locations"
       id="to-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 eCrJvo GkRdl"
+      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 cwdAZq gGwGIV"
   >
     <li aria-live="off"
         id="current-position"
@@ -445,7 +441,6 @@ exports[`LocationField/Mobile Context SelectedLocationCustomClear smoke-test 1`]
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"
@@ -499,11 +494,11 @@ exports[`LocationField/Mobile Context SelectedLocationCustomClear smoke-test 1`]
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
-  <ul aria-hidden="true"
+  <ul aria-hidden="false"
       aria-label="Suggested locations"
       id="to-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 eCrJvo GkRdl"
+      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 cwdAZq gGwGIV"
   >
     <li aria-live="off"
         id="current-position"
@@ -547,7 +542,6 @@ exports[`LocationField/Mobile Context SlowGeocoder smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -582,11 +576,11 @@ exports[`LocationField/Mobile Context SlowGeocoder smoke-test 1`] = `
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
-  <ul aria-hidden="true"
+  <ul aria-hidden="false"
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 eCrJvo GkRdl"
+      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 cwdAZq gGwGIV"
   >
     <li aria-live="off"
         id="current-position"
@@ -630,7 +624,6 @@ exports[`LocationField/Mobile Context Styled smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 512 512"
@@ -665,11 +658,11 @@ exports[`LocationField/Mobile Context Styled smoke-test 1`] = `
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
-  <ul aria-hidden="true"
+  <ul aria-hidden="false"
       aria-label="Suggested locations"
       id="from-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 eCrJvo GkRdl"
+      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 cwdAZq gGwGIV"
   >
     <li aria-live="off"
         id="current-position"
@@ -713,7 +706,6 @@ exports[`LocationField/Mobile Context WithCustomIcons smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 640 512"
@@ -748,11 +740,11 @@ exports[`LocationField/Mobile Context WithCustomIcons smoke-test 1`] = `
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
-  <ul aria-hidden="true"
+  <ul aria-hidden="false"
       aria-label="Suggested locations"
       id="to-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 eCrJvo GkRdl"
+      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 cwdAZq gGwGIV"
   >
     <h2 class="styled__MenuGroupHeader-sc-xahsq2-8 iDacNN">
       Nearby Stops
@@ -1028,7 +1020,6 @@ exports[`LocationField/Mobile Context WithNearbyStops smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"
@@ -1063,11 +1054,11 @@ exports[`LocationField/Mobile Context WithNearbyStops smoke-test 1`] = `
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
-  <ul aria-hidden="true"
+  <ul aria-hidden="false"
       aria-label="Suggested locations"
       id="to-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 eCrJvo GkRdl"
+      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 cwdAZq gGwGIV"
   >
     <h2 class="styled__MenuGroupHeader-sc-xahsq2-8 iDacNN">
       Nearby Stops
@@ -1192,7 +1183,6 @@ exports[`LocationField/Mobile Context WithSessionSearches smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"
@@ -1227,11 +1217,11 @@ exports[`LocationField/Mobile Context WithSessionSearches smoke-test 1`] = `
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
-  <ul aria-hidden="true"
+  <ul aria-hidden="false"
       aria-label="Suggested locations"
       id="to-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 eCrJvo GkRdl"
+      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 cwdAZq gGwGIV"
   >
     <h2 class="styled__MenuGroupHeader-sc-xahsq2-8 iDacNN">
       Recently Searched
@@ -1307,7 +1297,6 @@ exports[`LocationField/Mobile Context WithUserSettings smoke-test 1`] = `
           aria-label="Toggle displaying the list of suggested locations"
           tabindex="-1"
           type="button"
-          aria-disabled="false"
           class="styled__BaseButton-sc-xahsq2-1 styled__DropdownButton-sc-xahsq2-4 hoozke dYRKXf"
   >
     <svg viewbox="0 0 384 512"
@@ -1342,11 +1331,11 @@ exports[`LocationField/Mobile Context WithUserSettings smoke-test 1`] = `
         class="styled__HiddenContent-sc-xahsq2-0 iCqxXz"
   >
   </span>
-  <ul aria-hidden="true"
+  <ul aria-hidden="false"
       aria-label="Suggested locations"
       id="to-listbox"
       role="listbox"
-      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 eCrJvo GkRdl"
+      class="styled__MenuItemList-sc-xahsq2-5 styled__StaticMenuItemList-sc-xahsq2-16 cwdAZq gGwGIV"
   >
     <h2 class="styled__MenuGroupHeader-sc-xahsq2-8 iDacNN">
       My Places

--- a/packages/location-field/src/styled.ts
+++ b/packages/location-field/src/styled.ts
@@ -34,7 +34,7 @@ export const DropdownButton = styled(BaseButton)`
 
 export const MenuItemList = styled.ul.attrs({
   role: "listbox"
-})`
+})<{ $menuOpen?: boolean }>`
   background-clip: padding-box;
   background-color: #fff;
   border-radius: 4px;
@@ -55,10 +55,8 @@ export const MenuItemList = styled.ul.attrs({
   /* this is an annoyingly high number, but is needed to be on top of some otp-rr components */
   z-index: 1000000;
 
-  /* If the associated input is not in an expanded state, hide the list. */
-  input[aria-expanded="false"] ~ & {
-    ${hiddenCss}
-  }
+  /* Hide visually when the menu is closed (separate from aria-expanded for AT). */
+  ${props => !props.$menuOpen && hiddenCss}
 `;
 
 export const Input = styled.input`


### PR DESCRIPTION
This is a follow up ticket to fix my mistake on https://github.com/opentripplanner/otp-ui/pull/948

Amy made a comment that menuItemCount would always be === 1 
https://github.com/opentripplanner/otp-ui/pull/948#issuecomment-4604157098

thought my solution would fix this since it was on mac that we found this issue 

But after testing I think this solution works

I also added a desktop story of suppressNearby since that what we are using on our side 

i also copied the accessibility overrides for the storybook from desktop to mobile was getting some error


The goal was to make sure that there was 
- no regression

- on location unavailable (it will still appear saying current location not available) 
<img width="1024" height="768" alt="image" src="https://github.com/user-attachments/assets/e0d49bba-c27f-4802-88ff-df8ee1b5afc7" />

- on SuppressNearby there is no open box  (please note this is the before the fix i just wanted to show what i mean by open box) 
<img width="1024" height="768" alt="image" src="https://github.com/user-attachments/assets/57378f59-16df-45b5-a75d-dd1950833474" />

