### PR TITLE
feat(transitive-overlay): pass map ref, pull fonts from tiles

### DIFF
--- a/packages/transitive-overlay/src/util.ts
+++ b/packages/transitive-overlay/src/util.ts
@@ -547,7 +547,7 @@ const getFontsFromVectorTiles = (map: MapRef): SortedFonts => {
     // There are often duplicates so first filter those out.
     fontLayers?.forEach((f: string) => fonts.add(f));
   });
-  // Once we have a list of unique fonts, sort them into bold and regular buckets
+  // Once we have a list of unique fonts, sort them into bold and regular buckets.
   fonts.forEach(f => {
     const fontLowerCase = f.toLowerCase();
     switch (true) {


### PR DESCRIPTION
For some reason sem-rel did not release a new transitive package