### PR TITLE
Closed stops itinerary view

### DIFF
--- a/packages/itinerary-body/i18n/en-US.yml
+++ b/packages/itinerary-body/i18n/en-US.yml
@@ -106,6 +106,7 @@ otpUi:
       yesterday: Yesterday
     alertsHeader: "{alertCount, plural, =1 {# alert} other {# alerts}}"
     arriveAt: Arrive at {place}
+    closed: Closed
     disembarkAt: Disembark at {legDestination}
     expandDetails: (Expand details)
     fare: "Fare: {fare}"

--- a/packages/itinerary-body/i18n/en-US.yml
+++ b/packages/itinerary-body/i18n/en-US.yml
@@ -106,7 +106,7 @@ otpUi:
       yesterday: Yesterday
     alertsHeader: "{alertCount, plural, =1 {# alert} other {# alerts}}"
     arriveAt: Arrive at {place}
-    closed: Closed
+    stopIsClosed: Closed
     disembarkAt: Disembark at {legDestination}
     expandDetails: (Expand details)
     fare: "Fare: {fare}"

--- a/packages/itinerary-body/i18n/fr.yml
+++ b/packages/itinerary-body/i18n/fr.yml
@@ -112,6 +112,7 @@ otpUi:
       yesterday: hier
     alertsHeader: "{alertCount, plural, =0 {# alerte} =1 {# alerte} other {# alertes}}"
     arriveAt: Arrivée à {place}
+    closed: Closed
     disembarkAt: Descendez à {legDestination}
     expandDetails: (Plus de détails)
     fare: "Tarif : {fare}"

--- a/packages/itinerary-body/i18n/fr.yml
+++ b/packages/itinerary-body/i18n/fr.yml
@@ -112,7 +112,7 @@ otpUi:
       yesterday: hier
     alertsHeader: "{alertCount, plural, =0 {# alerte} =1 {# alerte} other {# alertes}}"
     arriveAt: Arrivée à {place}
-    stopIsClosed: Closed
+    stopIsClosed: Arrêt supprimé
     disembarkAt: Descendez à {legDestination}
     expandDetails: (Plus de détails)
     fare: "Tarif : {fare}"

--- a/packages/itinerary-body/i18n/fr.yml
+++ b/packages/itinerary-body/i18n/fr.yml
@@ -112,7 +112,7 @@ otpUi:
       yesterday: hier
     alertsHeader: "{alertCount, plural, =0 {# alerte} =1 {# alerte} other {# alertes}}"
     arriveAt: Arrivée à {place}
-    closed: Closed
+    stopIsClosed: Closed
     disembarkAt: Descendez à {legDestination}
     expandDetails: (Plus de détails)
     fare: "Tarif : {fare}"

--- a/packages/itinerary-body/src/ItineraryBody/index.tsx
+++ b/packages/itinerary-body/src/ItineraryBody/index.tsx
@@ -17,6 +17,7 @@ const ItineraryBody = ({
   AlertToggleIcon,
   alwaysCollapseAlerts = false,
   className,
+  closedStopIds,
   config,
   defaultFareSelector,
   diagramVisible,
@@ -71,6 +72,7 @@ const ItineraryBody = ({
           // eslint-disable-next-line react/no-array-index-key
           key={i + (isDestination ? 1 : 0)}
           canceled={leg.realtimeState === "CANCELED"}
+          closedStopIds={closedStopIds}
           config={config}
           defaultFareSelector={defaultFareSelector}
           diagramVisible={diagramVisible}

--- a/packages/itinerary-body/src/ItineraryBody/place-row.tsx
+++ b/packages/itinerary-body/src/ItineraryBody/place-row.tsx
@@ -54,6 +54,7 @@ export default function PlaceRow({
   AlertToggleIcon,
   alwaysCollapseAlerts,
   canceled,
+  closedStopIds,
   config,
   defaultFareSelector,
   diagramVisible,
@@ -209,6 +210,7 @@ export default function PlaceRow({
               AlertBodyIcon={AlertBodyIcon}
               AlertToggleIcon={AlertToggleIcon}
               alwaysCollapseAlerts={alwaysCollapseAlerts}
+              closedStopIds={closedStopIds}
               defaultFareSelector={defaultFareSelector}
               leg={leg}
               legDestination={legDestination}

--- a/packages/itinerary-body/src/TransitLegBody/index.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/index.tsx
@@ -44,6 +44,7 @@ interface Props {
   AlertBodyIcon?: FunctionComponent;
   AlertToggleIcon?: FunctionComponent;
   alwaysCollapseAlerts: boolean;
+  closedStopIds?: Set<string>;
   defaultFareSelector?: FareProductSelector;
   intl: IntlShape;
   leg: Leg;
@@ -172,6 +173,7 @@ class TransitLegBody extends Component<Props, State> {
       AlertBodyIcon,
       AlertToggleIcon = S.DefaultAlertToggleIcon,
       alwaysCollapseAlerts,
+      closedStopIds,
       defaultFareSelector,
       intl,
       leg,
@@ -398,7 +400,10 @@ class TransitLegBody extends Component<Props, State> {
                   height={stopsExpanded ? "auto" : 0}
                 >
                   <S.TransitLegExpandedBody>
-                    <IntermediateStops stops={leg.intermediateStops} />
+                    <IntermediateStops
+                      closedStopIds={closedStopIds}
+                      stops={leg.intermediateStops}
+                    />
                     {legCost?.price && (
                       <S.TransitLegFare>
                         <FormattedMessage

--- a/packages/itinerary-body/src/TransitLegBody/intermediate-stops.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/intermediate-stops.tsx
@@ -1,4 +1,3 @@
-import colors from "@opentripplanner/building-blocks";
 import { Place } from "@opentripplanner/types";
 import React, { ReactElement } from "react";
 

--- a/packages/itinerary-body/src/TransitLegBody/intermediate-stops.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/intermediate-stops.tsx
@@ -39,7 +39,7 @@ export default function IntermediateStops({
             <S.StopMarker>&bull;</S.StopMarker>
             <S.StopNameContainer>
               <S.StopName closed={closed}>{stop.name}</S.StopName>
-              <S.StopClosed>{closed ? ` (${closedMessage})` : ""}</S.StopClosed>
+              {closed && <S.StopClosed>{closedMessage}</S.StopClosed>}
             </S.StopNameContainer>
           </S.StopRow>
         );

--- a/packages/itinerary-body/src/TransitLegBody/intermediate-stops.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/intermediate-stops.tsx
@@ -1,21 +1,49 @@
+import colors from "@opentripplanner/building-blocks";
 import { Place } from "@opentripplanner/types";
 import React, { ReactElement } from "react";
 
+import { useIntl } from "react-intl";
 import * as S from "../styled";
+import { defaultMessages } from "../util";
 
 interface Props {
+  closedStopIds?: Set<string>;
   stops: Place[];
 }
 
-export default function IntermediateStops({ stops }: Props): ReactElement {
+export default function IntermediateStops({
+  closedStopIds,
+  stops
+}: Props): ReactElement {
+  // The closed stops are in the format {agencyId}:{stopId}, but the stops that are fed to this
+  // component only use the {stopId} portion, so we need to strip off the agencyId prefix and the colon
+  const closedStopsNumericCodes = new Set<string>();
+  closedStopIds?.forEach(stop => {
+    if (!stop.includes(":")) closedStopsNumericCodes.add(stop);
+    else {
+      const split = stop.split(":");
+      if (split.length === 2) closedStopsNumericCodes.add(split[1]);
+    }
+  });
+  const intl = useIntl();
+  const closedMessage = intl.formatMessage({
+    defaultMessage: defaultMessages["otpUi.TransitLegBody.closed"],
+    description: "Denotes a closed stop in the itinerary body",
+    id: "otpUi.TransitLegBody.closed"
+  });
   return (
     <S.IntermediateStops>
-      {stops.map((stop, k) => (
-        <S.StopRow key={k}>
-          <S.StopMarker>&bull;</S.StopMarker>
-          <S.StopName>{stop.name}</S.StopName>
-        </S.StopRow>
-      ))}
+      {stops.map((stop, k) => {
+        const closed = closedStopsNumericCodes.has(stop.stopCode ?? "");
+        return (
+          <S.StopRow key={k}>
+            <S.StopMarker>&bull;</S.StopMarker>
+            <S.StopName style={{ color: closed ? `${colors.red[700]}` : "" }}>
+              {`${stop.name}${closed ? ` (${closedMessage})` : ""}`}
+            </S.StopName>
+          </S.StopRow>
+        );
+      })}
     </S.IntermediateStops>
   );
 }

--- a/packages/itinerary-body/src/TransitLegBody/intermediate-stops.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/intermediate-stops.tsx
@@ -37,9 +37,10 @@ export default function IntermediateStops({
         return (
           <S.StopRow key={k}>
             <S.StopMarker>&bull;</S.StopMarker>
-            <S.StopName closed={closed}>
-              {`${stop.name}${closed ? ` (${closedMessage})` : ""}`}
-            </S.StopName>
+            <S.StopNameContainer>
+              <S.StopName closed={closed}>{stop.name}</S.StopName>
+              <S.StopClosed>{closed ? ` (${closedMessage})` : ""}</S.StopClosed>
+            </S.StopNameContainer>
           </S.StopRow>
         );
       })}

--- a/packages/itinerary-body/src/TransitLegBody/intermediate-stops.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/intermediate-stops.tsx
@@ -26,9 +26,9 @@ export default function IntermediateStops({
   });
   const intl = useIntl();
   const closedMessage = intl.formatMessage({
-    defaultMessage: defaultMessages["otpUi.TransitLegBody.closed"],
+    defaultMessage: defaultMessages["otpUi.TransitLegBody.stopIsClosed"],
     description: "Denotes a closed stop in the itinerary body",
-    id: "otpUi.TransitLegBody.closed"
+    id: "otpUi.TransitLegBody.stopIsClosed"
   });
   return (
     <S.IntermediateStops>

--- a/packages/itinerary-body/src/TransitLegBody/intermediate-stops.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/intermediate-stops.tsx
@@ -38,7 +38,7 @@ export default function IntermediateStops({
         return (
           <S.StopRow key={k}>
             <S.StopMarker>&bull;</S.StopMarker>
-            <S.StopName style={{ color: closed ? `${colors.red[700]}` : "" }}>
+            <S.StopName closed={closed}>
               {`${stop.name}${closed ? ` (${closedMessage})` : ""}`}
             </S.StopName>
           </S.StopRow>

--- a/packages/itinerary-body/src/stories/OtpRrItineraryBody.story.tsx
+++ b/packages/itinerary-body/src/stories/OtpRrItineraryBody.story.tsx
@@ -63,6 +63,7 @@ if (!isTestRunner()) {
 
 interface StoryWrapperProps {
   alwaysCollapseAlerts?: boolean;
+  closedStopIds?: Set<string>;
   defaultFareSelector?: FareProductSelector;
   hideDrivingDirections?: boolean;
   itinerary: Itinerary;
@@ -74,6 +75,7 @@ interface StoryWrapperProps {
 
 function OtpRRItineraryBodyWrapper({
   alwaysCollapseAlerts,
+  closedStopIds,
   defaultFareSelector,
   hideDrivingDirections = false,
   itinerary,
@@ -85,6 +87,7 @@ function OtpRRItineraryBodyWrapper({
   return (
     <ItineraryBodyDefaultsWrapper
       alwaysCollapseAlerts={alwaysCollapseAlerts}
+      closedStopIds={closedStopIds}
       defaultFareSelector={defaultFareSelector}
       hideDrivingDirections={hideDrivingDirections}
       itinerary={itinerary}
@@ -139,6 +142,13 @@ walkTransitWalkItineraryCanceled.legs.forEach(leg => {
 
 export const WalkTransitWalkItineraryCanceled = (): ReactElement => (
   <OtpRRItineraryBodyWrapper itinerary={walkTransitWalkItineraryCanceled} />
+);
+
+export const WalkTransitWalkItineraryClosedStop = (): ReactElement => (
+  <OtpRRItineraryBodyWrapper
+    closedStopIds={new Set(["TriMet:8384"])}
+    itinerary={walkTransitWalkItinerary}
+  />
 );
 
 export const WalkTransitWalkItineraryMetric = (): ReactElement => (

--- a/packages/itinerary-body/src/stories/OtpUiItineraryBody.story.tsx
+++ b/packages/itinerary-body/src/stories/OtpUiItineraryBody.story.tsx
@@ -76,6 +76,14 @@ export const WalkTransitWalkItineraryCanceled = (): ReactElement => (
   />
 );
 
+export const WalkTransitWalkItineraryClosedStop = (): ReactElement => (
+  <ItineraryBodyDefaultsWrapper
+    closedStopIds={new Set(["TriMet:8384"])}
+    itinerary={walkTransitWalkItinerary}
+    RouteDescriptionFooter={RouteDescriptionFooterWithWaitTimes}
+  />
+);
+
 export const WalkTransitTransferWithA11yItinerary = (): ReactElement => (
   <ItineraryBodyDefaultsWrapper
     itinerary={walkTransitWalkTransitWalkA11yItinerary}

--- a/packages/itinerary-body/src/stories/__snapshots__/OtpRrItineraryBody.story.tsx.snap
+++ b/packages/itinerary-body/src/stories/__snapshots__/OtpRrItineraryBody.story.tsx.snap
@@ -581,8 +581,6 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -1541,8 +1539,6 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -4323,8 +4319,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; Lawrence
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4335,8 +4329,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; 28th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4347,8 +4339,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; 31st
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4359,8 +4349,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; 33rd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4371,8 +4359,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; Imperial
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4383,8 +4369,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; 38th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4395,8 +4379,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; 42nd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4407,8 +4389,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; 44th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4419,8 +4399,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; 48th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4431,8 +4409,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; 50th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4443,8 +4419,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; Sacramento
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4455,8 +4429,6 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; 54th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -6231,8 +6203,6 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -7165,8 +7135,6 @@ exports[`ItineraryBody/otp-react-redux CustomTimeColumn smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           W Burnside &amp; SW 2nd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -7177,8 +7145,6 @@ exports[`ItineraryBody/otp-react-redux CustomTimeColumn smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 8th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -9037,8 +9003,6 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Broadway &amp; 32nd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -9049,8 +9013,6 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE 33rd &amp; Schuyler
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -9061,8 +9023,6 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE 33rd &amp; US Grant Pl
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -9073,8 +9033,6 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE 33rd &amp; Brazee
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -9085,8 +9043,6 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE 33rd &amp; Knott
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -9097,8 +9053,6 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE 33rd &amp; Stanton
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -9109,8 +9063,6 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE 33rd &amp; Siskiyou
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -9121,8 +9073,6 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE 33rd &amp; Alameda
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -10524,8 +10474,6 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Washington Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -10536,8 +10484,6 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Goose Hollow/SW Jefferson St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -10548,8 +10494,6 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Kings Hill/SW Salmon St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -10560,8 +10504,6 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Providence Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -10572,8 +10514,6 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Library/SW 9th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -10584,8 +10524,6 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Pioneer Square South MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -10596,8 +10534,6 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Mall/SW 4th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -10608,8 +10544,6 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Yamhill District MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -11831,8 +11765,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           South Mount Vernon Park &amp; Ride
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -11843,8 +11775,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Broadway - Everett Community College
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -11855,8 +11785,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Broadway &amp; 14th  (near hospital)
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -11867,8 +11795,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Broadway just South of the Event Center
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -12260,8 +12186,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Broadway &amp; 34th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -12272,8 +12196,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           South Everett Fwy Station Bay 3
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -12284,8 +12206,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Ash Way Park &amp; Ride Bay 1
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -12677,8 +12597,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Alderwood Mall Pkwy &amp; Beech Rd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -12689,8 +12607,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Alderwood Mall Pkwy &amp; 184th St SW
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -12701,8 +12617,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Canyon Park Fwy Station Bay 4
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -12713,8 +12627,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Beardslee Blvd &amp; Ross Rd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -12725,8 +12637,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           UW Bothell &amp; Cascadia College
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -13118,8 +13028,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Woodinville Dr &amp; Kaysner Way
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -13130,8 +13038,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Bothell Way NE &amp; NE 180th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -13142,8 +13048,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Bothell Way &amp; 96th Ave NE
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -13154,8 +13058,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Bothell Way &amp; 91st Ave NE
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -13166,8 +13068,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Bothell Way &amp; 83rd Pl NE
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -13178,8 +13078,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Bothell Way &amp; 80th Ave NE
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -13190,8 +13088,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Bothell Way &amp; 77th Ct NE
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -13202,8 +13098,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Bothell Way &amp; Kenmore Park &amp; Ride
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -13214,8 +13108,6 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Bothell Way &amp; 68th Ave NE
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -14112,8 +14004,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           S Main St &amp; Ken Pratt Blvd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14124,8 +14014,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           S Main St &amp; Jersey Ave
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14136,8 +14024,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           S Main St &amp; Missouri Ave
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14148,8 +14034,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           S Main St &amp; Quebec Ave
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14160,8 +14044,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           US 287 &amp; Pike Rd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14172,8 +14054,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           US 287 &amp; Niwot Rd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14184,8 +14064,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           US 287 &amp; Hwy 52
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14196,8 +14074,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           US 287 &amp; Lookout Rd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14208,8 +14084,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           US 287 &amp; Dawson Dr
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14220,8 +14094,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           US 287 &amp; Goose Haven Dr
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14232,8 +14104,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           US 287 &amp; Isabelle Rd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -14658,8 +14528,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Arapahoe Rd &amp; US 287
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14670,8 +14538,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Arapahoe Rd &amp; 111th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14682,8 +14548,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Arapahoe Rd &amp; Hawkridge Rd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14694,8 +14558,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           2800 Block 119th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14706,8 +14568,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           119th St &amp; Austin Ave
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14718,8 +14578,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Erie Pkwy &amp; Brennan St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14730,8 +14588,6 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Erie Pkwy &amp; Meller St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -16612,8 +16468,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Quatama MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -16624,8 +16478,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Willow Creek/SW 185th Ave TC MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -16636,8 +16488,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Elmonica/SW 170th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -16648,8 +16498,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Merlo Rd/SW 158th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -16660,8 +16508,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Beaverton Creek MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -16672,8 +16518,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Millikan Way MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -16684,8 +16528,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Beaverton Central MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -16696,8 +16538,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Beaverton TC MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -16708,8 +16548,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Sunset TC MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -16720,8 +16558,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Washington Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -16732,8 +16568,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Goose Hollow/SW Jefferson St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -17278,8 +17112,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           W Burnside &amp; SW 15th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17290,8 +17122,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           W Burnside &amp; SW 13th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17302,8 +17132,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           W Burnside &amp; SW 10th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17314,8 +17142,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           W Burnside &amp; SW 6th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17326,8 +17152,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           W Burnside &amp; SW 2nd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17338,8 +17162,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; NE Grand
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17350,8 +17172,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 8th Ave
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17362,8 +17182,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 12th Ave
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17374,8 +17192,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 16th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17386,8 +17202,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 20th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17398,8 +17212,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 24th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17410,8 +17222,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 28th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17422,8 +17232,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 32nd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17434,8 +17242,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE Floral
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17446,8 +17252,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE Laurelhurst
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17458,8 +17262,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE Cesar Chavez Blvd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17470,8 +17272,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 41st
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17482,8 +17282,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 44th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17494,8 +17292,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 47th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17506,8 +17302,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 52nd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17518,8 +17312,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 55th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17530,8 +17322,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 57th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17542,8 +17332,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 60th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17554,8 +17342,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; 63rd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17566,8 +17352,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 67th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17578,8 +17362,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 69th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17590,8 +17372,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 72nd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17602,8 +17382,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 74th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17614,8 +17392,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 79th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17626,8 +17402,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 82nd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17638,8 +17412,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 87th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -17650,8 +17422,6 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           9100 Block E Burnside
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -19152,8 +18922,6 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Washington Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -19164,8 +18932,6 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Goose Hollow/SW Jefferson St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -19176,8 +18942,6 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Kings Hill/SW Salmon St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -19188,8 +18952,6 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Providence Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -19200,8 +18962,6 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Library/SW 9th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -19212,8 +18972,6 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Pioneer Square South MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -19224,8 +18982,6 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Mall/SW 4th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -19236,8 +18992,6 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Yamhill District MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -19835,8 +19589,6 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Halladay St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -19847,8 +19599,6 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Lynn St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -19859,8 +19609,6 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Crockett St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -19871,8 +19619,6 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Galer St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -19883,8 +19629,6 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Prospect St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -19895,8 +19639,6 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           7th Ave N &amp; Thomas St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -20070,8 +19812,6 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Bell St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -20082,8 +19822,6 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Virginia St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -20094,8 +19832,6 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Pike St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -20106,8 +19842,6 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Seneca St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -20118,8 +19852,6 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Cherry St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -20130,8 +19862,6 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave S &amp; S Main St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -20779,8 +20509,6 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -21739,8 +21467,6 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -22699,8 +22425,6 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -23659,8 +23383,6 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -24402,8 +24124,6 @@ exports[`ItineraryBody/otp-react-redux TncTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           W Burnside &amp; SW 2nd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -24414,8 +24134,6 @@ exports[`ItineraryBody/otp-react-redux TncTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 8th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -25375,8 +25093,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Philadelphia Airport Terminals E &amp; F
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25387,8 +25103,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Bartram Av &amp; 90th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25399,8 +25113,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           89th St &amp; Bartram Av - FS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -25692,8 +25404,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Tinicum Blvd &amp; 88th St - FS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25704,8 +25414,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Tinicum Blvd &amp; 86th St - MBFS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25716,8 +25424,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Bartram Av &amp; 84th St - MBNS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25728,8 +25434,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Bartram Av &amp; 84th St - MBFS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25740,8 +25444,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Island Av &amp; Penrose Av - MBNS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25752,8 +25454,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Island Av &amp; Penrose Av - MBFS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25764,8 +25464,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Island Av &amp; Escort Av - MBNS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25776,8 +25474,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Island Av &amp; Escort Av
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25788,8 +25484,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Island Av &amp; Escort Av - MBFS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25800,8 +25494,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Enterprise Av &amp; Executive Av
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25812,8 +25504,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Executive Av &amp; Enterprise Av - FS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25824,8 +25514,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Executive Av &amp; Escort Av
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25836,8 +25524,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Escort Av &amp; Island Av
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25848,8 +25534,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Island Av &amp; Penrose Av - MBNS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25860,8 +25544,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Island Av &amp; Penrose Av - MBNS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25872,8 +25554,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Penrose Av &amp; 26th St - MBNS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25884,8 +25564,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Penrose &amp; Pattison Av - MBNS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25896,8 +25574,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Penrose &amp; Pattison Av - FS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25908,8 +25584,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Penrose Av &amp; 20th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25920,8 +25594,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Penrose Av &amp; 20th St - FS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25932,8 +25604,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Moyamensing Av &amp; Pollock St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25944,8 +25614,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Moyamensing Av &amp; 18th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25956,8 +25624,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Moyamensing Av &amp; 17th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25968,8 +25634,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Moyamensing Av &amp; 16th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25980,8 +25644,6 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Moyamensing Av &amp; 15th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -27684,8 +27346,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Washington Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -27696,8 +27356,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Goose Hollow/SW Jefferson St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -27708,8 +27366,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Kings Hill/SW Salmon St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -27720,8 +27376,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Providence Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -27732,8 +27386,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Library/SW 9th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -27744,8 +27396,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Pioneer Square South MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -27756,8 +27406,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Mall/SW 4th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -27768,8 +27416,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Yamhill District MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -29279,8 +28925,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Washington Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29291,8 +28935,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Goose Hollow/SW Jefferson St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29303,8 +28945,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Kings Hill/SW Salmon St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29315,8 +28955,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Providence Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29327,8 +28965,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Library/SW 9th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29339,8 +28975,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Pioneer Square South MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29351,8 +28985,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Mall/SW 4th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29363,8 +28995,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Yamhill District MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -30874,8 +30504,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Washington Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -30886,8 +30514,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Goose Hollow/SW Jefferson St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -30898,8 +30524,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Kings Hill/SW Salmon St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -30910,8 +30534,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Providence Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -30922,8 +30544,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Library/SW 9th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -30934,8 +30554,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Pioneer Square South MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -30946,8 +30564,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Mall/SW 4th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -30958,8 +30574,6 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Yamhill District MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -31923,8 +31537,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Broadway &amp; 34th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -31935,8 +31547,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           South Everett Fwy Station Bay 3
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -31947,8 +31557,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Ash Way Park &amp; Ride Bay 1
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -31959,8 +31567,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Lynnwood Transit Center Bay D3
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -31971,8 +31577,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Mountlake Terrace Fwy Station Bay 6
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -32261,8 +31865,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           1st Ave NE &amp; NE 95th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32273,8 +31875,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N 92nd St &amp; Corliss Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32285,8 +31885,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           College Way N &amp; N 97th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32297,8 +31895,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           College Way N &amp; N 103rd St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32309,8 +31905,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Meridian Ave N &amp; N 105th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32321,8 +31915,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N Northgate Way &amp; Meridian Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32333,8 +31925,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N Northgate Way &amp; Stone Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -32793,8 +32383,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 100th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32805,8 +32393,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 95th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32817,8 +32403,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 90th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32829,8 +32413,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 85th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32841,8 +32423,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 80th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32853,8 +32433,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 76th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32865,8 +32443,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 65th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32877,8 +32453,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 46th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32889,8 +32463,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Lynn St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32901,8 +32473,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Galer St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32913,8 +32483,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           7th Ave N &amp; Thomas St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32925,8 +32493,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Wall St &amp; 5th Ave
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32937,8 +32503,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Bell St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32949,8 +32513,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Virginia St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32961,8 +32523,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Pike St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32973,8 +32533,6 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Seneca St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -33951,8 +33509,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Cesar Chavez Blvd &amp; Clinton
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -33963,8 +33519,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Cesar Chavez Blvd &amp; Division
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -33975,8 +33529,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Cesar Chavez Blvd &amp; Lincoln
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -33987,8 +33539,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Cesar Chavez Blvd &amp; Stephens
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -34455,8 +34005,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Hawthorne &amp; 37th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -34467,8 +34015,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Hawthorne &amp; 34th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -34479,8 +34025,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Hawthorne &amp; 32nd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -34491,8 +34035,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Hawthorne &amp; 30th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -35298,8 +34840,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Cesar Chavez Blvd &amp; Clinton
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -35310,8 +34850,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Cesar Chavez Blvd &amp; Division
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -35322,8 +34860,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Cesar Chavez Blvd &amp; Lincoln
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -35334,8 +34870,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Cesar Chavez Blvd &amp; Stephens
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -35833,8 +35367,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Hawthorne &amp; 37th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -35845,8 +35377,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Hawthorne &amp; 34th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -35857,8 +35387,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Hawthorne &amp; 32nd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -35869,8 +35397,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Hawthorne &amp; 30th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -36819,8 +36345,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -37787,8 +37311,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -38748,7 +38270,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryClosedStop smoke-
                           Galleria/SW 10th Ave MAX Station
                         </div>
                         <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                          (Closed)
+                          Closed
                         </span>
                       </div>
                     </li>
@@ -39708,8 +39230,6 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -40638,8 +40158,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Broadway &amp; 34th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -40650,8 +40168,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           South Everett Fwy Station Bay 3
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -40662,8 +40178,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Ash Way Park &amp; Ride Bay 1
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -40674,8 +40188,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Lynnwood Transit Center Bay D3
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -40686,8 +40198,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Mountlake Terrace Fwy Station Bay 6
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -40976,8 +40486,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           1st Ave NE &amp; NE 95th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -40988,8 +40496,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N 92nd St &amp; Corliss Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41000,8 +40506,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           College Way N &amp; N 97th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41012,8 +40516,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           College Way N &amp; N 103rd St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41024,8 +40526,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Meridian Ave N &amp; N 105th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41036,8 +40536,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N Northgate Way &amp; Meridian Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41048,8 +40546,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N Northgate Way &amp; Stone Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -41508,8 +41004,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 100th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41520,8 +41014,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 95th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41532,8 +41024,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 90th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41544,8 +41034,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 85th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41556,8 +41044,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 80th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41568,8 +41054,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 76th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41580,8 +41064,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 65th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41592,8 +41074,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 46th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41604,8 +41084,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Lynn St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41616,8 +41094,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Galer St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41628,8 +41104,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           7th Ave N &amp; Thomas St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41640,8 +41114,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Wall St &amp; 5th Ave
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41652,8 +41124,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Bell St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41664,8 +41134,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Virginia St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41676,8 +41144,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Pike St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41688,8 +41154,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Seneca St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -42539,8 +42003,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Broadway &amp; 34th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42551,8 +42013,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           South Everett Fwy Station Bay 3
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42563,8 +42023,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Ash Way Park &amp; Ride Bay 1
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42575,8 +42033,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Lynnwood Transit Center Bay D3
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42587,8 +42043,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Mountlake Terrace Fwy Station Bay 6
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -42877,8 +42331,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           1st Ave NE &amp; NE 95th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42889,8 +42341,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N 92nd St &amp; Corliss Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42901,8 +42351,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           College Way N &amp; N 97th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42913,8 +42361,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           College Way N &amp; N 103rd St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42925,8 +42371,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Meridian Ave N &amp; N 105th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42937,8 +42381,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N Northgate Way &amp; Meridian Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42949,8 +42391,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N Northgate Way &amp; Stone Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -43409,8 +42849,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 100th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43421,8 +42859,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 95th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43433,8 +42869,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 90th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43445,8 +42879,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 85th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43457,8 +42889,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 80th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43469,8 +42899,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 76th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43481,8 +42909,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 65th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43493,8 +42919,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 46th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43505,8 +42929,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Lynn St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43517,8 +42939,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Galer St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43529,8 +42949,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           7th Ave N &amp; Thomas St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43541,8 +42959,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Wall St &amp; 5th Ave
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43553,8 +42969,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Bell St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43565,8 +42979,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Virginia St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43577,8 +42989,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Pike St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43589,8 +42999,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Seneca St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -44440,8 +43848,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Broadway &amp; 34th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -44452,8 +43858,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           South Everett Fwy Station Bay 3
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -44464,8 +43868,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Ash Way Park &amp; Ride Bay 1
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -44476,8 +43878,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Lynnwood Transit Center Bay D3
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -44488,8 +43888,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Mountlake Terrace Fwy Station Bay 6
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -44778,8 +44176,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           1st Ave NE &amp; NE 95th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -44790,8 +44186,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N 92nd St &amp; Corliss Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -44802,8 +44196,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           College Way N &amp; N 97th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -44814,8 +44206,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           College Way N &amp; N 103rd St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -44826,8 +44216,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Meridian Ave N &amp; N 105th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -44838,8 +44226,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N Northgate Way &amp; Meridian Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -44850,8 +44236,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N Northgate Way &amp; Stone Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -45310,8 +44694,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 100th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45322,8 +44704,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 95th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45334,8 +44714,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 90th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45346,8 +44724,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 85th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45358,8 +44734,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 80th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45370,8 +44744,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 76th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45382,8 +44754,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 65th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45394,8 +44764,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 46th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45406,8 +44774,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Lynn St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45418,8 +44784,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Galer St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45430,8 +44794,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           7th Ave N &amp; Thomas St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45442,8 +44804,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Wall St &amp; 5th Ave
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45454,8 +44814,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Bell St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45466,8 +44824,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Virginia St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45478,8 +44834,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Pike St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45490,8 +44844,6 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Seneca St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>

--- a/packages/itinerary-body/src/stories/__snapshots__/OtpRrItineraryBody.story.tsx.snap
+++ b/packages/itinerary-body/src/stories/__snapshots__/OtpRrItineraryBody.story.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -338,7 +338,7 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -355,7 +355,7 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
             </a>
           </div>
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -364,7 +364,7 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -397,9 +397,9 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -407,7 +407,7 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -415,13 +415,13 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -443,8 +443,8 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -452,7 +452,7 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -460,13 +460,13 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -488,8 +488,8 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -497,7 +497,7 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -505,13 +505,13 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -536,9 +536,9 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -571,14 +571,18 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -954,7 +958,7 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
 `;
 
 exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -1291,7 +1295,7 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -1308,7 +1312,7 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
             </a>
           </div>
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -1317,7 +1321,7 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -1350,9 +1354,9 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -1360,7 +1364,7 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -1368,14 +1372,14 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -1397,8 +1401,8 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -1406,7 +1410,7 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -1414,14 +1418,14 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -1443,8 +1447,8 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -1452,7 +1456,7 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -1460,14 +1464,14 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -1492,9 +1496,9 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -1527,14 +1531,18 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -1910,7 +1918,7 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
 `;
 
 exports[`ItineraryBody/otp-react-redux BikeOnlyItinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 dncEaQ leg-line">
@@ -2250,7 +2258,7 @@ exports[`ItineraryBody/otp-react-redux BikeOnlyItinerary smoke-test 1`] = `
 `;
 
 exports[`ItineraryBody/otp-react-redux BikeRentalItinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -3085,7 +3093,7 @@ exports[`ItineraryBody/otp-react-redux BikeRentalItinerary smoke-test 1`] = `
 `;
 
 exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -4136,7 +4144,7 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -4152,7 +4160,7 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
               </span>
             </a>
           </div>
-          <div class="styled__TransitAlertDiv-sc-1q8npbl-86 dNKGjA alert-toggle">
+          <div class="styled__TransitAlertDiv-sc-1q8npbl-88 bJSHRu alert-toggle">
             <svg viewbox="0 0 512 512"
                  height="15"
                  width="15"
@@ -4160,7 +4168,7 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -4174,9 +4182,9 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -4184,7 +4192,7 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -4192,14 +4200,14 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     For trips to Tigard Transit Center, no service to the stop at NE Sandy &amp; 91st (Stop ID 5145) due to PBOT sidewalk construction. Use temporary stop on the west side of 91st.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of July 31, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -4221,8 +4229,8 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -4230,7 +4238,7 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -4238,14 +4246,14 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     For trips to Parkrose/Sumner Transit Center, no service to the stop at NE Sandy &amp; 47th (Stop ID 5094) due to long-term construction. Use the temporary stop located at NE Sandy &amp; 48th (Stop ID 14073).
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of July 12, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -4270,9 +4278,9 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 12 min / 13 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -4305,102 +4313,150 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; Lawrence
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; Lawrence
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; 28th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; 28th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; 31st
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; 31st
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; 33rd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; 33rd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; Imperial
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; Imperial
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; 38th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; 38th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; 42nd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; 42nd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; 44th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; 44th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; 48th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; 48th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; 50th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; 50th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; Sacramento
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; Sacramento
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; 54th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; 54th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -5217,7 +5273,7 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
 `;
 
 exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -5996,7 +6052,7 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -6012,7 +6068,7 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
               </span>
             </a>
           </div>
-          <div class="styled__TransitAlertDiv-sc-1q8npbl-86 dNKGjA alert-toggle">
+          <div class="styled__TransitAlertDiv-sc-1q8npbl-88 bJSHRu alert-toggle">
             <svg viewbox="0 0 512 512"
                  height="15"
                  width="15"
@@ -6020,7 +6076,7 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -6034,9 +6090,9 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -6044,7 +6100,7 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -6052,14 +6108,14 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -6081,8 +6137,8 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -6090,7 +6146,7 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -6098,14 +6154,14 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -6130,9 +6186,9 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -6165,14 +6221,18 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -6688,7 +6748,7 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
 `;
 
 exports[`ItineraryBody/otp-react-redux CustomTimeColumn smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fiFXVo leg-line">
@@ -7042,7 +7102,7 @@ exports[`ItineraryBody/otp-react-redux CustomTimeColumn smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="#"
                rel="noopener noreferrer"
@@ -7060,9 +7120,9 @@ exports[`ItineraryBody/otp-react-redux CustomTimeColumn smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 6 min / 3 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -7095,22 +7155,30 @@ exports[`ItineraryBody/otp-react-redux CustomTimeColumn smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        W Burnside &amp; SW 2nd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          W Burnside &amp; SW 2nd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 8th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 8th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -7433,7 +7501,7 @@ exports[`ItineraryBody/otp-react-redux CustomTimeColumn smoke-test 1`] = `
 `;
 
 exports[`ItineraryBody/otp-react-redux EScooterRentalItinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -7916,7 +7984,7 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalItinerary smoke-test 1`] = 
 `;
 
 exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -8901,7 +8969,7 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -8924,9 +8992,9 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 8 min / 9 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -8959,70 +9027,102 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Broadway &amp; 32nd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Broadway &amp; 32nd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE 33rd &amp; Schuyler
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE 33rd &amp; Schuyler
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE 33rd &amp; US Grant Pl
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE 33rd &amp; US Grant Pl
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE 33rd &amp; Brazee
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE 33rd &amp; Brazee
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE 33rd &amp; Knott
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE 33rd &amp; Knott
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE 33rd &amp; Stanton
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE 33rd &amp; Stanton
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE 33rd &amp; Siskiyou
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE 33rd &amp; Siskiyou
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE 33rd &amp; Alameda
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE 33rd &amp; Alameda
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -9735,7 +9835,7 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
 `;
 
 exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fiFXVo leg-line">
@@ -10245,7 +10345,7 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -10261,7 +10361,7 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
               </span>
             </a>
           </div>
-          <div class="styled__TransitAlertDiv-sc-1q8npbl-86 dNKGjA alert-toggle">
+          <div class="styled__TransitAlertDiv-sc-1q8npbl-88 bJSHRu alert-toggle">
             <svg viewbox="0 0 512 512"
                  height="15"
                  width="15"
@@ -10269,7 +10369,7 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -10283,9 +10383,9 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -10293,7 +10393,7 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -10301,14 +10401,14 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -10330,8 +10430,8 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -10339,7 +10439,7 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -10347,14 +10447,14 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -10379,9 +10479,9 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 21 min / 9 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -10414,70 +10514,102 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Washington Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Washington Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Goose Hollow/SW Jefferson St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Goose Hollow/SW Jefferson St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Kings Hill/SW Salmon St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Kings Hill/SW Salmon St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Providence Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Providence Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Library/SW 9th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Library/SW 9th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Pioneer Square South MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Pioneer Square South MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Mall/SW 4th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Mall/SW 4th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Yamhill District MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Yamhill District MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -10888,7 +11020,7 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
 `;
 
 exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -11629,7 +11761,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="https://www.skagittransit.org"
                rel="noopener noreferrer"
@@ -11650,13 +11782,13 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 1 hr 0 min / 5 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -11689,42 +11821,58 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        South Mount Vernon Park &amp; Ride
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          South Mount Vernon Park &amp; Ride
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Broadway - Everett Community College
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Broadway - Everett Community College
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Broadway &amp; 14th  (near hospital)
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Broadway &amp; 14th  (near hospital)
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Broadway just South of the Event Center
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Broadway just South of the Event Center
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
-                  <div class="styled__TransitLegFare-sc-1q8npbl-90 jswIwD">
+                  <div class="styled__TransitLegFare-sc-1q8npbl-92 fBtYSN">
                     Fare: $1.00
                   </div>
                 </div>
@@ -12042,7 +12190,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="https://www.soundtransit.org/"
                rel="noopener noreferrer"
@@ -12063,13 +12211,13 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 26 min / 4 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -12102,34 +12250,46 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Broadway &amp; 34th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Broadway &amp; 34th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        South Everett Fwy Station Bay 3
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          South Everett Fwy Station Bay 3
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Ash Way Park &amp; Ride Bay 1
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Ash Way Park &amp; Ride Bay 1
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
-                  <div class="styled__TransitLegFare-sc-1q8npbl-90 jswIwD">
+                  <div class="styled__TransitLegFare-sc-1q8npbl-92 fBtYSN">
                     Fare: $3.25
                   </div>
                 </div>
@@ -12447,7 +12607,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="https://www.soundtransit.org/"
                rel="noopener noreferrer"
@@ -12468,13 +12628,13 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 25 min / 6 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -12507,50 +12667,70 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Alderwood Mall Pkwy &amp; Beech Rd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Alderwood Mall Pkwy &amp; Beech Rd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Alderwood Mall Pkwy &amp; 184th St SW
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Alderwood Mall Pkwy &amp; 184th St SW
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Canyon Park Fwy Station Bay 4
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Canyon Park Fwy Station Bay 4
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Beardslee Blvd &amp; Ross Rd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Beardslee Blvd &amp; Ross Rd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        UW Bothell &amp; Cascadia College
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          UW Bothell &amp; Cascadia College
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
-                  <div class="styled__TransitLegFare-sc-1q8npbl-90 jswIwD">
+                  <div class="styled__TransitLegFare-sc-1q8npbl-92 fBtYSN">
                     Fare: $3.25
                   </div>
                 </div>
@@ -12868,7 +13048,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="https://kingcounty.gov/en/dept/metro"
                rel="noopener noreferrer"
@@ -12889,13 +13069,13 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 11 min / 10 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -12928,82 +13108,118 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Woodinville Dr &amp; Kaysner Way
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Woodinville Dr &amp; Kaysner Way
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Bothell Way NE &amp; NE 180th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Bothell Way NE &amp; NE 180th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Bothell Way &amp; 96th Ave NE
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Bothell Way &amp; 96th Ave NE
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Bothell Way &amp; 91st Ave NE
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Bothell Way &amp; 91st Ave NE
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Bothell Way &amp; 83rd Pl NE
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Bothell Way &amp; 83rd Pl NE
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Bothell Way &amp; 80th Ave NE
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Bothell Way &amp; 80th Ave NE
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Bothell Way &amp; 77th Ct NE
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Bothell Way &amp; 77th Ct NE
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Bothell Way &amp; Kenmore Park &amp; Ride
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Bothell Way &amp; Kenmore Park &amp; Ride
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Bothell Way &amp; 68th Ave NE
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Bothell Way &amp; 68th Ave NE
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
-                  <div class="styled__TransitLegFare-sc-1q8npbl-90 jswIwD">
+                  <div class="styled__TransitLegFare-sc-1q8npbl-92 fBtYSN">
                     Fare: $2.75
                   </div>
                 </div>
@@ -13395,7 +13611,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
 `;
 
 exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -13832,7 +14048,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://rtd-denver.com"
                rel="noopener noreferrer"
@@ -13851,9 +14067,9 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 18 min / 12 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -13886,94 +14102,138 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        S Main St &amp; Ken Pratt Blvd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          S Main St &amp; Ken Pratt Blvd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        S Main St &amp; Jersey Ave
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          S Main St &amp; Jersey Ave
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        S Main St &amp; Missouri Ave
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          S Main St &amp; Missouri Ave
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        S Main St &amp; Quebec Ave
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          S Main St &amp; Quebec Ave
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        US 287 &amp; Pike Rd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          US 287 &amp; Pike Rd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        US 287 &amp; Niwot Rd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          US 287 &amp; Niwot Rd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        US 287 &amp; Hwy 52
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          US 287 &amp; Hwy 52
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        US 287 &amp; Lookout Rd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          US 287 &amp; Lookout Rd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        US 287 &amp; Dawson Dr
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          US 287 &amp; Dawson Dr
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        US 287 &amp; Goose Haven Dr
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          US 287 &amp; Goose Haven Dr
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        US 287 &amp; Isabelle Rd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          US 287 &amp; Isabelle Rd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -14334,7 +14594,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://rtd-denver.com"
                rel="noopener noreferrer"
@@ -14353,9 +14613,9 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 9 min / 8 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -14388,62 +14648,90 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Arapahoe Rd &amp; US 287
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Arapahoe Rd &amp; US 287
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Arapahoe Rd &amp; 111th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Arapahoe Rd &amp; 111th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Arapahoe Rd &amp; Hawkridge Rd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Arapahoe Rd &amp; Hawkridge Rd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        2800 Block 119th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          2800 Block 119th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        119th St &amp; Austin Ave
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          119th St &amp; Austin Ave
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Erie Pkwy &amp; Brennan St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Erie Pkwy &amp; Brennan St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Erie Pkwy &amp; Meller St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Erie Pkwy &amp; Meller St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -14794,7 +15082,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="https://60plusride.org/"
                rel="noopener noreferrer"
@@ -14898,7 +15186,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
 `;
 
 exports[`ItineraryBody/otp-react-redux OTP2ScooterItinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -15705,7 +15993,7 @@ exports[`ItineraryBody/otp-react-redux OTP2ScooterItinerary smoke-test 1`] = `
 `;
 
 exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -16254,7 +16542,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="https://trimet.org/"
                rel="noopener noreferrer"
@@ -16275,13 +16563,13 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 34 min / 12 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -16314,94 +16602,138 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Quatama MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Quatama MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Willow Creek/SW 185th Ave TC MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Willow Creek/SW 185th Ave TC MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Elmonica/SW 170th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Elmonica/SW 170th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Merlo Rd/SW 158th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Merlo Rd/SW 158th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Beaverton Creek MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Beaverton Creek MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Millikan Way MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Millikan Way MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Beaverton Central MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Beaverton Central MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Beaverton TC MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Beaverton TC MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Sunset TC MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Sunset TC MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Washington Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Washington Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Goose Hollow/SW Jefferson St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Goose Hollow/SW Jefferson St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -16876,7 +17208,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="https://trimet.org/"
                rel="noopener noreferrer"
@@ -16897,13 +17229,13 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 28 min / 33 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -16936,262 +17268,390 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        W Burnside &amp; SW 15th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          W Burnside &amp; SW 15th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        W Burnside &amp; SW 13th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          W Burnside &amp; SW 13th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        W Burnside &amp; SW 10th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          W Burnside &amp; SW 10th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        W Burnside &amp; SW 6th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          W Burnside &amp; SW 6th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        W Burnside &amp; SW 2nd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          W Burnside &amp; SW 2nd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; NE Grand
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; NE Grand
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 8th Ave
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 8th Ave
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 12th Ave
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 12th Ave
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 16th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 16th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 20th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 20th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 24th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 24th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 28th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 28th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 32nd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 32nd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE Floral
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE Floral
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE Laurelhurst
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE Laurelhurst
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE Cesar Chavez Blvd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE Cesar Chavez Blvd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 41st
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 41st
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 44th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 44th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 47th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 47th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 52nd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 52nd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 55th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 55th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 57th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 57th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 60th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 60th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; 63rd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; 63rd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 67th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 67th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 69th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 69th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 72nd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 72nd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 74th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 74th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 79th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 79th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 82nd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 82nd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 87th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 87th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        9100 Block E Burnside
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          9100 Block E Burnside
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -17593,7 +18053,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
 `;
 
 exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fiFXVo leg-line">
@@ -18513,7 +18973,7 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -18529,7 +18989,7 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
               </span>
             </a>
           </div>
-          <div class="styled__TransitAlertDiv-sc-1q8npbl-86 dNKGjA alert-toggle">
+          <div class="styled__TransitAlertDiv-sc-1q8npbl-88 bJSHRu alert-toggle">
             <svg viewbox="0 0 512 512"
                  height="15"
                  width="15"
@@ -18537,7 +18997,7 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -18551,9 +19011,9 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -18561,7 +19021,7 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -18569,14 +19029,14 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -18598,8 +19058,8 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -18607,7 +19067,7 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -18615,14 +19075,14 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -18647,9 +19107,9 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 21 min / 9 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -18682,70 +19142,102 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Washington Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Washington Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Goose Hollow/SW Jefferson St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Goose Hollow/SW Jefferson St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Kings Hill/SW Salmon St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Kings Hill/SW Salmon St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Providence Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Providence Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Library/SW 9th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Library/SW 9th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Pioneer Square South MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Pioneer Square South MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Mall/SW 4th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Mall/SW 4th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Yamhill District MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Yamhill District MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -19156,7 +19648,7 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
 `;
 
 exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper transit  ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 giaaKO leg-line">
@@ -19273,7 +19765,7 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="https://kingcounty.gov/en/dept/metro"
                rel="noopener noreferrer"
@@ -19294,13 +19786,13 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 7 min / 7 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -19333,54 +19825,78 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Halladay St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Halladay St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Lynn St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Lynn St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Crockett St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Crockett St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Galer St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Galer St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Prospect St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Prospect St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        7th Ave N &amp; Thomas St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          7th Ave N &amp; Thomas St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -19484,7 +20000,7 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="https://kingcounty.gov/en/dept/metro"
                rel="noopener noreferrer"
@@ -19505,13 +20021,13 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 16 min / 7 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -19544,54 +20060,78 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Bell St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Bell St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Virginia St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Virginia St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Pike St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Pike St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Seneca St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Seneca St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Cherry St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Cherry St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave S &amp; S Main St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave S &amp; S Main St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -19657,7 +20197,7 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
 `;
 
 exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -19993,7 +20533,7 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -20010,7 +20550,7 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
             </a>
           </div>
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -20019,7 +20559,7 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -20052,9 +20592,9 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -20062,7 +20602,7 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -20070,14 +20610,14 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -20099,8 +20639,8 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -20108,7 +20648,7 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -20116,14 +20656,14 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -20145,8 +20685,8 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -20154,7 +20694,7 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -20162,14 +20702,14 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -20194,9 +20734,9 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -20229,14 +20769,18 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -20612,7 +21156,7 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
 `;
 
 exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -20949,7 +21493,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -20966,7 +21510,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
             </a>
           </div>
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -20975,7 +21519,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -21008,9 +21552,9 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -21018,7 +21562,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -21026,14 +21570,14 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -21055,8 +21599,8 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -21064,7 +21608,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -21072,14 +21616,14 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -21101,8 +21645,8 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -21110,7 +21654,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -21118,14 +21662,14 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -21150,9 +21694,9 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -21185,14 +21729,18 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -21568,7 +22116,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
 `;
 
 exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -21905,7 +22453,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -21922,7 +22470,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
             </a>
           </div>
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -21931,7 +22479,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -21964,9 +22512,9 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -21974,7 +22522,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -21982,14 +22530,14 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -22011,8 +22559,8 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -22020,7 +22568,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -22028,14 +22576,14 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -22057,8 +22605,8 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -22066,7 +22614,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -22074,14 +22622,14 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -22106,9 +22654,9 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -22141,14 +22689,18 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -22524,7 +23076,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
 `;
 
 exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -22861,7 +23413,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -22878,7 +23430,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
             </a>
           </div>
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -22887,7 +23439,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -22920,9 +23472,9 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -22930,7 +23482,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -22938,14 +23490,14 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -22967,8 +23519,8 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -22976,7 +23528,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -22984,14 +23536,14 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -23013,8 +23565,8 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -23022,7 +23574,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -23030,14 +23582,14 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -23062,9 +23614,9 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -23097,14 +23649,18 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -23480,7 +24036,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
 `;
 
 exports[`ItineraryBody/otp-react-redux TncTransitItinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fiFXVo leg-line">
@@ -23778,7 +24334,7 @@ exports[`ItineraryBody/otp-react-redux TncTransitItinerary smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="https://trimet.org/"
                rel="noopener noreferrer"
@@ -23801,9 +24357,9 @@ exports[`ItineraryBody/otp-react-redux TncTransitItinerary smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 6 min / 3 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -23836,22 +24392,30 @@ exports[`ItineraryBody/otp-react-redux TncTransitItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        W Burnside &amp; SW 2nd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          W Burnside &amp; SW 2nd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 8th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 8th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -24118,7 +24682,7 @@ exports[`ItineraryBody/otp-react-redux TncTransitItinerary smoke-test 1`] = `
 `;
 
 exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -24741,7 +25305,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="https://www5.septa.org/"
                rel="noopener noreferrer"
@@ -24762,13 +25326,13 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 8 min / 4 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -24801,30 +25365,42 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Philadelphia Airport Terminals E &amp; F
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Philadelphia Airport Terminals E &amp; F
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Bartram Av &amp; 90th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Bartram Av &amp; 90th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        89th St &amp; Bartram Av - FS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          89th St &amp; Bartram Av - FS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -25046,7 +25622,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="https://www5.septa.org/"
                rel="noopener noreferrer"
@@ -25067,13 +25643,13 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 20 min / 26 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -25106,206 +25682,306 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Tinicum Blvd &amp; 88th St - FS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Tinicum Blvd &amp; 88th St - FS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Tinicum Blvd &amp; 86th St - MBFS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Tinicum Blvd &amp; 86th St - MBFS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Bartram Av &amp; 84th St - MBNS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Bartram Av &amp; 84th St - MBNS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Bartram Av &amp; 84th St - MBFS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Bartram Av &amp; 84th St - MBFS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Island Av &amp; Penrose Av - MBNS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Island Av &amp; Penrose Av - MBNS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Island Av &amp; Penrose Av - MBFS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Island Av &amp; Penrose Av - MBFS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Island Av &amp; Escort Av - MBNS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Island Av &amp; Escort Av - MBNS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Island Av &amp; Escort Av
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Island Av &amp; Escort Av
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Island Av &amp; Escort Av - MBFS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Island Av &amp; Escort Av - MBFS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Enterprise Av &amp; Executive Av
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Enterprise Av &amp; Executive Av
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Executive Av &amp; Enterprise Av - FS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Executive Av &amp; Enterprise Av - FS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Executive Av &amp; Escort Av
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Executive Av &amp; Escort Av
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Escort Av &amp; Island Av
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Escort Av &amp; Island Av
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Island Av &amp; Penrose Av - MBNS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Island Av &amp; Penrose Av - MBNS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Island Av &amp; Penrose Av - MBNS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Island Av &amp; Penrose Av - MBNS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Penrose Av &amp; 26th St - MBNS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Penrose Av &amp; 26th St - MBNS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Penrose &amp; Pattison Av - MBNS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Penrose &amp; Pattison Av - MBNS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Penrose &amp; Pattison Av - FS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Penrose &amp; Pattison Av - FS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Penrose Av &amp; 20th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Penrose Av &amp; 20th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Penrose Av &amp; 20th St - FS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Penrose Av &amp; 20th St - FS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Moyamensing Av &amp; Pollock St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Moyamensing Av &amp; Pollock St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Moyamensing Av &amp; 18th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Moyamensing Av &amp; 18th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Moyamensing Av &amp; 17th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Moyamensing Av &amp; 17th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Moyamensing Av &amp; 16th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Moyamensing Av &amp; 16th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Moyamensing Av &amp; 15th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Moyamensing Av &amp; 15th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -25888,7 +26564,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
 `;
 
 exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fiFXVo leg-line">
@@ -26808,7 +27484,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -26825,7 +27501,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
             </a>
           </div>
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -26834,7 +27510,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -26867,9 +27543,9 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -26877,7 +27553,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -26885,14 +27561,14 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -26914,8 +27590,8 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -26923,7 +27599,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -26931,14 +27607,14 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -26963,9 +27639,9 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 21 min / 9 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -26998,70 +27674,102 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Washington Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Washington Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Goose Hollow/SW Jefferson St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Goose Hollow/SW Jefferson St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Kings Hill/SW Salmon St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Kings Hill/SW Salmon St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Providence Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Providence Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Library/SW 9th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Library/SW 9th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Pioneer Square South MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Pioneer Square South MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Mall/SW 4th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Mall/SW 4th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Yamhill District MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Yamhill District MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -27472,7 +28180,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
 `;
 
 exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fiFXVo leg-line">
@@ -28392,7 +29100,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -28408,7 +29116,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
               </span>
             </a>
           </div>
-          <div class="styled__TransitAlertDiv-sc-1q8npbl-86 dNKGjA alert-toggle">
+          <div class="styled__TransitAlertDiv-sc-1q8npbl-88 bJSHRu alert-toggle">
             <svg viewbox="0 0 512 512"
                  height="15"
                  width="15"
@@ -28416,7 +29124,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -28430,9 +29138,9 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -28440,7 +29148,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -28448,14 +29156,14 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -28477,8 +29185,8 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -28486,7 +29194,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -28494,14 +29202,14 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -28526,9 +29234,9 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 21 min / 9 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -28561,70 +29269,102 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Washington Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Washington Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Goose Hollow/SW Jefferson St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Goose Hollow/SW Jefferson St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Kings Hill/SW Salmon St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Kings Hill/SW Salmon St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Providence Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Providence Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Library/SW 9th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Library/SW 9th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Pioneer Square South MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Pioneer Square South MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Mall/SW 4th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Mall/SW 4th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Yamhill District MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Yamhill District MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -29035,7 +29775,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
 `;
 
 exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 fiFXVo leg-line">
@@ -29955,7 +30695,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -29971,7 +30711,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
               </span>
             </a>
           </div>
-          <div class="styled__TransitAlertDiv-sc-1q8npbl-86 dNKGjA alert-toggle">
+          <div class="styled__TransitAlertDiv-sc-1q8npbl-88 bJSHRu alert-toggle">
             <svg viewbox="0 0 512 512"
                  height="15"
                  width="15"
@@ -29979,7 +30719,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -29993,9 +30733,9 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -30003,7 +30743,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -30011,14 +30751,14 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -30040,8 +30780,8 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -30049,7 +30789,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -30057,14 +30797,14 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -30089,9 +30829,9 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 21 min / 9 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -30124,70 +30864,102 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Washington Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Washington Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Goose Hollow/SW Jefferson St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Goose Hollow/SW Jefferson St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Kings Hill/SW Salmon St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Kings Hill/SW Salmon St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Providence Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Providence Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Library/SW 9th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Library/SW 9th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Pioneer Square South MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Pioneer Square South MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Mall/SW 4th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Mall/SW 4th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Yamhill District MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Yamhill District MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -30598,7 +31370,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
 `;
 
 exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -31087,7 +31859,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://www.communitytransit.org/"
                rel="noopener noreferrer"
@@ -31106,9 +31878,9 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 47 min / 6 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -31141,46 +31913,66 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Broadway &amp; 34th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Broadway &amp; 34th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        South Everett Fwy Station Bay 3
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          South Everett Fwy Station Bay 3
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Ash Way Park &amp; Ride Bay 1
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Ash Way Park &amp; Ride Bay 1
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Lynnwood Transit Center Bay D3
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Lynnwood Transit Center Bay D3
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Mountlake Terrace Fwy Station Bay 6
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Mountlake Terrace Fwy Station Bay 6
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -31405,7 +32197,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://metro.kingcounty.gov"
                rel="noopener noreferrer"
@@ -31424,9 +32216,9 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 11 min / 8 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -31459,62 +32251,90 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        1st Ave NE &amp; NE 95th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          1st Ave NE &amp; NE 95th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N 92nd St &amp; Corliss Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N 92nd St &amp; Corliss Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        College Way N &amp; N 97th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          College Way N &amp; N 97th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        College Way N &amp; N 103rd St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          College Way N &amp; N 103rd St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Meridian Ave N &amp; N 105th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Meridian Ave N &amp; N 105th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N Northgate Way &amp; Meridian Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N Northgate Way &amp; Meridian Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N Northgate Way &amp; Stone Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N Northgate Way &amp; Stone Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -31909,7 +32729,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://metro.kingcounty.gov"
                rel="noopener noreferrer"
@@ -31928,9 +32748,9 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 31 min / 17 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -31963,134 +32783,198 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 100th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 100th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 95th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 95th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 90th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 90th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 85th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 85th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 80th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 80th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 76th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 76th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 65th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 65th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 46th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 46th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Lynn St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Lynn St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Galer St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Galer St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        7th Ave N &amp; Thomas St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          7th Ave N &amp; Thomas St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Wall St &amp; 5th Ave
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Wall St &amp; 5th Ave
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Bell St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Bell St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Virginia St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Virginia St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Pike St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Pike St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Seneca St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Seneca St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -32387,7 +33271,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
 `;
 
 exports[`ItineraryBody/otp-react-redux WalkOnlyItinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -32658,7 +33542,7 @@ exports[`ItineraryBody/otp-react-redux WalkOnlyItinerary smoke-test 1`] = `
 `;
 
 exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -32999,7 +33883,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -33022,9 +33906,9 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 4 min / 5 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -33057,38 +33941,54 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Cesar Chavez Blvd &amp; Clinton
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Cesar Chavez Blvd &amp; Clinton
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Cesar Chavez Blvd &amp; Division
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Cesar Chavez Blvd &amp; Division
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Cesar Chavez Blvd &amp; Lincoln
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Cesar Chavez Blvd &amp; Lincoln
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Cesar Chavez Blvd &amp; Stephens
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Cesar Chavez Blvd &amp; Stephens
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -33487,7 +34387,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -33510,9 +34410,9 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 4 min / 5 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -33545,38 +34445,54 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Hawthorne &amp; 37th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Hawthorne &amp; 37th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Hawthorne &amp; 34th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Hawthorne &amp; 34th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Hawthorne &amp; 32nd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Hawthorne &amp; 32nd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Hawthorne &amp; 30th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Hawthorne &amp; 30th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -33911,7 +34827,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
 `;
 
 exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -34314,7 +35230,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -34337,9 +35253,9 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 4 min / 5 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -34372,38 +35288,54 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Cesar Chavez Blvd &amp; Clinton
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Cesar Chavez Blvd &amp; Clinton
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Cesar Chavez Blvd &amp; Division
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Cesar Chavez Blvd &amp; Division
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Cesar Chavez Blvd &amp; Lincoln
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Cesar Chavez Blvd &amp; Lincoln
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Cesar Chavez Blvd &amp; Stephens
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Cesar Chavez Blvd &amp; Stephens
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -34833,7 +35765,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -34856,9 +35788,9 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 4 min / 5 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -34891,38 +35823,54 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Hawthorne &amp; 37th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Hawthorne &amp; 37th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Hawthorne &amp; 34th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Hawthorne &amp; 34th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Hawthorne &amp; 32nd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Hawthorne &amp; 32nd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Hawthorne &amp; 30th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Hawthorne &amp; 30th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -35288,7 +36236,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
 `;
 
 exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -35625,7 +36573,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -35642,7 +36590,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
             </a>
           </div>
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -35651,7 +36599,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -35684,9 +36632,9 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -35694,7 +36642,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -35702,14 +36650,14 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -35731,8 +36679,8 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -35740,7 +36688,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -35748,14 +36696,14 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -35777,8 +36725,8 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -35786,7 +36734,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -35794,14 +36742,14 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -35826,9 +36774,9 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -35861,14 +36809,18 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -36244,7 +37196,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
 `;
 
 exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -36589,7 +37541,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -36606,7 +37558,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
             </a>
           </div>
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -36615,7 +37567,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -36648,9 +37600,9 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -36658,7 +37610,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -36666,14 +37618,14 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -36695,8 +37647,8 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -36704,7 +37656,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -36712,14 +37664,14 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -36741,8 +37693,8 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -36750,7 +37702,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -36758,14 +37710,14 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -36790,9 +37742,9 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -36825,14 +37777,18 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -37208,7 +38164,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
 `;
 
 exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryClosedStop smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -37545,7 +38501,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryClosedStop smoke-
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -37562,7 +38518,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryClosedStop smoke-
             </a>
           </div>
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -37571,7 +38527,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryClosedStop smoke-
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -37604,9 +38560,9 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryClosedStop smoke-
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -37614,7 +38570,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryClosedStop smoke-
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -37622,14 +38578,14 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryClosedStop smoke-
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -37651,8 +38607,8 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryClosedStop smoke-
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -37660,7 +38616,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryClosedStop smoke-
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -37668,14 +38624,14 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryClosedStop smoke-
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -37697,8 +38653,8 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryClosedStop smoke-
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -37706,7 +38662,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryClosedStop smoke-
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -37714,14 +38670,14 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryClosedStop smoke-
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -37746,9 +38702,9 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryClosedStop smoke-
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -37781,14 +38737,19 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryClosedStop smoke-
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jlyFEH">
-                        Galleria/SW 10th Ave MAX Station (Closed)
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 ivKDyt">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                          (Closed)
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -38164,7 +39125,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryClosedStop smoke-
 `;
 
 exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -38501,7 +39462,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -38518,7 +39479,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
             </a>
           </div>
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -38527,7 +39488,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -38560,9 +39521,9 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -38570,7 +39531,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -38578,14 +39539,14 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -38607,8 +39568,8 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -38616,7 +39577,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -38624,14 +39585,14 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -38653,8 +39614,8 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -38662,7 +39623,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -38670,14 +39631,14 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -38702,9 +39663,9 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -38737,14 +39698,18 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -39120,7 +40085,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
 `;
 
 exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -39609,7 +40574,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://www.communitytransit.org/"
                rel="noopener noreferrer"
@@ -39628,9 +40593,9 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 47 min / 6 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -39663,46 +40628,66 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Broadway &amp; 34th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Broadway &amp; 34th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        South Everett Fwy Station Bay 3
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          South Everett Fwy Station Bay 3
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Ash Way Park &amp; Ride Bay 1
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Ash Way Park &amp; Ride Bay 1
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Lynnwood Transit Center Bay D3
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Lynnwood Transit Center Bay D3
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Mountlake Terrace Fwy Station Bay 6
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Mountlake Terrace Fwy Station Bay 6
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -39927,7 +40912,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://metro.kingcounty.gov"
                rel="noopener noreferrer"
@@ -39946,9 +40931,9 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 11 min / 8 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -39981,62 +40966,90 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        1st Ave NE &amp; NE 95th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          1st Ave NE &amp; NE 95th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N 92nd St &amp; Corliss Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N 92nd St &amp; Corliss Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        College Way N &amp; N 97th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          College Way N &amp; N 97th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        College Way N &amp; N 103rd St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          College Way N &amp; N 103rd St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Meridian Ave N &amp; N 105th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Meridian Ave N &amp; N 105th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N Northgate Way &amp; Meridian Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N Northgate Way &amp; Meridian Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N Northgate Way &amp; Stone Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N Northgate Way &amp; Stone Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -40431,7 +41444,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://metro.kingcounty.gov"
                rel="noopener noreferrer"
@@ -40450,9 +41463,9 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 31 min / 17 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -40485,134 +41498,198 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 100th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 100th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 95th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 95th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 90th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 90th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 85th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 85th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 80th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 80th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 76th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 76th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 65th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 65th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 46th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 46th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Lynn St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Lynn St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Galer St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Galer St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        7th Ave N &amp; Thomas St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          7th Ave N &amp; Thomas St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Wall St &amp; 5th Ave
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Wall St &amp; 5th Ave
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Bell St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Bell St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Virginia St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Virginia St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Pike St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Pike St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Seneca St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Seneca St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -40909,7 +41986,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
 `;
 
 exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -41398,7 +42475,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://www.communitytransit.org/"
                rel="noopener noreferrer"
@@ -41417,9 +42494,9 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 47 min / 6 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -41452,46 +42529,66 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Broadway &amp; 34th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Broadway &amp; 34th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        South Everett Fwy Station Bay 3
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          South Everett Fwy Station Bay 3
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Ash Way Park &amp; Ride Bay 1
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Ash Way Park &amp; Ride Bay 1
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Lynnwood Transit Center Bay D3
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Lynnwood Transit Center Bay D3
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Mountlake Terrace Fwy Station Bay 6
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Mountlake Terrace Fwy Station Bay 6
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -41716,7 +42813,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://metro.kingcounty.gov"
                rel="noopener noreferrer"
@@ -41735,9 +42832,9 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 11 min / 8 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -41770,62 +42867,90 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        1st Ave NE &amp; NE 95th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          1st Ave NE &amp; NE 95th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N 92nd St &amp; Corliss Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N 92nd St &amp; Corliss Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        College Way N &amp; N 97th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          College Way N &amp; N 97th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        College Way N &amp; N 103rd St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          College Way N &amp; N 103rd St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Meridian Ave N &amp; N 105th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Meridian Ave N &amp; N 105th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N Northgate Way &amp; Meridian Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N Northgate Way &amp; Meridian Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N Northgate Way &amp; Stone Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N Northgate Way &amp; Stone Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -42220,7 +43345,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://metro.kingcounty.gov"
                rel="noopener noreferrer"
@@ -42239,9 +43364,9 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 31 min / 17 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -42274,134 +43399,198 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 100th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 100th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 95th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 95th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 90th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 90th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 85th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 85th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 80th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 80th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 76th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 76th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 65th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 65th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 46th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 46th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Lynn St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Lynn St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Galer St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Galer St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        7th Ave N &amp; Thomas St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          7th Ave N &amp; Thomas St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Wall St &amp; 5th Ave
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Wall St &amp; 5th Ave
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Bell St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Bell St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Virginia St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Virginia St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Pike St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Pike St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Seneca St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Seneca St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -42698,7 +43887,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
 `;
 
 exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
-<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 dbxmtN">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
     <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
       <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
@@ -43187,7 +44376,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://www.communitytransit.org/"
                rel="noopener noreferrer"
@@ -43206,9 +44395,9 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 47 min / 6 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -43241,46 +44430,66 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Broadway &amp; 34th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Broadway &amp; 34th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        South Everett Fwy Station Bay 3
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          South Everett Fwy Station Bay 3
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Ash Way Park &amp; Ride Bay 1
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Ash Way Park &amp; Ride Bay 1
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Lynnwood Transit Center Bay D3
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Lynnwood Transit Center Bay D3
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Mountlake Terrace Fwy Station Bay 6
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Mountlake Terrace Fwy Station Bay 6
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -43505,7 +44714,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://metro.kingcounty.gov"
                rel="noopener noreferrer"
@@ -43524,9 +44733,9 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 11 min / 8 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -43559,62 +44768,90 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        1st Ave NE &amp; NE 95th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          1st Ave NE &amp; NE 95th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N 92nd St &amp; Corliss Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N 92nd St &amp; Corliss Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        College Way N &amp; N 97th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          College Way N &amp; N 97th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        College Way N &amp; N 103rd St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          College Way N &amp; N 103rd St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Meridian Ave N &amp; N 105th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Meridian Ave N &amp; N 105th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N Northgate Way &amp; Meridian Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N Northgate Way &amp; Meridian Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N Northgate Way &amp; Stone Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N Northgate Way &amp; Stone Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -44009,7 +45246,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://metro.kingcounty.gov"
                rel="noopener noreferrer"
@@ -44028,9 +45265,9 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 31 min / 17 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -44063,134 +45300,198 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 100th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 100th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 95th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 95th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 90th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 90th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 85th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 85th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 80th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 80th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 76th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 76th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 65th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 65th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 46th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 46th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Lynn St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Lynn St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Galer St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Galer St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        7th Ave N &amp; Thomas St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          7th Ave N &amp; Thomas St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Wall St &amp; 5th Ave
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Wall St &amp; 5th Ave
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Bell St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Bell St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Virginia St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Virginia St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Pike St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Pike St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Seneca St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Seneca St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>

--- a/packages/itinerary-body/src/stories/__snapshots__/OtpRrItineraryBody.story.tsx.snap
+++ b/packages/itinerary-body/src/stories/__snapshots__/OtpRrItineraryBody.story.tsx.snap
@@ -37207,6 +37207,964 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
 </ol>
 `;
 
+exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryClosedStop smoke-test 1`] = `
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
+  <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
+    <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
+      <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
+      </div>
+      <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
+        <svg viewbox="0 0 512 512"
+             height="14"
+             width="14"
+             aria-hidden="true"
+             focusable="false"
+             fill="currentColor"
+             xmlns="http://www.w3.org/2000/svg"
+             color="white"
+             class="StyledIconBase-sc-ea9ulj-0 ebjPRL line-column-content__StackedCircle-sc-1wcbb7o-2 line-column-content__StackedCircleInner-sc-1wcbb7o-3 iTIsMm hPKTER"
+        >
+          <path fill="currentColor"
+                d="M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0 0 114.6 0 256s114.6 256 256 256z"
+          >
+          </path>
+        </svg>
+        <svg viewbox="0 0 512 512"
+             height="20"
+             width="20"
+             aria-hidden="true"
+             focusable="false"
+             fill="currentColor"
+             xmlns="http://www.w3.org/2000/svg"
+             class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__FromIcon-sc-n5xcvc-0 dDqEuj line-column-content__StyledLocationIcon-sc-1wcbb7o-4 jnioyI"
+        >
+          <path fill="currentColor"
+                d="M160 256c0-53.9 42.1-96 96-96 53 0 96 42.1 96 96 0 53-43 96-96 96-53.9 0-96-43-96-96zm352 0c0 141.4-114.6 256-256 256S0 397.4 0 256 114.6 0 256 0s256 114.6 256 256zM256 48C141.1 48 48 141.1 48 256s93.1 208 208 208 208-93.1 208-208S370.9 48 256 48z"
+          >
+          </path>
+        </svg>
+      </span>
+    </div>
+    <div class="styled__PlaceHeader-sc-1q8npbl-54 hMGsin">
+      <span aria-hidden="true"
+            class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
+      >
+        KGW Studio on the Sq, Portland, OR, USA
+      </span>
+    </div>
+    <div class="styled__TimeColumn-sc-1q8npbl-49 kSAQNU">
+      3:44 PM
+    </div>
+    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+      from KGW Studio on the Sq, Portland, OR, USA
+    </span>
+    <div class="styled__PlaceDetails-sc-1q8npbl-53 cHqDbl place-details ">
+      <div class="styled__LegBody-sc-1q8npbl-30 JONmo">
+        <div class="styled__LegClickable-sc-1q8npbl-31 dtGQxb">
+          <span class="styled__LegDescription-sc-1q8npbl-33 hYfuZi">
+            <span class="styled__LegIconAndRouteShortName-sc-1q8npbl-42 iUQXKp">
+              <span class="styled__LegIconContainer-sc-1q8npbl-41 spMya">
+                <svg xmlns="http://www.w3.org/2000/svg"
+                     version="1.0"
+                     x="0px"
+                     y="0px"
+                     viewbox="0 0 55.74 100"
+                     height="100%"
+                     width="100%"
+                     leg="[object Object]"
+                >
+                  <path d="M31.269,13.769c3.862,0,6.884-3.025,6.884-6.885C38.153,3.022,35.131,0,31.269,0c-3.86,0-6.885,3.022-6.885,6.884  C24.384,10.744,27.409,13.769,31.269,13.769z">
+                  </path>
+                  <path d="M1.249,51.724l4.512-0.421L5.863,35.25l8.224-5.204c0,0-1.333,10.545-1.333,16.085c0,4.831-0.172,8.736-0.172,8.736  L2.054,96.918L9.489,100L21.28,61.549l8.195,10.424l9.339,26.337l8.394-3.355l-9.425-27.965L27.446,50.665l2.901-21.399l6.46,13.544  l16.622,5.708l2.311-4.199l-15.234-8.887c0,0-3.691-9.819-6.711-15.962c-1.027-2.091-5.196-2.774-6.894-2.901  c-4.896-0.362-7.428,1.296-11.488,3.432C11.358,22.131,0,30.728,0,30.728L1.249,51.724z">
+                  </path>
+                </svg>
+              </span>
+            </span>
+            <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+              -
+            </span>
+            <span class="styled__AccessLegDescriptionHeading-sc-1q8npbl-29 gNdrYT walk-leg">
+              Walk 269 feet to
+              <span class="styled__LegDescriptionPlace-sc-1q8npbl-37 idePhS">
+                Pioneer Square North MAX Station
+              </span>
+            </span>
+            <button class="styled__TransparentButton-sc-1q8npbl-1 styled__LegClickableButton-sc-1q8npbl-32 jOzsRd LYxWc">
+              <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                Zoom to leg on map
+              </span>
+            </button>
+          </span>
+        </div>
+        <span class="styled__LegDetails-sc-1q8npbl-46 breQFf">
+          <span class="styled__StepsHeaderAndMapLink-sc-1q8npbl-67 byVRQm">
+            <button aria-expanded="false"
+                    class="styled__TransparentButton-sc-1q8npbl-1 styled__StepsHeaderButton-sc-1q8npbl-68 jOzsRd flixGN"
+            >
+              1 min
+              <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
+                <svg viewbox="0 0 320 512"
+                     height="15"
+                     width="15"
+                     aria-hidden="true"
+                     focusable="false"
+                     fill="currentColor"
+                     xmlns="http://www.w3.org/2000/svg"
+                     class="StyledIconBase-sc-ea9ulj-0 ebjPRL"
+                >
+                  <path fill="currentColor"
+                        d="M137.4 374.6c12.5 12.5 32.8 12.5 45.3 0l128-128c9.2-9.2 11.9-22.9 6.9-34.9S301 191.9 288 191.9L32 192c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9l128 128z"
+                  >
+                  </path>
+                </svg>
+              </span>
+              <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                (Expand details)
+              </span>
+            </button>
+            <a aria-label="Show street imagery at this location"
+               role="link"
+               title="Show street imagery at this location"
+               class="mapillary-button__Container-sc-l7gdsc-0 fUOQNZ"
+            >
+              <svg viewbox="0 0 512 512"
+                   aria-hidden="true"
+                   focusable="false"
+                   fill="currentColor"
+                   xmlns="http://www.w3.org/2000/svg"
+                   class="StyledIconBase-sc-ea9ulj-0 ebjPRL mapillary-button__Icon-sc-l7gdsc-1 dQCpQk"
+                   style="padding-bottom: 1px;"
+              >
+                <path fill="currentColor"
+                      d="M320 64c0-35.3-28.7-64-64-64s-64 28.7-64 64 28.7 64 64 64 64-28.7 64-64zm-96 96c-35.3 0-64 28.7-64 64v48c0 17.7 14.3 32 32 32h1.8l11.1 99.5c1.8 16.2 15.5 28.5 31.8 28.5h38.7c16.3 0 30-12.3 31.8-28.5l11-99.5h1.8c17.7 0 32-14.3 32-32v-48c0-35.3-28.7-64-64-64h-64zm-91.7 234.2c13-2.4 21.7-14.9 19.3-27.9s-14.9-21.7-27.9-19.3c-32.4 5.9-60.9 14.2-82 24.8-10.5 5.3-20.3 11.7-27.8 19.6C6.4 399.5 0 410.5 0 424c0 21.4 15.5 36.1 29.1 45 14.7 9.6 34.3 17.3 56.4 23.4C130.2 504.7 190.4 512 256 512s125.8-7.3 170.4-19.6c22.1-6.1 41.8-13.8 56.4-23.4 13.7-8.9 29.1-23.6 29.1-45 0-13.5-6.4-24.5-14-32.6-7.5-7.9-17.3-14.3-27.8-19.6-21-10.6-49.5-18.9-82-24.8-13-2.4-25.5 6.3-27.9 19.3s6.3 25.5 19.3 27.9c30.2 5.5 53.7 12.8 69 20.5 3.2 1.6 5.8 3.1 7.9 4.5 3.6 2.4 3.6 7.2 0 9.6-8.8 5.7-23.1 11.8-43 17.3C374.3 457 318.5 464 256 464s-118.3-7-157.7-17.9c-19.9-5.5-34.2-11.6-43-17.3-3.6-2.4-3.6-7.2 0-9.6 2.1-1.4 4.8-2.9 7.9-4.5 15.3-7.7 38.8-14.9 69-20.5z"
+                >
+                </path>
+              </svg>
+            </a>
+          </span>
+          <div aria-hidden="true"
+               class="rah-static rah-static--height-zero "
+               style="grid-column: 1 / span 2; height: 0px; overflow: hidden;"
+          >
+            <div style="display: none;">
+              <ol class="styled__Steps-sc-1q8npbl-65 bEBTRA">
+                <li class="styled__StepRow-sc-1q8npbl-71 kVZYtk">
+                  <div class="styled__StepIconContainer-sc-1q8npbl-70 fosTFg">
+                    <svg viewbox="0 0 261 261">
+                      <path d="M100.5 110.5v150h60v-150h40l-70-110-70 110h40z">
+                      </path>
+                    </svg>
+                  </div>
+                  <div class="styled__StepDescriptionContainer-sc-1q8npbl-66 tiDJD">
+                    <span>
+                      Head northwest on
+                      <span class="styled__StepStreetName-sc-1q8npbl-72 iJrUDA">
+                        Unnamed Path
+                      </span>
+                      <span class="styled__StepLength-sc-1q8npbl-73 cCaIgd">
+                        167 feet
+                      </span>
+                    </span>
+                    <a aria-label="Show street imagery at this location"
+                       role="link"
+                       title="Show street imagery at this location"
+                       class="mapillary-button__Container-sc-l7gdsc-0 fUOQNZ"
+                    >
+                      <svg viewbox="0 0 512 512"
+                           aria-hidden="true"
+                           focusable="false"
+                           fill="currentColor"
+                           xmlns="http://www.w3.org/2000/svg"
+                           class="StyledIconBase-sc-ea9ulj-0 ebjPRL mapillary-button__Icon-sc-l7gdsc-1 dQCpQk"
+                           style="padding-bottom: 1px;"
+                      >
+                        <path fill="currentColor"
+                              d="M320 64c0-35.3-28.7-64-64-64s-64 28.7-64 64 28.7 64 64 64 64-28.7 64-64zm-96 96c-35.3 0-64 28.7-64 64v48c0 17.7 14.3 32 32 32h1.8l11.1 99.5c1.8 16.2 15.5 28.5 31.8 28.5h38.7c16.3 0 30-12.3 31.8-28.5l11-99.5h1.8c17.7 0 32-14.3 32-32v-48c0-35.3-28.7-64-64-64h-64zm-91.7 234.2c13-2.4 21.7-14.9 19.3-27.9s-14.9-21.7-27.9-19.3c-32.4 5.9-60.9 14.2-82 24.8-10.5 5.3-20.3 11.7-27.8 19.6C6.4 399.5 0 410.5 0 424c0 21.4 15.5 36.1 29.1 45 14.7 9.6 34.3 17.3 56.4 23.4C130.2 504.7 190.4 512 256 512s125.8-7.3 170.4-19.6c22.1-6.1 41.8-13.8 56.4-23.4 13.7-8.9 29.1-23.6 29.1-45 0-13.5-6.4-24.5-14-32.6-7.5-7.9-17.3-14.3-27.8-19.6-21-10.6-49.5-18.9-82-24.8-13-2.4-25.5 6.3-27.9 19.3s6.3 25.5 19.3 27.9c30.2 5.5 53.7 12.8 69 20.5 3.2 1.6 5.8 3.1 7.9 4.5 3.6 2.4 3.6 7.2 0 9.6-8.8 5.7-23.1 11.8-43 17.3C374.3 457 318.5 464 256 464s-118.3-7-157.7-17.9c-19.9-5.5-34.2-11.6-43-17.3-3.6-2.4-3.6-7.2 0-9.6 2.1-1.4 4.8-2.9 7.9-4.5 15.3-7.7 38.8-14.9 69-20.5z"
+                        >
+                        </path>
+                      </svg>
+                    </a>
+                  </div>
+                </li>
+                <li class="styled__StepRow-sc-1q8npbl-71 kVZYtk">
+                  <div class="styled__StepIconContainer-sc-1q8npbl-70 fosTFg">
+                    <svg viewbox="0 0 261 261">
+                      <path d="M114.5 100.5h60v160h60v-170c0-30-20-50-50-50h-70V.5l-100 69.14 100 70.86v-40z">
+                      </path>
+                    </svg>
+                  </div>
+                  <div class="styled__StepDescriptionContainer-sc-1q8npbl-66 tiDJD">
+                    <span>
+                      Left on
+                      <span class="styled__StepStreetName-sc-1q8npbl-72 iJrUDA">
+                        Pioneer Sq N (path)
+                      </span>
+                      <span class="styled__StepLength-sc-1q8npbl-73 cCaIgd">
+                        101 feet
+                      </span>
+                    </span>
+                    <a aria-label="Show street imagery at this location"
+                       role="link"
+                       title="Show street imagery at this location"
+                       class="mapillary-button__Container-sc-l7gdsc-0 fUOQNZ"
+                    >
+                      <svg viewbox="0 0 512 512"
+                           aria-hidden="true"
+                           focusable="false"
+                           fill="currentColor"
+                           xmlns="http://www.w3.org/2000/svg"
+                           class="StyledIconBase-sc-ea9ulj-0 ebjPRL mapillary-button__Icon-sc-l7gdsc-1 dQCpQk"
+                           style="padding-bottom: 1px;"
+                      >
+                        <path fill="currentColor"
+                              d="M320 64c0-35.3-28.7-64-64-64s-64 28.7-64 64 28.7 64 64 64 64-28.7 64-64zm-96 96c-35.3 0-64 28.7-64 64v48c0 17.7 14.3 32 32 32h1.8l11.1 99.5c1.8 16.2 15.5 28.5 31.8 28.5h38.7c16.3 0 30-12.3 31.8-28.5l11-99.5h1.8c17.7 0 32-14.3 32-32v-48c0-35.3-28.7-64-64-64h-64zm-91.7 234.2c13-2.4 21.7-14.9 19.3-27.9s-14.9-21.7-27.9-19.3c-32.4 5.9-60.9 14.2-82 24.8-10.5 5.3-20.3 11.7-27.8 19.6C6.4 399.5 0 410.5 0 424c0 21.4 15.5 36.1 29.1 45 14.7 9.6 34.3 17.3 56.4 23.4C130.2 504.7 190.4 512 256 512s125.8-7.3 170.4-19.6c22.1-6.1 41.8-13.8 56.4-23.4 13.7-8.9 29.1-23.6 29.1-45 0-13.5-6.4-24.5-14-32.6-7.5-7.9-17.3-14.3-27.8-19.6-21-10.6-49.5-18.9-82-24.8-13-2.4-25.5 6.3-27.9 19.3s6.3 25.5 19.3 27.9c30.2 5.5 53.7 12.8 69 20.5 3.2 1.6 5.8 3.1 7.9 4.5 3.6 2.4 3.6 7.2 0 9.6-8.8 5.7-23.1 11.8-43 17.3C374.3 457 318.5 464 256 464s-118.3-7-157.7-17.9c-19.9-5.5-34.2-11.6-43-17.3-3.6-2.4-3.6-7.2 0-9.6 2.1-1.4 4.8-2.9 7.9-4.5 15.3-7.7 38.8-14.9 69-20.5z"
+                        >
+                        </path>
+                      </svg>
+                    </a>
+                  </div>
+                </li>
+              </ol>
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+  </li>
+  <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper transit  ">
+    <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
+      <div class="line-column-content__LegLine-sc-1wcbb7o-1 jA-dKKm leg-line">
+      </div>
+      <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
+        <svg viewbox="0 0 512 512"
+             height="20"
+             width="20"
+             aria-hidden="true"
+             focusable="false"
+             fill="currentColor"
+             xmlns="http://www.w3.org/2000/svg"
+             color="black"
+             class="StyledIconBase-sc-ea9ulj-0 ebjPRL line-column-content__StackedCircle-sc-1wcbb7o-2 iTIsMm"
+        >
+          <path fill="currentColor"
+                d="M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0 0 114.6 0 256s114.6 256 256 256z"
+          >
+          </path>
+        </svg>
+        <svg viewbox="0 0 512 512"
+             height="14"
+             width="14"
+             aria-hidden="true"
+             focusable="false"
+             fill="currentColor"
+             xmlns="http://www.w3.org/2000/svg"
+             color="white"
+             class="StyledIconBase-sc-ea9ulj-0 ebjPRL line-column-content__StackedCircle-sc-1wcbb7o-2 line-column-content__StackedCircleInner-sc-1wcbb7o-3 iTIsMm hPKTER"
+        >
+          <path fill="currentColor"
+                d="M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0 0 114.6 0 256s114.6 256 256 256z"
+          >
+          </path>
+        </svg>
+      </span>
+    </div>
+    <div class="styled__PlaceHeader-sc-1q8npbl-54 hMGsin">
+      <span aria-hidden="true"
+            class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
+      >
+        Pioneer Square North MAX Station
+      </span>
+    </div>
+    <div class="styled__TimeColumn-sc-1q8npbl-49 kSAQNU">
+      3:46 PM
+    </div>
+    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+      from Pioneer Square North MAX Station
+    </span>
+    <div class="styled__PlaceDetails-sc-1q8npbl-53 cHqDbl place-details transit">
+      <div class="styled__PlaceSubheader-sc-1q8npbl-56 yYVTt transit-leg-subheader">
+        Stop ID 8383
+        <button role="link"
+                class="styled__TransparentButton-sc-1q8npbl-1 styled__LinkButton-sc-1q8npbl-3 styled__ViewerButton-sc-1q8npbl-5 jOzsRd eTOvCo jYHBEM"
+        >
+          Stop Viewer
+        </button>
+      </div>
+      <div class="styled__LegBody-sc-1q8npbl-30 JONmo">
+        <div class="styled__LegClickable-sc-1q8npbl-31 dtGQxb">
+          <span class="styled__LegDescription-sc-1q8npbl-33 hYfuZi">
+            <span>
+              <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                - Ride
+              </span>
+              <span class="styled__LegDescription-sc-1q8npbl-33 styled__LegDescriptionForTransit-sc-1q8npbl-40 hYfuZi dMulzk">
+                <span class="styled__LegIconAndRouteShortName-sc-1q8npbl-42 iUQXKp">
+                  <span class="styled__LegIconContainer-sc-1q8npbl-41 spMya">
+                    <svg xmlns="http://www.w3.org/2000/svg"
+                         version="1.0"
+                         viewbox="0 0 66.461 100"
+                         height="100%"
+                         width="100%"
+                         leg="[object Object]"
+                         aria-label="TRAM"
+                    >
+                      <path d="M28.549,7.023c-1.933-0.007-3.508-1.582-3.512-3.511C25.041,1.555,26.616-0.021,28.549,0  c1.952-0.021,3.526,1.555,3.511,3.512C32.075,5.441,30.5,7.016,28.549,7.023L28.549,7.023z">
+                      </path>
+                      <path d="M37.913,7.023c1.936-0.007,3.512-1.582,3.512-3.511c0-1.957-1.576-3.532-3.512-3.512c-1.95-0.021-3.525,1.555-3.512,3.512  C34.388,5.441,35.963,7.016,37.913,7.023L37.913,7.023z">
+                      </path>
+                      <path d="M51.856,78.064c4.872-0.809,9.73-5.898,9.719-12.109V20.611C61.587,14.218,56.2,8.34,48.903,8.347H33.281H17.606  C10.265,8.34,4.878,14.218,4.885,20.611v45.344c-0.007,6.211,4.852,11.301,9.719,12.109L0,100h8.446l10.432-15.37H33.23h14.351  L58.063,100h8.397L51.856,78.064z M24.986,13.031c0.002-1.136,0.969-2.072,2.085-2.088h6.158h6.159  c1.117,0.016,2.088,0.952,2.088,2.088v3.559c0,1.133-0.916,2.092-2.088,2.088H33.23h-6.158c-1.167,0.004-2.083-0.955-2.085-2.088  V13.031z M17.301,71.45c-3.059-0.023-5.553-2.517-5.546-5.598c-0.007-3.071,2.487-5.562,5.546-5.547  c3.09-0.016,5.584,2.476,5.598,5.547C22.886,68.934,20.391,71.427,17.301,71.45z M18.014,41.986  c-3.508-0.021-6.369-2.421-6.362-6.363v-8.141c0.025-3.396,2.219-6.356,6.362-6.363H33.23h15.215  c4.148,0.007,6.343,2.967,6.363,6.363v8.141c0.011,3.942-2.85,6.343-6.363,6.363H33.23H18.014z M43.46,65.853  c-0.009-3.071,2.482-5.562,5.545-5.547c3.09-0.016,5.584,2.476,5.6,5.547c-0.016,3.081-2.51,5.574-5.6,5.598  C45.942,71.427,43.451,68.934,43.46,65.853z">
+                      </path>
+                    </svg>
+                  </span>
+                  <span class="styled__LegDescriptionRouteShortName-sc-1q8npbl-39 dtVjki">
+                    MAX Blue Line
+                  </span>
+                </span>
+                <span class="styled__LegDescriptionRouteLongName-sc-1q8npbl-38 ctSday">
+                  <span>
+                    MAX Blue Line
+                    <span class="styled__LegDescriptionHeadsignPrefix-sc-1q8npbl-35 eGbGrz">
+                      to
+                    </span>
+                    Hillsboro
+                  </span>
+                </span>
+              </span>
+              <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                - Disembark at Providence Park MAX Station
+              </span>
+            </span>
+            <button class="styled__TransparentButton-sc-1q8npbl-1 styled__LegClickableButton-sc-1q8npbl-32 jOzsRd LYxWc transit-leg-button">
+              <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                Zoom to leg on map
+              </span>
+            </button>
+          </span>
+        </div>
+        <div class="transit-leg-details-wrapper"
+             aria-label="Leg details"
+             role="group"
+        >
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+            Service operated by
+            <a href="http://trimet.org/"
+               rel="noopener noreferrer"
+               target="_blank"
+            >
+              TriMet
+              <img alt
+                   src="http://news.trimet.org/wordpress/wp-content/uploads/2019/04/TriMet-logo-300x300.png"
+                   height="25"
+              >
+              <span class="styled__SROnly-sc-1q8npbl-63 haVgW">
+                (External Link)
+              </span>
+            </a>
+          </div>
+          <button aria-expanded="false"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+          >
+            <svg viewbox="0 0 512 512"
+                 height="15"
+                 width="15"
+                 aria-hidden="true"
+                 focusable="false"
+                 fill="currentColor"
+                 xmlns="http://www.w3.org/2000/svg"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+            >
+              <path fill="currentColor"
+                    d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
+              >
+              </path>
+            </svg>
+            3 alerts
+            <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
+              <svg viewbox="0 0 320 512"
+                   height="15"
+                   width="15"
+                   aria-hidden="true"
+                   focusable="false"
+                   fill="currentColor"
+                   xmlns="http://www.w3.org/2000/svg"
+                   class="StyledIconBase-sc-ea9ulj-0 ebjPRL"
+              >
+                <path fill="currentColor"
+                      d="M137.4 374.6c12.5 12.5 32.8 12.5 45.3 0l128-128c9.2-9.2 11.9-22.9 6.9-34.9S301 191.9 288 191.9L32 192c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9l128 128z"
+                >
+                </path>
+              </svg>
+            </span>
+            <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+              (Expand details)
+            </span>
+          </button>
+          <div aria-hidden="true"
+               class="rah-static rah-static--height-zero "
+               style="height: 0px; overflow: hidden;"
+          >
+            <div style="display: none;">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                    <svg viewbox="0 0 512 512"
+                         height="18"
+                         width="18"
+                         aria-hidden="true"
+                         focusable="false"
+                         fill="currentColor"
+                         xmlns="http://www.w3.org/2000/svg"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                    >
+                      <path fill="currentColor"
+                            d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
+                      >
+                      </path>
+                    </svg>
+                  </div>
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                    TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
+                  </div>
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                    Effective as of December 15, 2019
+                    <a href="http://trimet.org/alerts/"
+                       target="_blank"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                    >
+                      <svg viewbox="0 0 512 512"
+                           height="10"
+                           aria-hidden="true"
+                           focusable="false"
+                           fill="currentColor"
+                           xmlns="http://www.w3.org/2000/svg"
+                           class="StyledIconBase-sc-ea9ulj-0 ebjPRL"
+                      >
+                        <path fill="currentColor"
+                              d="M352 0c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9L370.7 96 201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L416 141.3l41.4 41.4c9.2 9.2 22.9 11.9 34.9 6.9s19.8-16.6 19.8-29.6V32c0-17.7-14.3-32-32-32H352zM80 32C35.8 32 0 67.8 0 112v320c0 44.2 35.8 80 80 80h320c44.2 0 80-35.8 80-80V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v112c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16h112c17.7 0 32-14.3 32-32s-14.3-32-32-32H80z"
+                        >
+                        </path>
+                      </svg>
+                      See alert on TriMet website
+                      <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                        (Opens new window)
+                      </span>
+                    </a>
+                  </div>
+                </li>
+                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                    <svg viewbox="0 0 512 512"
+                         height="18"
+                         width="18"
+                         aria-hidden="true"
+                         focusable="false"
+                         fill="currentColor"
+                         xmlns="http://www.w3.org/2000/svg"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                    >
+                      <path fill="currentColor"
+                            d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
+                      >
+                      </path>
+                    </svg>
+                  </div>
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                    The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
+                  </div>
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                    Effective as of November 6, 2019
+                    <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
+                       target="_blank"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                    >
+                      <svg viewbox="0 0 512 512"
+                           height="10"
+                           aria-hidden="true"
+                           focusable="false"
+                           fill="currentColor"
+                           xmlns="http://www.w3.org/2000/svg"
+                           class="StyledIconBase-sc-ea9ulj-0 ebjPRL"
+                      >
+                        <path fill="currentColor"
+                              d="M352 0c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9L370.7 96 201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L416 141.3l41.4 41.4c9.2 9.2 22.9 11.9 34.9 6.9s19.8-16.6 19.8-29.6V32c0-17.7-14.3-32-32-32H352zM80 32C35.8 32 0 67.8 0 112v320c0 44.2 35.8 80 80 80h320c44.2 0 80-35.8 80-80V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v112c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16h112c17.7 0 32-14.3 32-32s-14.3-32-32-32H80z"
+                        >
+                        </path>
+                      </svg>
+                      See alert on TriMet website
+                      <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                        (Opens new window)
+                      </span>
+                    </a>
+                  </div>
+                </li>
+                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                    <svg viewbox="0 0 512 512"
+                         height="18"
+                         width="18"
+                         aria-hidden="true"
+                         focusable="false"
+                         fill="currentColor"
+                         xmlns="http://www.w3.org/2000/svg"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                    >
+                      <path fill="currentColor"
+                            d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
+                      >
+                      </path>
+                    </svg>
+                  </div>
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                    The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
+                  </div>
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                    Effective as of November 3, 2019
+                    <a href="http://trimet.org/alerts/"
+                       target="_blank"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                    >
+                      <svg viewbox="0 0 512 512"
+                           height="10"
+                           aria-hidden="true"
+                           focusable="false"
+                           fill="currentColor"
+                           xmlns="http://www.w3.org/2000/svg"
+                           class="StyledIconBase-sc-ea9ulj-0 ebjPRL"
+                      >
+                        <path fill="currentColor"
+                              d="M352 0c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9L370.7 96 201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L416 141.3l41.4 41.4c9.2 9.2 22.9 11.9 34.9 6.9s19.8-16.6 19.8-29.6V32c0-17.7-14.3-32-32-32H352zM80 32C35.8 32 0 67.8 0 112v320c0 44.2 35.8 80 80 80h320c44.2 0 80-35.8 80-80V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v112c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16h112c17.7 0 32-14.3 32-32s-14.3-32-32-32H80z"
+                        >
+                        </path>
+                      </svg>
+                      See alert on TriMet website
+                      <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                        (Opens new window)
+                      </span>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+                Ride 3 min / 2 stops
+                <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
+                  <svg viewbox="0 0 320 512"
+                       height="15"
+                       width="15"
+                       aria-hidden="true"
+                       focusable="false"
+                       fill="currentColor"
+                       xmlns="http://www.w3.org/2000/svg"
+                       class="StyledIconBase-sc-ea9ulj-0 ebjPRL"
+                  >
+                    <path fill="currentColor"
+                          d="M137.4 374.6c12.5 12.5 32.8 12.5 45.3 0l128-128c9.2-9.2 11.9-22.9 6.9-34.9S301 191.9 288 191.9L32 192c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9l128 128z"
+                    >
+                    </path>
+                  </svg>
+                </span>
+                <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                  (Expand details)
+                </span>
+              </button>
+              <button role="link"
+                      class="styled__TransparentButton-sc-1q8npbl-1 styled__LinkButton-sc-1q8npbl-3 styled__ViewerButton-sc-1q8npbl-5 jOzsRd eTOvCo jYHBEM"
+              >
+                Trip Viewer
+              </button>
+            </div>
+            <div aria-hidden="true"
+                 class="rah-static rah-static--height-zero "
+                 style="height: 0px; overflow: hidden;"
+            >
+              <div style="display: none;">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                  <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
+                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
+                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                        •
+                      </div>
+                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk"
+                           style="color: rgb(191, 62, 58);"
+                      >
+                        Galleria/SW 10th Ave MAX Station (Closed)
+                      </div>
+                    </li>
+                  </ol>
+                </div>
+              </div>
+            </div>
+            <span>
+              Typical wait: 15 min
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </li>
+  <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
+    <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
+      <div class="line-column-content__LegLine-sc-1wcbb7o-1 kLHuao leg-line">
+      </div>
+      <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
+        <svg viewbox="0 0 512 512"
+             height="20"
+             width="20"
+             aria-hidden="true"
+             focusable="false"
+             fill="currentColor"
+             xmlns="http://www.w3.org/2000/svg"
+             color="black"
+             class="StyledIconBase-sc-ea9ulj-0 ebjPRL line-column-content__StackedCircle-sc-1wcbb7o-2 iTIsMm"
+        >
+          <path fill="currentColor"
+                d="M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0 0 114.6 0 256s114.6 256 256 256z"
+          >
+          </path>
+        </svg>
+        <svg viewbox="0 0 512 512"
+             height="14"
+             width="14"
+             aria-hidden="true"
+             focusable="false"
+             fill="currentColor"
+             xmlns="http://www.w3.org/2000/svg"
+             color="white"
+             class="StyledIconBase-sc-ea9ulj-0 ebjPRL line-column-content__StackedCircle-sc-1wcbb7o-2 line-column-content__StackedCircleInner-sc-1wcbb7o-3 iTIsMm hPKTER"
+        >
+          <path fill="currentColor"
+                d="M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0 0 114.6 0 256s114.6 256 256 256z"
+          >
+          </path>
+        </svg>
+      </span>
+    </div>
+    <div class="styled__PlaceHeader-sc-1q8npbl-54 hMGsin">
+      <span aria-hidden="true"
+            class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
+      >
+        Providence Park MAX Station
+      </span>
+    </div>
+    <div class="styled__TimeColumn-sc-1q8npbl-49 kSAQNU">
+      3:49 PM
+    </div>
+    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+      from Providence Park MAX Station
+    </span>
+    <div class="styled__PlaceDetails-sc-1q8npbl-53 cHqDbl place-details ">
+      <div class="styled__PlaceSubheader-sc-1q8npbl-56 yYVTt transit-leg-subheader">
+        Stop ID 9757
+        <button role="link"
+                class="styled__TransparentButton-sc-1q8npbl-1 styled__LinkButton-sc-1q8npbl-3 styled__ViewerButton-sc-1q8npbl-5 jOzsRd eTOvCo jYHBEM"
+        >
+          Stop Viewer
+        </button>
+      </div>
+      <div class="styled__LegBody-sc-1q8npbl-30 JONmo">
+        <div class="styled__LegClickable-sc-1q8npbl-31 dtGQxb">
+          <span class="styled__LegDescription-sc-1q8npbl-33 hYfuZi">
+            <span class="styled__LegIconAndRouteShortName-sc-1q8npbl-42 iUQXKp">
+              <span class="styled__LegIconContainer-sc-1q8npbl-41 spMya">
+                <svg xmlns="http://www.w3.org/2000/svg"
+                     version="1.0"
+                     x="0px"
+                     y="0px"
+                     viewbox="0 0 55.74 100"
+                     height="100%"
+                     width="100%"
+                     leg="[object Object]"
+                >
+                  <path d="M31.269,13.769c3.862,0,6.884-3.025,6.884-6.885C38.153,3.022,35.131,0,31.269,0c-3.86,0-6.885,3.022-6.885,6.884  C24.384,10.744,27.409,13.769,31.269,13.769z">
+                  </path>
+                  <path d="M1.249,51.724l4.512-0.421L5.863,35.25l8.224-5.204c0,0-1.333,10.545-1.333,16.085c0,4.831-0.172,8.736-0.172,8.736  L2.054,96.918L9.489,100L21.28,61.549l8.195,10.424l9.339,26.337l8.394-3.355l-9.425-27.965L27.446,50.665l2.901-21.399l6.46,13.544  l16.622,5.708l2.311-4.199l-15.234-8.887c0,0-3.691-9.819-6.711-15.962c-1.027-2.091-5.196-2.774-6.894-2.901  c-4.896-0.362-7.428,1.296-11.488,3.432C11.358,22.131,0,30.728,0,30.728L1.249,51.724z">
+                  </path>
+                </svg>
+              </span>
+            </span>
+            <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+              -
+            </span>
+            <span class="styled__AccessLegDescriptionHeading-sc-1q8npbl-29 gNdrYT walk-leg">
+              Walk 249 feet to
+              <span class="styled__LegDescriptionPlace-sc-1q8npbl-37 idePhS">
+                1737 SW Morrison St, Portland, OR, USA 97205
+              </span>
+            </span>
+            <button class="styled__TransparentButton-sc-1q8npbl-1 styled__LegClickableButton-sc-1q8npbl-32 jOzsRd LYxWc">
+              <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                Zoom to leg on map
+              </span>
+            </button>
+          </span>
+        </div>
+        <span class="styled__LegDetails-sc-1q8npbl-46 breQFf">
+          <span class="styled__StepsHeaderAndMapLink-sc-1q8npbl-67 byVRQm">
+            <button aria-expanded="false"
+                    class="styled__TransparentButton-sc-1q8npbl-1 styled__StepsHeaderButton-sc-1q8npbl-68 jOzsRd flixGN"
+            >
+              1 min
+              <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
+                <svg viewbox="0 0 320 512"
+                     height="15"
+                     width="15"
+                     aria-hidden="true"
+                     focusable="false"
+                     fill="currentColor"
+                     xmlns="http://www.w3.org/2000/svg"
+                     class="StyledIconBase-sc-ea9ulj-0 ebjPRL"
+                >
+                  <path fill="currentColor"
+                        d="M137.4 374.6c12.5 12.5 32.8 12.5 45.3 0l128-128c9.2-9.2 11.9-22.9 6.9-34.9S301 191.9 288 191.9L32 192c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9l128 128z"
+                  >
+                  </path>
+                </svg>
+              </span>
+              <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                (Expand details)
+              </span>
+            </button>
+            <a aria-label="Show street imagery at this location"
+               role="link"
+               title="Show street imagery at this location"
+               class="mapillary-button__Container-sc-l7gdsc-0 fUOQNZ"
+            >
+              <svg viewbox="0 0 512 512"
+                   aria-hidden="true"
+                   focusable="false"
+                   fill="currentColor"
+                   xmlns="http://www.w3.org/2000/svg"
+                   class="StyledIconBase-sc-ea9ulj-0 ebjPRL mapillary-button__Icon-sc-l7gdsc-1 dQCpQk"
+                   style="padding-bottom: 1px;"
+              >
+                <path fill="currentColor"
+                      d="M320 64c0-35.3-28.7-64-64-64s-64 28.7-64 64 28.7 64 64 64 64-28.7 64-64zm-96 96c-35.3 0-64 28.7-64 64v48c0 17.7 14.3 32 32 32h1.8l11.1 99.5c1.8 16.2 15.5 28.5 31.8 28.5h38.7c16.3 0 30-12.3 31.8-28.5l11-99.5h1.8c17.7 0 32-14.3 32-32v-48c0-35.3-28.7-64-64-64h-64zm-91.7 234.2c13-2.4 21.7-14.9 19.3-27.9s-14.9-21.7-27.9-19.3c-32.4 5.9-60.9 14.2-82 24.8-10.5 5.3-20.3 11.7-27.8 19.6C6.4 399.5 0 410.5 0 424c0 21.4 15.5 36.1 29.1 45 14.7 9.6 34.3 17.3 56.4 23.4C130.2 504.7 190.4 512 256 512s125.8-7.3 170.4-19.6c22.1-6.1 41.8-13.8 56.4-23.4 13.7-8.9 29.1-23.6 29.1-45 0-13.5-6.4-24.5-14-32.6-7.5-7.9-17.3-14.3-27.8-19.6-21-10.6-49.5-18.9-82-24.8-13-2.4-25.5 6.3-27.9 19.3s6.3 25.5 19.3 27.9c30.2 5.5 53.7 12.8 69 20.5 3.2 1.6 5.8 3.1 7.9 4.5 3.6 2.4 3.6 7.2 0 9.6-8.8 5.7-23.1 11.8-43 17.3C374.3 457 318.5 464 256 464s-118.3-7-157.7-17.9c-19.9-5.5-34.2-11.6-43-17.3-3.6-2.4-3.6-7.2 0-9.6 2.1-1.4 4.8-2.9 7.9-4.5 15.3-7.7 38.8-14.9 69-20.5z"
+                >
+                </path>
+              </svg>
+            </a>
+          </span>
+          <div aria-hidden="true"
+               class="rah-static rah-static--height-zero "
+               style="grid-column: 1 / span 2; height: 0px; overflow: hidden;"
+          >
+            <div style="display: none;">
+              <ol class="styled__Steps-sc-1q8npbl-65 bEBTRA">
+                <li class="styled__StepRow-sc-1q8npbl-71 kVZYtk">
+                  <div class="styled__StepIconContainer-sc-1q8npbl-70 fosTFg">
+                    <svg viewbox="0 0 261 261">
+                      <path d="M100.5 110.5v150h60v-150h40l-70-110-70 110h40z">
+                      </path>
+                    </svg>
+                  </div>
+                  <div class="styled__StepDescriptionContainer-sc-1q8npbl-66 tiDJD">
+                    <span>
+                      Head west on
+                      <span class="styled__StepStreetName-sc-1q8npbl-72 iJrUDA">
+                        Providence Park (path)
+                      </span>
+                      <span class="styled__StepLength-sc-1q8npbl-73 cCaIgd">
+                        19 feet
+                      </span>
+                    </span>
+                    <a aria-label="Show street imagery at this location"
+                       role="link"
+                       title="Show street imagery at this location"
+                       class="mapillary-button__Container-sc-l7gdsc-0 fUOQNZ"
+                    >
+                      <svg viewbox="0 0 512 512"
+                           aria-hidden="true"
+                           focusable="false"
+                           fill="currentColor"
+                           xmlns="http://www.w3.org/2000/svg"
+                           class="StyledIconBase-sc-ea9ulj-0 ebjPRL mapillary-button__Icon-sc-l7gdsc-1 dQCpQk"
+                           style="padding-bottom: 1px;"
+                      >
+                        <path fill="currentColor"
+                              d="M320 64c0-35.3-28.7-64-64-64s-64 28.7-64 64 28.7 64 64 64 64-28.7 64-64zm-96 96c-35.3 0-64 28.7-64 64v48c0 17.7 14.3 32 32 32h1.8l11.1 99.5c1.8 16.2 15.5 28.5 31.8 28.5h38.7c16.3 0 30-12.3 31.8-28.5l11-99.5h1.8c17.7 0 32-14.3 32-32v-48c0-35.3-28.7-64-64-64h-64zm-91.7 234.2c13-2.4 21.7-14.9 19.3-27.9s-14.9-21.7-27.9-19.3c-32.4 5.9-60.9 14.2-82 24.8-10.5 5.3-20.3 11.7-27.8 19.6C6.4 399.5 0 410.5 0 424c0 21.4 15.5 36.1 29.1 45 14.7 9.6 34.3 17.3 56.4 23.4C130.2 504.7 190.4 512 256 512s125.8-7.3 170.4-19.6c22.1-6.1 41.8-13.8 56.4-23.4 13.7-8.9 29.1-23.6 29.1-45 0-13.5-6.4-24.5-14-32.6-7.5-7.9-17.3-14.3-27.8-19.6-21-10.6-49.5-18.9-82-24.8-13-2.4-25.5 6.3-27.9 19.3s6.3 25.5 19.3 27.9c30.2 5.5 53.7 12.8 69 20.5 3.2 1.6 5.8 3.1 7.9 4.5 3.6 2.4 3.6 7.2 0 9.6-8.8 5.7-23.1 11.8-43 17.3C374.3 457 318.5 464 256 464s-118.3-7-157.7-17.9c-19.9-5.5-34.2-11.6-43-17.3-3.6-2.4-3.6-7.2 0-9.6 2.1-1.4 4.8-2.9 7.9-4.5 15.3-7.7 38.8-14.9 69-20.5z"
+                        >
+                        </path>
+                      </svg>
+                    </a>
+                  </div>
+                </li>
+                <li class="styled__StepRow-sc-1q8npbl-71 kVZYtk">
+                  <div class="styled__StepIconContainer-sc-1q8npbl-70 fosTFg">
+                    <svg viewbox="0 0 261 261">
+                      <path d="M146.5 140.5l100-70.86L146.5.5v40h-70c-30 0-50 20-50 50v170h60v-160h60v40z">
+                      </path>
+                    </svg>
+                  </div>
+                  <div class="styled__StepDescriptionContainer-sc-1q8npbl-66 tiDJD">
+                    <span>
+                      Right on
+                      <span class="styled__StepStreetName-sc-1q8npbl-72 iJrUDA">
+                        Unnamed Path
+                      </span>
+                      <span class="styled__StepLength-sc-1q8npbl-73 cCaIgd">
+                        104 feet
+                      </span>
+                    </span>
+                    <a aria-label="Show street imagery at this location"
+                       role="link"
+                       title="Show street imagery at this location"
+                       class="mapillary-button__Container-sc-l7gdsc-0 fUOQNZ"
+                    >
+                      <svg viewbox="0 0 512 512"
+                           aria-hidden="true"
+                           focusable="false"
+                           fill="currentColor"
+                           xmlns="http://www.w3.org/2000/svg"
+                           class="StyledIconBase-sc-ea9ulj-0 ebjPRL mapillary-button__Icon-sc-l7gdsc-1 dQCpQk"
+                           style="padding-bottom: 1px;"
+                      >
+                        <path fill="currentColor"
+                              d="M320 64c0-35.3-28.7-64-64-64s-64 28.7-64 64 28.7 64 64 64 64-28.7 64-64zm-96 96c-35.3 0-64 28.7-64 64v48c0 17.7 14.3 32 32 32h1.8l11.1 99.5c1.8 16.2 15.5 28.5 31.8 28.5h38.7c16.3 0 30-12.3 31.8-28.5l11-99.5h1.8c17.7 0 32-14.3 32-32v-48c0-35.3-28.7-64-64-64h-64zm-91.7 234.2c13-2.4 21.7-14.9 19.3-27.9s-14.9-21.7-27.9-19.3c-32.4 5.9-60.9 14.2-82 24.8-10.5 5.3-20.3 11.7-27.8 19.6C6.4 399.5 0 410.5 0 424c0 21.4 15.5 36.1 29.1 45 14.7 9.6 34.3 17.3 56.4 23.4C130.2 504.7 190.4 512 256 512s125.8-7.3 170.4-19.6c22.1-6.1 41.8-13.8 56.4-23.4 13.7-8.9 29.1-23.6 29.1-45 0-13.5-6.4-24.5-14-32.6-7.5-7.9-17.3-14.3-27.8-19.6-21-10.6-49.5-18.9-82-24.8-13-2.4-25.5 6.3-27.9 19.3s6.3 25.5 19.3 27.9c30.2 5.5 53.7 12.8 69 20.5 3.2 1.6 5.8 3.1 7.9 4.5 3.6 2.4 3.6 7.2 0 9.6-8.8 5.7-23.1 11.8-43 17.3C374.3 457 318.5 464 256 464s-118.3-7-157.7-17.9c-19.9-5.5-34.2-11.6-43-17.3-3.6-2.4-3.6-7.2 0-9.6 2.1-1.4 4.8-2.9 7.9-4.5 15.3-7.7 38.8-14.9 69-20.5z"
+                        >
+                        </path>
+                      </svg>
+                    </a>
+                  </div>
+                </li>
+                <li class="styled__StepRow-sc-1q8npbl-71 kVZYtk">
+                  <div class="styled__StepIconContainer-sc-1q8npbl-70 fosTFg">
+                    <svg viewbox="0 0 261 261">
+                      <path d="M146.5 140.5l100-70.86L146.5.5v40h-70c-30 0-50 20-50 50v170h60v-160h60v40z">
+                      </path>
+                    </svg>
+                  </div>
+                  <div class="styled__StepDescriptionContainer-sc-1q8npbl-66 tiDJD">
+                    <span>
+                      Right on
+                      <span class="styled__StepStreetName-sc-1q8npbl-72 iJrUDA">
+                        Unnamed Path
+                      </span>
+                      <span class="styled__StepLength-sc-1q8npbl-73 cCaIgd">
+                        27 feet
+                      </span>
+                    </span>
+                    <a aria-label="Show street imagery at this location"
+                       role="link"
+                       title="Show street imagery at this location"
+                       class="mapillary-button__Container-sc-l7gdsc-0 fUOQNZ"
+                    >
+                      <svg viewbox="0 0 512 512"
+                           aria-hidden="true"
+                           focusable="false"
+                           fill="currentColor"
+                           xmlns="http://www.w3.org/2000/svg"
+                           class="StyledIconBase-sc-ea9ulj-0 ebjPRL mapillary-button__Icon-sc-l7gdsc-1 dQCpQk"
+                           style="padding-bottom: 1px;"
+                      >
+                        <path fill="currentColor"
+                              d="M320 64c0-35.3-28.7-64-64-64s-64 28.7-64 64 28.7 64 64 64 64-28.7 64-64zm-96 96c-35.3 0-64 28.7-64 64v48c0 17.7 14.3 32 32 32h1.8l11.1 99.5c1.8 16.2 15.5 28.5 31.8 28.5h38.7c16.3 0 30-12.3 31.8-28.5l11-99.5h1.8c17.7 0 32-14.3 32-32v-48c0-35.3-28.7-64-64-64h-64zm-91.7 234.2c13-2.4 21.7-14.9 19.3-27.9s-14.9-21.7-27.9-19.3c-32.4 5.9-60.9 14.2-82 24.8-10.5 5.3-20.3 11.7-27.8 19.6C6.4 399.5 0 410.5 0 424c0 21.4 15.5 36.1 29.1 45 14.7 9.6 34.3 17.3 56.4 23.4C130.2 504.7 190.4 512 256 512s125.8-7.3 170.4-19.6c22.1-6.1 41.8-13.8 56.4-23.4 13.7-8.9 29.1-23.6 29.1-45 0-13.5-6.4-24.5-14-32.6-7.5-7.9-17.3-14.3-27.8-19.6-21-10.6-49.5-18.9-82-24.8-13-2.4-25.5 6.3-27.9 19.3s6.3 25.5 19.3 27.9c30.2 5.5 53.7 12.8 69 20.5 3.2 1.6 5.8 3.1 7.9 4.5 3.6 2.4 3.6 7.2 0 9.6-8.8 5.7-23.1 11.8-43 17.3C374.3 457 318.5 464 256 464s-118.3-7-157.7-17.9c-19.9-5.5-34.2-11.6-43-17.3-3.6-2.4-3.6-7.2 0-9.6 2.1-1.4 4.8-2.9 7.9-4.5 15.3-7.7 38.8-14.9 69-20.5z"
+                        >
+                        </path>
+                      </svg>
+                    </a>
+                  </div>
+                </li>
+                <li class="styled__StepRow-sc-1q8npbl-71 kVZYtk">
+                  <div class="styled__StepIconContainer-sc-1q8npbl-70 fosTFg">
+                    <svg viewbox="0 0 261 261">
+                      <path d="M146.5 140.5l100-70.86L146.5.5v40h-70c-30 0-50 20-50 50v170h60v-160h60v40z">
+                      </path>
+                    </svg>
+                  </div>
+                  <div class="styled__StepDescriptionContainer-sc-1q8npbl-66 tiDJD">
+                    <span>
+                      Right on
+                      <span class="styled__StepStreetName-sc-1q8npbl-72 iJrUDA">
+                        SW Morrison St
+                      </span>
+                      <span class="styled__StepLength-sc-1q8npbl-73 cCaIgd">
+                        99 feet
+                      </span>
+                    </span>
+                    <a aria-label="Show street imagery at this location"
+                       role="link"
+                       title="Show street imagery at this location"
+                       class="mapillary-button__Container-sc-l7gdsc-0 fUOQNZ"
+                    >
+                      <svg viewbox="0 0 512 512"
+                           aria-hidden="true"
+                           focusable="false"
+                           fill="currentColor"
+                           xmlns="http://www.w3.org/2000/svg"
+                           class="StyledIconBase-sc-ea9ulj-0 ebjPRL mapillary-button__Icon-sc-l7gdsc-1 dQCpQk"
+                           style="padding-bottom: 1px;"
+                      >
+                        <path fill="currentColor"
+                              d="M320 64c0-35.3-28.7-64-64-64s-64 28.7-64 64 28.7 64 64 64 64-28.7 64-64zm-96 96c-35.3 0-64 28.7-64 64v48c0 17.7 14.3 32 32 32h1.8l11.1 99.5c1.8 16.2 15.5 28.5 31.8 28.5h38.7c16.3 0 30-12.3 31.8-28.5l11-99.5h1.8c17.7 0 32-14.3 32-32v-48c0-35.3-28.7-64-64-64h-64zm-91.7 234.2c13-2.4 21.7-14.9 19.3-27.9s-14.9-21.7-27.9-19.3c-32.4 5.9-60.9 14.2-82 24.8-10.5 5.3-20.3 11.7-27.8 19.6C6.4 399.5 0 410.5 0 424c0 21.4 15.5 36.1 29.1 45 14.7 9.6 34.3 17.3 56.4 23.4C130.2 504.7 190.4 512 256 512s125.8-7.3 170.4-19.6c22.1-6.1 41.8-13.8 56.4-23.4 13.7-8.9 29.1-23.6 29.1-45 0-13.5-6.4-24.5-14-32.6-7.5-7.9-17.3-14.3-27.8-19.6-21-10.6-49.5-18.9-82-24.8-13-2.4-25.5 6.3-27.9 19.3s6.3 25.5 19.3 27.9c30.2 5.5 53.7 12.8 69 20.5 3.2 1.6 5.8 3.1 7.9 4.5 3.6 2.4 3.6 7.2 0 9.6-8.8 5.7-23.1 11.8-43 17.3C374.3 457 318.5 464 256 464s-118.3-7-157.7-17.9c-19.9-5.5-34.2-11.6-43-17.3-3.6-2.4-3.6-7.2 0-9.6 2.1-1.4 4.8-2.9 7.9-4.5 15.3-7.7 38.8-14.9 69-20.5z"
+                        >
+                        </path>
+                      </svg>
+                    </a>
+                  </div>
+                </li>
+              </ol>
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+  </li>
+  <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
+    <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
+      <span class="line-column-content__IconStacker-sc-1wcbb7o-0 ldGHux">
+        <svg viewbox="0 0 512 512"
+             height="14"
+             width="14"
+             aria-hidden="true"
+             focusable="false"
+             fill="currentColor"
+             xmlns="http://www.w3.org/2000/svg"
+             color="white"
+             class="StyledIconBase-sc-ea9ulj-0 ebjPRL line-column-content__StackedCircle-sc-1wcbb7o-2 line-column-content__StackedCircleInner-sc-1wcbb7o-3 iTIsMm hPKTER"
+        >
+          <path fill="currentColor"
+                d="M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0 0 114.6 0 256s114.6 256 256 256z"
+          >
+          </path>
+        </svg>
+        <svg viewbox="0 0 384 512"
+             height="20"
+             width="20"
+             aria-hidden="true"
+             focusable="false"
+             fill="currentColor"
+             xmlns="http://www.w3.org/2000/svg"
+             class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__ToIcon-sc-n5xcvc-2 gZxRwk line-column-content__StyledLocationIcon-sc-1wcbb7o-4 jnioyI"
+        >
+          <path fill="currentColor"
+                d="M215.7 499.2C267 435 384 279.4 384 192 384 86 298 0 192 0S0 86 0 192c0 87.4 117 243 168.3 307.2 12.3 15.3 35.1 15.3 47.4 0zM192 256c-35.3 0-64-28.7-64-64s28.7-64 64-64 64 28.7 64 64-28.7 64-64 64z"
+          >
+          </path>
+        </svg>
+      </span>
+    </div>
+    <div class="styled__PlaceHeader-sc-1q8npbl-54 hMGsin">
+      <span aria-hidden="true"
+            class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
+      >
+        1737 SW Morrison St, Portland, OR, USA 97205
+      </span>
+    </div>
+    <div class="styled__TimeColumn-sc-1q8npbl-49 kSAQNU">
+      3:50 PM
+    </div>
+    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+      Arrive at 1737 SW Morrison St, Portland, OR, USA 97205
+    </span>
+    <div class="styled__PlaceDetails-sc-1q8npbl-53 cHqDbl place-details ">
+    </div>
+  </li>
+</ol>
+`;
+
 exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF itinerary-body__StyledItineraryBody-sc-1aqc6e3-0 jyGWIy">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">

--- a/packages/itinerary-body/src/stories/__snapshots__/OtpRrItineraryBody.story.tsx.snap
+++ b/packages/itinerary-body/src/stories/__snapshots__/OtpRrItineraryBody.story.tsx.snap
@@ -577,7 +577,7 @@ exports[`ItineraryBody/otp-react-redux AlertNoEffectiveAsOfItinerary smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -1533,7 +1533,7 @@ exports[`ItineraryBody/otp-react-redux ApproximatePrefixItinerary smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -4311,7 +4311,7 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; Lawrence
                       </div>
                     </li>
@@ -4319,7 +4319,7 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; 28th
                       </div>
                     </li>
@@ -4327,7 +4327,7 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; 31st
                       </div>
                     </li>
@@ -4335,7 +4335,7 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; 33rd
                       </div>
                     </li>
@@ -4343,7 +4343,7 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; Imperial
                       </div>
                     </li>
@@ -4351,7 +4351,7 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; 38th
                       </div>
                     </li>
@@ -4359,7 +4359,7 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; 42nd
                       </div>
                     </li>
@@ -4367,7 +4367,7 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; 44th
                       </div>
                     </li>
@@ -4375,7 +4375,7 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; 48th
                       </div>
                     </li>
@@ -4383,7 +4383,7 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; 50th
                       </div>
                     </li>
@@ -4391,7 +4391,7 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; Sacramento
                       </div>
                     </li>
@@ -4399,7 +4399,7 @@ exports[`ItineraryBody/otp-react-redux BikeRentalTransitItinerary smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; 54th
                       </div>
                     </li>
@@ -6171,7 +6171,7 @@ exports[`ItineraryBody/otp-react-redux BikeTransitBikeItinerary smoke-test 1`] =
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -7101,7 +7101,7 @@ exports[`ItineraryBody/otp-react-redux CustomTimeColumn smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         W Burnside &amp; SW 2nd
                       </div>
                     </li>
@@ -7109,7 +7109,7 @@ exports[`ItineraryBody/otp-react-redux CustomTimeColumn smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 8th
                       </div>
                     </li>
@@ -8965,7 +8965,7 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Broadway &amp; 32nd
                       </div>
                     </li>
@@ -8973,7 +8973,7 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE 33rd &amp; Schuyler
                       </div>
                     </li>
@@ -8981,7 +8981,7 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE 33rd &amp; US Grant Pl
                       </div>
                     </li>
@@ -8989,7 +8989,7 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE 33rd &amp; Brazee
                       </div>
                     </li>
@@ -8997,7 +8997,7 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE 33rd &amp; Knott
                       </div>
                     </li>
@@ -9005,7 +9005,7 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE 33rd &amp; Stanton
                       </div>
                     </li>
@@ -9013,7 +9013,7 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE 33rd &amp; Siskiyou
                       </div>
                     </li>
@@ -9021,7 +9021,7 @@ exports[`ItineraryBody/otp-react-redux EScooterRentalTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE 33rd &amp; Alameda
                       </div>
                     </li>
@@ -10420,7 +10420,7 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Washington Park MAX Station
                       </div>
                     </li>
@@ -10428,7 +10428,7 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Goose Hollow/SW Jefferson St MAX Station
                       </div>
                     </li>
@@ -10436,7 +10436,7 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Kings Hill/SW Salmon St MAX Station
                       </div>
                     </li>
@@ -10444,7 +10444,7 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Providence Park MAX Station
                       </div>
                     </li>
@@ -10452,7 +10452,7 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Library/SW 9th Ave MAX Station
                       </div>
                     </li>
@@ -10460,7 +10460,7 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Pioneer Square South MAX Station
                       </div>
                     </li>
@@ -10468,7 +10468,7 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Mall/SW 4th Ave MAX Station
                       </div>
                     </li>
@@ -10476,7 +10476,7 @@ exports[`ItineraryBody/otp-react-redux HideDrivingDirections smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Yamhill District MAX Station
                       </div>
                     </li>
@@ -11695,7 +11695,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         South Mount Vernon Park &amp; Ride
                       </div>
                     </li>
@@ -11703,7 +11703,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Broadway - Everett Community College
                       </div>
                     </li>
@@ -11711,7 +11711,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Broadway &amp; 14th  (near hospital)
                       </div>
                     </li>
@@ -11719,7 +11719,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Broadway just South of the Event Center
                       </div>
                     </li>
@@ -12108,7 +12108,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Broadway &amp; 34th St
                       </div>
                     </li>
@@ -12116,7 +12116,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         South Everett Fwy Station Bay 3
                       </div>
                     </li>
@@ -12124,7 +12124,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Ash Way Park &amp; Ride Bay 1
                       </div>
                     </li>
@@ -12513,7 +12513,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Alderwood Mall Pkwy &amp; Beech Rd
                       </div>
                     </li>
@@ -12521,7 +12521,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Alderwood Mall Pkwy &amp; 184th St SW
                       </div>
                     </li>
@@ -12529,7 +12529,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Canyon Park Fwy Station Bay 4
                       </div>
                     </li>
@@ -12537,7 +12537,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Beardslee Blvd &amp; Ross Rd
                       </div>
                     </li>
@@ -12545,7 +12545,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         UW Bothell &amp; Cascadia College
                       </div>
                     </li>
@@ -12934,7 +12934,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Woodinville Dr &amp; Kaysner Way
                       </div>
                     </li>
@@ -12942,7 +12942,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Bothell Way NE &amp; NE 180th St
                       </div>
                     </li>
@@ -12950,7 +12950,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Bothell Way &amp; 96th Ave NE
                       </div>
                     </li>
@@ -12958,7 +12958,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Bothell Way &amp; 91st Ave NE
                       </div>
                     </li>
@@ -12966,7 +12966,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Bothell Way &amp; 83rd Pl NE
                       </div>
                     </li>
@@ -12974,7 +12974,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Bothell Way &amp; 80th Ave NE
                       </div>
                     </li>
@@ -12982,7 +12982,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Bothell Way &amp; 77th Ct NE
                       </div>
                     </li>
@@ -12990,7 +12990,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Bothell Way &amp; Kenmore Park &amp; Ride
                       </div>
                     </li>
@@ -12998,7 +12998,7 @@ exports[`ItineraryBody/otp-react-redux IndividualLegFareComponents smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Bothell Way &amp; 68th Ave NE
                       </div>
                     </li>
@@ -13892,7 +13892,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         S Main St &amp; Ken Pratt Blvd
                       </div>
                     </li>
@@ -13900,7 +13900,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         S Main St &amp; Jersey Ave
                       </div>
                     </li>
@@ -13908,7 +13908,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         S Main St &amp; Missouri Ave
                       </div>
                     </li>
@@ -13916,7 +13916,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         S Main St &amp; Quebec Ave
                       </div>
                     </li>
@@ -13924,7 +13924,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         US 287 &amp; Pike Rd
                       </div>
                     </li>
@@ -13932,7 +13932,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         US 287 &amp; Niwot Rd
                       </div>
                     </li>
@@ -13940,7 +13940,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         US 287 &amp; Hwy 52
                       </div>
                     </li>
@@ -13948,7 +13948,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         US 287 &amp; Lookout Rd
                       </div>
                     </li>
@@ -13956,7 +13956,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         US 287 &amp; Dawson Dr
                       </div>
                     </li>
@@ -13964,7 +13964,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         US 287 &amp; Goose Haven Dr
                       </div>
                     </li>
@@ -13972,7 +13972,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         US 287 &amp; Isabelle Rd
                       </div>
                     </li>
@@ -14394,7 +14394,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Arapahoe Rd &amp; US 287
                       </div>
                     </li>
@@ -14402,7 +14402,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Arapahoe Rd &amp; 111th St
                       </div>
                     </li>
@@ -14410,7 +14410,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Arapahoe Rd &amp; Hawkridge Rd
                       </div>
                     </li>
@@ -14418,7 +14418,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         2800 Block 119th St
                       </div>
                     </li>
@@ -14426,7 +14426,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         119th St &amp; Austin Ave
                       </div>
                     </li>
@@ -14434,7 +14434,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Erie Pkwy &amp; Brennan St
                       </div>
                     </li>
@@ -14442,7 +14442,7 @@ exports[`ItineraryBody/otp-react-redux OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Erie Pkwy &amp; Meller St
                       </div>
                     </li>
@@ -16320,7 +16320,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Quatama MAX Station
                       </div>
                     </li>
@@ -16328,7 +16328,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Willow Creek/SW 185th Ave TC MAX Station
                       </div>
                     </li>
@@ -16336,7 +16336,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Elmonica/SW 170th Ave MAX Station
                       </div>
                     </li>
@@ -16344,7 +16344,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Merlo Rd/SW 158th Ave MAX Station
                       </div>
                     </li>
@@ -16352,7 +16352,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Beaverton Creek MAX Station
                       </div>
                     </li>
@@ -16360,7 +16360,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Millikan Way MAX Station
                       </div>
                     </li>
@@ -16368,7 +16368,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Beaverton Central MAX Station
                       </div>
                     </li>
@@ -16376,7 +16376,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Beaverton TC MAX Station
                       </div>
                     </li>
@@ -16384,7 +16384,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Sunset TC MAX Station
                       </div>
                     </li>
@@ -16392,7 +16392,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Washington Park MAX Station
                       </div>
                     </li>
@@ -16400,7 +16400,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Goose Hollow/SW Jefferson St MAX Station
                       </div>
                     </li>
@@ -16942,7 +16942,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         W Burnside &amp; SW 15th
                       </div>
                     </li>
@@ -16950,7 +16950,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         W Burnside &amp; SW 13th
                       </div>
                     </li>
@@ -16958,7 +16958,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         W Burnside &amp; SW 10th
                       </div>
                     </li>
@@ -16966,7 +16966,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         W Burnside &amp; SW 6th
                       </div>
                     </li>
@@ -16974,7 +16974,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         W Burnside &amp; SW 2nd
                       </div>
                     </li>
@@ -16982,7 +16982,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; NE Grand
                       </div>
                     </li>
@@ -16990,7 +16990,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 8th Ave
                       </div>
                     </li>
@@ -16998,7 +16998,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 12th Ave
                       </div>
                     </li>
@@ -17006,7 +17006,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 16th
                       </div>
                     </li>
@@ -17014,7 +17014,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 20th
                       </div>
                     </li>
@@ -17022,7 +17022,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 24th
                       </div>
                     </li>
@@ -17030,7 +17030,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 28th
                       </div>
                     </li>
@@ -17038,7 +17038,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 32nd
                       </div>
                     </li>
@@ -17046,7 +17046,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE Floral
                       </div>
                     </li>
@@ -17054,7 +17054,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE Laurelhurst
                       </div>
                     </li>
@@ -17062,7 +17062,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE Cesar Chavez Blvd
                       </div>
                     </li>
@@ -17070,7 +17070,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 41st
                       </div>
                     </li>
@@ -17078,7 +17078,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 44th
                       </div>
                     </li>
@@ -17086,7 +17086,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 47th
                       </div>
                     </li>
@@ -17094,7 +17094,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 52nd
                       </div>
                     </li>
@@ -17102,7 +17102,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 55th
                       </div>
                     </li>
@@ -17110,7 +17110,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 57th
                       </div>
                     </li>
@@ -17118,7 +17118,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 60th
                       </div>
                     </li>
@@ -17126,7 +17126,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; 63rd
                       </div>
                     </li>
@@ -17134,7 +17134,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 67th
                       </div>
                     </li>
@@ -17142,7 +17142,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 69th
                       </div>
                     </li>
@@ -17150,7 +17150,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 72nd
                       </div>
                     </li>
@@ -17158,7 +17158,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 74th
                       </div>
                     </li>
@@ -17166,7 +17166,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 79th
                       </div>
                     </li>
@@ -17174,7 +17174,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 82nd
                       </div>
                     </li>
@@ -17182,7 +17182,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 87th
                       </div>
                     </li>
@@ -17190,7 +17190,7 @@ exports[`ItineraryBody/otp-react-redux Otp24Itinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         9100 Block E Burnside
                       </div>
                     </li>
@@ -18688,7 +18688,7 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Washington Park MAX Station
                       </div>
                     </li>
@@ -18696,7 +18696,7 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Goose Hollow/SW Jefferson St MAX Station
                       </div>
                     </li>
@@ -18704,7 +18704,7 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Kings Hill/SW Salmon St MAX Station
                       </div>
                     </li>
@@ -18712,7 +18712,7 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Providence Park MAX Station
                       </div>
                     </li>
@@ -18720,7 +18720,7 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Library/SW 9th Ave MAX Station
                       </div>
                     </li>
@@ -18728,7 +18728,7 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Pioneer Square South MAX Station
                       </div>
                     </li>
@@ -18736,7 +18736,7 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Mall/SW 4th Ave MAX Station
                       </div>
                     </li>
@@ -18744,7 +18744,7 @@ exports[`ItineraryBody/otp-react-redux ParkAndRideItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Yamhill District MAX Station
                       </div>
                     </li>
@@ -19339,7 +19339,7 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Halladay St
                       </div>
                     </li>
@@ -19347,7 +19347,7 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Lynn St
                       </div>
                     </li>
@@ -19355,7 +19355,7 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Crockett St
                       </div>
                     </li>
@@ -19363,7 +19363,7 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Galer St
                       </div>
                     </li>
@@ -19371,7 +19371,7 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Prospect St
                       </div>
                     </li>
@@ -19379,7 +19379,7 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         7th Ave N &amp; Thomas St
                       </div>
                     </li>
@@ -19550,7 +19550,7 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Bell St
                       </div>
                     </li>
@@ -19558,7 +19558,7 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Virginia St
                       </div>
                     </li>
@@ -19566,7 +19566,7 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Pike St
                       </div>
                     </li>
@@ -19574,7 +19574,7 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Seneca St
                       </div>
                     </li>
@@ -19582,7 +19582,7 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Cherry St
                       </div>
                     </li>
@@ -19590,7 +19590,7 @@ exports[`ItineraryBody/otp-react-redux StayOnBoardItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave S &amp; S Main St
                       </div>
                     </li>
@@ -20235,7 +20235,7 @@ exports[`ItineraryBody/otp-react-redux StopWithNoStopCode smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -21191,7 +21191,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsAlwaysCollapsing smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -22147,7 +22147,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsNotAlwaysCollapsing smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -23103,7 +23103,7 @@ exports[`ItineraryBody/otp-react-redux ThreeAlertsWithoutCollapsingProp smoke-te
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -23842,7 +23842,7 @@ exports[`ItineraryBody/otp-react-redux TncTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         W Burnside &amp; SW 2nd
                       </div>
                     </li>
@@ -23850,7 +23850,7 @@ exports[`ItineraryBody/otp-react-redux TncTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 8th
                       </div>
                     </li>
@@ -24807,7 +24807,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Philadelphia Airport Terminals E &amp; F
                       </div>
                     </li>
@@ -24815,7 +24815,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Bartram Av &amp; 90th St
                       </div>
                     </li>
@@ -24823,7 +24823,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         89th St &amp; Bartram Av - FS
                       </div>
                     </li>
@@ -25112,7 +25112,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Tinicum Blvd &amp; 88th St - FS
                       </div>
                     </li>
@@ -25120,7 +25120,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Tinicum Blvd &amp; 86th St - MBFS
                       </div>
                     </li>
@@ -25128,7 +25128,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Bartram Av &amp; 84th St - MBNS
                       </div>
                     </li>
@@ -25136,7 +25136,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Bartram Av &amp; 84th St - MBFS
                       </div>
                     </li>
@@ -25144,7 +25144,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Island Av &amp; Penrose Av - MBNS
                       </div>
                     </li>
@@ -25152,7 +25152,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Island Av &amp; Penrose Av - MBFS
                       </div>
                     </li>
@@ -25160,7 +25160,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Island Av &amp; Escort Av - MBNS
                       </div>
                     </li>
@@ -25168,7 +25168,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Island Av &amp; Escort Av
                       </div>
                     </li>
@@ -25176,7 +25176,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Island Av &amp; Escort Av - MBFS
                       </div>
                     </li>
@@ -25184,7 +25184,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Enterprise Av &amp; Executive Av
                       </div>
                     </li>
@@ -25192,7 +25192,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Executive Av &amp; Enterprise Av - FS
                       </div>
                     </li>
@@ -25200,7 +25200,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Executive Av &amp; Escort Av
                       </div>
                     </li>
@@ -25208,7 +25208,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Escort Av &amp; Island Av
                       </div>
                     </li>
@@ -25216,7 +25216,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Island Av &amp; Penrose Av - MBNS
                       </div>
                     </li>
@@ -25224,7 +25224,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Island Av &amp; Penrose Av - MBNS
                       </div>
                     </li>
@@ -25232,7 +25232,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Penrose Av &amp; 26th St - MBNS
                       </div>
                     </li>
@@ -25240,7 +25240,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Penrose &amp; Pattison Av - MBNS
                       </div>
                     </li>
@@ -25248,7 +25248,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Penrose &amp; Pattison Av - FS
                       </div>
                     </li>
@@ -25256,7 +25256,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Penrose Av &amp; 20th St
                       </div>
                     </li>
@@ -25264,7 +25264,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Penrose Av &amp; 20th St - FS
                       </div>
                     </li>
@@ -25272,7 +25272,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Moyamensing Av &amp; Pollock St
                       </div>
                     </li>
@@ -25280,7 +25280,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Moyamensing Av &amp; 18th St
                       </div>
                     </li>
@@ -25288,7 +25288,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Moyamensing Av &amp; 17th St
                       </div>
                     </li>
@@ -25296,7 +25296,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Moyamensing Av &amp; 16th St
                       </div>
                     </li>
@@ -25304,7 +25304,7 @@ exports[`ItineraryBody/otp-react-redux TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Moyamensing Av &amp; 15th St
                       </div>
                     </li>
@@ -27004,7 +27004,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Washington Park MAX Station
                       </div>
                     </li>
@@ -27012,7 +27012,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Goose Hollow/SW Jefferson St MAX Station
                       </div>
                     </li>
@@ -27020,7 +27020,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Kings Hill/SW Salmon St MAX Station
                       </div>
                     </li>
@@ -27028,7 +27028,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Providence Park MAX Station
                       </div>
                     </li>
@@ -27036,7 +27036,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Library/SW 9th Ave MAX Station
                       </div>
                     </li>
@@ -27044,7 +27044,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Pioneer Square South MAX Station
                       </div>
                     </li>
@@ -27052,7 +27052,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Mall/SW 4th Ave MAX Station
                       </div>
                     </li>
@@ -27060,7 +27060,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsAlwaysCollapsing smoke-test 1`] 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Yamhill District MAX Station
                       </div>
                     </li>
@@ -28567,7 +28567,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Washington Park MAX Station
                       </div>
                     </li>
@@ -28575,7 +28575,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Goose Hollow/SW Jefferson St MAX Station
                       </div>
                     </li>
@@ -28583,7 +28583,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Kings Hill/SW Salmon St MAX Station
                       </div>
                     </li>
@@ -28591,7 +28591,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Providence Park MAX Station
                       </div>
                     </li>
@@ -28599,7 +28599,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Library/SW 9th Ave MAX Station
                       </div>
                     </li>
@@ -28607,7 +28607,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Pioneer Square South MAX Station
                       </div>
                     </li>
@@ -28615,7 +28615,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Mall/SW 4th Ave MAX Station
                       </div>
                     </li>
@@ -28623,7 +28623,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsNotAlwaysCollapsing smoke-test 1
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Yamhill District MAX Station
                       </div>
                     </li>
@@ -30130,7 +30130,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Washington Park MAX Station
                       </div>
                     </li>
@@ -30138,7 +30138,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Goose Hollow/SW Jefferson St MAX Station
                       </div>
                     </li>
@@ -30146,7 +30146,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Kings Hill/SW Salmon St MAX Station
                       </div>
                     </li>
@@ -30154,7 +30154,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Providence Park MAX Station
                       </div>
                     </li>
@@ -30162,7 +30162,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Library/SW 9th Ave MAX Station
                       </div>
                     </li>
@@ -30170,7 +30170,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Pioneer Square South MAX Station
                       </div>
                     </li>
@@ -30178,7 +30178,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Mall/SW 4th Ave MAX Station
                       </div>
                     </li>
@@ -30186,7 +30186,7 @@ exports[`ItineraryBody/otp-react-redux TwoAlertsWithoutCollapsingProp smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Yamhill District MAX Station
                       </div>
                     </li>
@@ -31147,7 +31147,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Broadway &amp; 34th St
                       </div>
                     </li>
@@ -31155,7 +31155,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         South Everett Fwy Station Bay 3
                       </div>
                     </li>
@@ -31163,7 +31163,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Ash Way Park &amp; Ride Bay 1
                       </div>
                     </li>
@@ -31171,7 +31171,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Lynnwood Transit Center Bay D3
                       </div>
                     </li>
@@ -31179,7 +31179,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Mountlake Terrace Fwy Station Bay 6
                       </div>
                     </li>
@@ -31465,7 +31465,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         1st Ave NE &amp; NE 95th St
                       </div>
                     </li>
@@ -31473,7 +31473,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N 92nd St &amp; Corliss Ave N
                       </div>
                     </li>
@@ -31481,7 +31481,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         College Way N &amp; N 97th St
                       </div>
                     </li>
@@ -31489,7 +31489,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         College Way N &amp; N 103rd St
                       </div>
                     </li>
@@ -31497,7 +31497,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Meridian Ave N &amp; N 105th St
                       </div>
                     </li>
@@ -31505,7 +31505,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N Northgate Way &amp; Meridian Ave N
                       </div>
                     </li>
@@ -31513,7 +31513,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N Northgate Way &amp; Stone Ave N
                       </div>
                     </li>
@@ -31969,7 +31969,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 100th St
                       </div>
                     </li>
@@ -31977,7 +31977,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 95th St
                       </div>
                     </li>
@@ -31985,7 +31985,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 90th St
                       </div>
                     </li>
@@ -31993,7 +31993,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 85th St
                       </div>
                     </li>
@@ -32001,7 +32001,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 80th St
                       </div>
                     </li>
@@ -32009,7 +32009,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 76th St
                       </div>
                     </li>
@@ -32017,7 +32017,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 65th St
                       </div>
                     </li>
@@ -32025,7 +32025,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 46th St
                       </div>
                     </li>
@@ -32033,7 +32033,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Lynn St
                       </div>
                     </li>
@@ -32041,7 +32041,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Galer St
                       </div>
                     </li>
@@ -32049,7 +32049,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         7th Ave N &amp; Thomas St
                       </div>
                     </li>
@@ -32057,7 +32057,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Wall St &amp; 5th Ave
                       </div>
                     </li>
@@ -32065,7 +32065,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Bell St
                       </div>
                     </li>
@@ -32073,7 +32073,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Virginia St
                       </div>
                     </li>
@@ -32081,7 +32081,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Pike St
                       </div>
                     </li>
@@ -32089,7 +32089,7 @@ exports[`ItineraryBody/otp-react-redux WalkInterlinedTransitItinerary smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Seneca St
                       </div>
                     </li>
@@ -33063,7 +33063,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Cesar Chavez Blvd &amp; Clinton
                       </div>
                     </li>
@@ -33071,7 +33071,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Cesar Chavez Blvd &amp; Division
                       </div>
                     </li>
@@ -33079,7 +33079,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Cesar Chavez Blvd &amp; Lincoln
                       </div>
                     </li>
@@ -33087,7 +33087,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Cesar Chavez Blvd &amp; Stephens
                       </div>
                     </li>
@@ -33551,7 +33551,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Hawthorne &amp; 37th
                       </div>
                     </li>
@@ -33559,7 +33559,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Hawthorne &amp; 34th
                       </div>
                     </li>
@@ -33567,7 +33567,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Hawthorne &amp; 32nd
                       </div>
                     </li>
@@ -33575,7 +33575,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferItinerary smoke-test 1
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Hawthorne &amp; 30th
                       </div>
                     </li>
@@ -34378,7 +34378,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Cesar Chavez Blvd &amp; Clinton
                       </div>
                     </li>
@@ -34386,7 +34386,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Cesar Chavez Blvd &amp; Division
                       </div>
                     </li>
@@ -34394,7 +34394,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Cesar Chavez Blvd &amp; Lincoln
                       </div>
                     </li>
@@ -34402,7 +34402,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Cesar Chavez Blvd &amp; Stephens
                       </div>
                     </li>
@@ -34897,7 +34897,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Hawthorne &amp; 37th
                       </div>
                     </li>
@@ -34905,7 +34905,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Hawthorne &amp; 34th
                       </div>
                     </li>
@@ -34913,7 +34913,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Hawthorne &amp; 32nd
                       </div>
                     </li>
@@ -34921,7 +34921,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitTransferWithA11yItinerary smok
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Hawthorne &amp; 30th
                       </div>
                     </li>
@@ -35867,7 +35867,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItinerary smoke-test 1`] =
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -36831,7 +36831,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryCanceled smoke-te
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -37787,9 +37787,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryClosedStop smoke-
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk"
-                           style="color: rgb(191, 62, 58);"
-                      >
+                      <div class="styled__StopName-sc-1q8npbl-76 jlyFEH">
                         Galleria/SW 10th Ave MAX Station (Closed)
                       </div>
                     </li>
@@ -38745,7 +38743,7 @@ exports[`ItineraryBody/otp-react-redux WalkTransitWalkItineraryMetric smoke-test
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -39671,7 +39669,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Broadway &amp; 34th St
                       </div>
                     </li>
@@ -39679,7 +39677,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         South Everett Fwy Station Bay 3
                       </div>
                     </li>
@@ -39687,7 +39685,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Ash Way Park &amp; Ride Bay 1
                       </div>
                     </li>
@@ -39695,7 +39693,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Lynnwood Transit Center Bay D3
                       </div>
                     </li>
@@ -39703,7 +39701,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Mountlake Terrace Fwy Station Bay 6
                       </div>
                     </li>
@@ -39989,7 +39987,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         1st Ave NE &amp; NE 95th St
                       </div>
                     </li>
@@ -39997,7 +39995,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N 92nd St &amp; Corliss Ave N
                       </div>
                     </li>
@@ -40005,7 +40003,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         College Way N &amp; N 97th St
                       </div>
                     </li>
@@ -40013,7 +40011,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         College Way N &amp; N 103rd St
                       </div>
                     </li>
@@ -40021,7 +40019,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Meridian Ave N &amp; N 105th St
                       </div>
                     </li>
@@ -40029,7 +40027,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N Northgate Way &amp; Meridian Ave N
                       </div>
                     </li>
@@ -40037,7 +40035,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N Northgate Way &amp; Stone Ave N
                       </div>
                     </li>
@@ -40493,7 +40491,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 100th St
                       </div>
                     </li>
@@ -40501,7 +40499,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 95th St
                       </div>
                     </li>
@@ -40509,7 +40507,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 90th St
                       </div>
                     </li>
@@ -40517,7 +40515,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 85th St
                       </div>
                     </li>
@@ -40525,7 +40523,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 80th St
                       </div>
                     </li>
@@ -40533,7 +40531,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 76th St
                       </div>
                     </li>
@@ -40541,7 +40539,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 65th St
                       </div>
                     </li>
@@ -40549,7 +40547,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 46th St
                       </div>
                     </li>
@@ -40557,7 +40555,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Lynn St
                       </div>
                     </li>
@@ -40565,7 +40563,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Galer St
                       </div>
                     </li>
@@ -40573,7 +40571,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         7th Ave N &amp; Thomas St
                       </div>
                     </li>
@@ -40581,7 +40579,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Wall St &amp; 5th Ave
                       </div>
                     </li>
@@ -40589,7 +40587,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Bell St
                       </div>
                     </li>
@@ -40597,7 +40595,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Virginia St
                       </div>
                     </li>
@@ -40605,7 +40603,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Pike St
                       </div>
                     </li>
@@ -40613,7 +40611,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsAlwaysCollapsing smoke-test 1`]
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Seneca St
                       </div>
                     </li>
@@ -41460,7 +41458,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Broadway &amp; 34th St
                       </div>
                     </li>
@@ -41468,7 +41466,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         South Everett Fwy Station Bay 3
                       </div>
                     </li>
@@ -41476,7 +41474,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Ash Way Park &amp; Ride Bay 1
                       </div>
                     </li>
@@ -41484,7 +41482,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Lynnwood Transit Center Bay D3
                       </div>
                     </li>
@@ -41492,7 +41490,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Mountlake Terrace Fwy Station Bay 6
                       </div>
                     </li>
@@ -41778,7 +41776,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         1st Ave NE &amp; NE 95th St
                       </div>
                     </li>
@@ -41786,7 +41784,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N 92nd St &amp; Corliss Ave N
                       </div>
                     </li>
@@ -41794,7 +41792,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         College Way N &amp; N 97th St
                       </div>
                     </li>
@@ -41802,7 +41800,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         College Way N &amp; N 103rd St
                       </div>
                     </li>
@@ -41810,7 +41808,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Meridian Ave N &amp; N 105th St
                       </div>
                     </li>
@@ -41818,7 +41816,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N Northgate Way &amp; Meridian Ave N
                       </div>
                     </li>
@@ -41826,7 +41824,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N Northgate Way &amp; Stone Ave N
                       </div>
                     </li>
@@ -42282,7 +42280,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 100th St
                       </div>
                     </li>
@@ -42290,7 +42288,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 95th St
                       </div>
                     </li>
@@ -42298,7 +42296,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 90th St
                       </div>
                     </li>
@@ -42306,7 +42304,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 85th St
                       </div>
                     </li>
@@ -42314,7 +42312,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 80th St
                       </div>
                     </li>
@@ -42322,7 +42320,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 76th St
                       </div>
                     </li>
@@ -42330,7 +42328,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 65th St
                       </div>
                     </li>
@@ -42338,7 +42336,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 46th St
                       </div>
                     </li>
@@ -42346,7 +42344,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Lynn St
                       </div>
                     </li>
@@ -42354,7 +42352,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Galer St
                       </div>
                     </li>
@@ -42362,7 +42360,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         7th Ave N &amp; Thomas St
                       </div>
                     </li>
@@ -42370,7 +42368,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Wall St &amp; 5th Ave
                       </div>
                     </li>
@@ -42378,7 +42376,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Bell St
                       </div>
                     </li>
@@ -42386,7 +42384,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Virginia St
                       </div>
                     </li>
@@ -42394,7 +42392,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Pike St
                       </div>
                     </li>
@@ -42402,7 +42400,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsNotAlwaysCollapsing smoke-test 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Seneca St
                       </div>
                     </li>
@@ -43249,7 +43247,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Broadway &amp; 34th St
                       </div>
                     </li>
@@ -43257,7 +43255,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         South Everett Fwy Station Bay 3
                       </div>
                     </li>
@@ -43265,7 +43263,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Ash Way Park &amp; Ride Bay 1
                       </div>
                     </li>
@@ -43273,7 +43271,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Lynnwood Transit Center Bay D3
                       </div>
                     </li>
@@ -43281,7 +43279,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Mountlake Terrace Fwy Station Bay 6
                       </div>
                     </li>
@@ -43567,7 +43565,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         1st Ave NE &amp; NE 95th St
                       </div>
                     </li>
@@ -43575,7 +43573,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N 92nd St &amp; Corliss Ave N
                       </div>
                     </li>
@@ -43583,7 +43581,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         College Way N &amp; N 97th St
                       </div>
                     </li>
@@ -43591,7 +43589,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         College Way N &amp; N 103rd St
                       </div>
                     </li>
@@ -43599,7 +43597,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Meridian Ave N &amp; N 105th St
                       </div>
                     </li>
@@ -43607,7 +43605,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N Northgate Way &amp; Meridian Ave N
                       </div>
                     </li>
@@ -43615,7 +43613,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N Northgate Way &amp; Stone Ave N
                       </div>
                     </li>
@@ -44071,7 +44069,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 100th St
                       </div>
                     </li>
@@ -44079,7 +44077,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 95th St
                       </div>
                     </li>
@@ -44087,7 +44085,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 90th St
                       </div>
                     </li>
@@ -44095,7 +44093,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 85th St
                       </div>
                     </li>
@@ -44103,7 +44101,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 80th St
                       </div>
                     </li>
@@ -44111,7 +44109,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 76th St
                       </div>
                     </li>
@@ -44119,7 +44117,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 65th St
                       </div>
                     </li>
@@ -44127,7 +44125,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 46th St
                       </div>
                     </li>
@@ -44135,7 +44133,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Lynn St
                       </div>
                     </li>
@@ -44143,7 +44141,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Galer St
                       </div>
                     </li>
@@ -44151,7 +44149,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         7th Ave N &amp; Thomas St
                       </div>
                     </li>
@@ -44159,7 +44157,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Wall St &amp; 5th Ave
                       </div>
                     </li>
@@ -44167,7 +44165,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Bell St
                       </div>
                     </li>
@@ -44175,7 +44173,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Virginia St
                       </div>
                     </li>
@@ -44183,7 +44181,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Pike St
                       </div>
                     </li>
@@ -44191,7 +44189,7 @@ exports[`ItineraryBody/otp-react-redux ZeroAlertsWithoutCollapsingProp smoke-tes
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Seneca St
                       </div>
                     </li>

--- a/packages/itinerary-body/src/stories/__snapshots__/OtpUiItineraryBody.story.tsx.snap
+++ b/packages/itinerary-body/src/stories/__snapshots__/OtpUiItineraryBody.story.tsx.snap
@@ -1053,7 +1053,7 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Washington Park MAX Station
                       </div>
                     </li>
@@ -1061,7 +1061,7 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Goose Hollow/SW Jefferson St MAX Station
                       </div>
                     </li>
@@ -1069,7 +1069,7 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Kings Hill/SW Salmon St MAX Station
                       </div>
                     </li>
@@ -1077,7 +1077,7 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Providence Park MAX Station
                       </div>
                     </li>
@@ -1085,7 +1085,7 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Library/SW 9th Ave MAX Station
                       </div>
                     </li>
@@ -1093,7 +1093,7 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Pioneer Square South MAX Station
                       </div>
                     </li>
@@ -1101,7 +1101,7 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Mall/SW 4th Ave MAX Station
                       </div>
                     </li>
@@ -1109,7 +1109,7 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Yamhill District MAX Station
                       </div>
                     </li>
@@ -3975,7 +3975,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; Lawrence
                       </div>
                     </li>
@@ -3983,7 +3983,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; 28th
                       </div>
                     </li>
@@ -3991,7 +3991,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; 31st
                       </div>
                     </li>
@@ -3999,7 +3999,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; 33rd
                       </div>
                     </li>
@@ -4007,7 +4007,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; Imperial
                       </div>
                     </li>
@@ -4015,7 +4015,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; 38th
                       </div>
                     </li>
@@ -4023,7 +4023,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; 42nd
                       </div>
                     </li>
@@ -4031,7 +4031,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; 44th
                       </div>
                     </li>
@@ -4039,7 +4039,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; 48th
                       </div>
                     </li>
@@ -4047,7 +4047,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; 50th
                       </div>
                     </li>
@@ -4055,7 +4055,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; Sacramento
                       </div>
                     </li>
@@ -4063,7 +4063,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Sandy &amp; 54th
                       </div>
                     </li>
@@ -5828,7 +5828,7 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -6879,7 +6879,7 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -8773,7 +8773,7 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Broadway &amp; 32nd
                       </div>
                     </li>
@@ -8781,7 +8781,7 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE 33rd &amp; Schuyler
                       </div>
                     </li>
@@ -8789,7 +8789,7 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE 33rd &amp; US Grant Pl
                       </div>
                     </li>
@@ -8797,7 +8797,7 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE 33rd &amp; Brazee
                       </div>
                     </li>
@@ -8805,7 +8805,7 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE 33rd &amp; Knott
                       </div>
                     </li>
@@ -8813,7 +8813,7 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE 33rd &amp; Stanton
                       </div>
                     </li>
@@ -8821,7 +8821,7 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE 33rd &amp; Siskiyou
                       </div>
                     </li>
@@ -8829,7 +8829,7 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE 33rd &amp; Alameda
                       </div>
                     </li>
@@ -10214,7 +10214,7 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Washington Park MAX Station
                       </div>
                     </li>
@@ -10222,7 +10222,7 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Goose Hollow/SW Jefferson St MAX Station
                       </div>
                     </li>
@@ -10230,7 +10230,7 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Kings Hill/SW Salmon St MAX Station
                       </div>
                     </li>
@@ -10238,7 +10238,7 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Providence Park MAX Station
                       </div>
                     </li>
@@ -10246,7 +10246,7 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Library/SW 9th Ave MAX Station
                       </div>
                     </li>
@@ -10254,7 +10254,7 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Pioneer Square South MAX Station
                       </div>
                     </li>
@@ -10262,7 +10262,7 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Mall/SW 4th Ave MAX Station
                       </div>
                     </li>
@@ -10270,7 +10270,7 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Yamhill District MAX Station
                       </div>
                     </li>
@@ -11433,7 +11433,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         South Mount Vernon Park &amp; Ride
                       </div>
                     </li>
@@ -11441,7 +11441,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Broadway - Everett Community College
                       </div>
                     </li>
@@ -11449,7 +11449,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Broadway &amp; 14th  (near hospital)
                       </div>
                     </li>
@@ -11457,7 +11457,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Broadway just South of the Event Center
                       </div>
                     </li>
@@ -11780,7 +11780,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Broadway &amp; 34th St
                       </div>
                     </li>
@@ -11788,7 +11788,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         South Everett Fwy Station Bay 3
                       </div>
                     </li>
@@ -11796,7 +11796,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Ash Way Park &amp; Ride Bay 1
                       </div>
                     </li>
@@ -12119,7 +12119,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Alderwood Mall Pkwy &amp; Beech Rd
                       </div>
                     </li>
@@ -12127,7 +12127,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Alderwood Mall Pkwy &amp; 184th St SW
                       </div>
                     </li>
@@ -12135,7 +12135,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Canyon Park Fwy Station Bay 4
                       </div>
                     </li>
@@ -12143,7 +12143,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Beardslee Blvd &amp; Ross Rd
                       </div>
                     </li>
@@ -12151,7 +12151,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         UW Bothell &amp; Cascadia College
                       </div>
                     </li>
@@ -12473,7 +12473,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Woodinville Dr &amp; Kaysner Way
                       </div>
                     </li>
@@ -12481,7 +12481,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Bothell Way NE &amp; NE 180th St
                       </div>
                     </li>
@@ -12489,7 +12489,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Bothell Way &amp; 96th Ave NE
                       </div>
                     </li>
@@ -12497,7 +12497,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Bothell Way &amp; 91st Ave NE
                       </div>
                     </li>
@@ -12505,7 +12505,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Bothell Way &amp; 83rd Pl NE
                       </div>
                     </li>
@@ -12513,7 +12513,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Bothell Way &amp; 80th Ave NE
                       </div>
                     </li>
@@ -12521,7 +12521,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Bothell Way &amp; 77th Ct NE
                       </div>
                     </li>
@@ -12529,7 +12529,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Bothell Way &amp; Kenmore Park &amp; Ride
                       </div>
                     </li>
@@ -12537,7 +12537,7 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         NE Bothell Way &amp; 68th Ave NE
                       </div>
                     </li>
@@ -13379,7 +13379,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         S Main St &amp; Ken Pratt Blvd
                       </div>
                     </li>
@@ -13387,7 +13387,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         S Main St &amp; Jersey Ave
                       </div>
                     </li>
@@ -13395,7 +13395,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         S Main St &amp; Missouri Ave
                       </div>
                     </li>
@@ -13403,7 +13403,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         S Main St &amp; Quebec Ave
                       </div>
                     </li>
@@ -13411,7 +13411,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         US 287 &amp; Pike Rd
                       </div>
                     </li>
@@ -13419,7 +13419,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         US 287 &amp; Niwot Rd
                       </div>
                     </li>
@@ -13427,7 +13427,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         US 287 &amp; Hwy 52
                       </div>
                     </li>
@@ -13435,7 +13435,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         US 287 &amp; Lookout Rd
                       </div>
                     </li>
@@ -13443,7 +13443,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         US 287 &amp; Dawson Dr
                       </div>
                     </li>
@@ -13451,7 +13451,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         US 287 &amp; Goose Haven Dr
                       </div>
                     </li>
@@ -13459,7 +13459,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         US 287 &amp; Isabelle Rd
                       </div>
                     </li>
@@ -13837,7 +13837,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Arapahoe Rd &amp; US 287
                       </div>
                     </li>
@@ -13845,7 +13845,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Arapahoe Rd &amp; 111th St
                       </div>
                     </li>
@@ -13853,7 +13853,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Arapahoe Rd &amp; Hawkridge Rd
                       </div>
                     </li>
@@ -13861,7 +13861,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         2800 Block 119th St
                       </div>
                     </li>
@@ -13869,7 +13869,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         119th St &amp; Austin Ave
                       </div>
                     </li>
@@ -13877,7 +13877,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Erie Pkwy &amp; Brennan St
                       </div>
                     </li>
@@ -13885,7 +13885,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Erie Pkwy &amp; Meller St
                       </div>
                     </li>
@@ -16214,7 +16214,7 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Washington Park MAX Station
                       </div>
                     </li>
@@ -16222,7 +16222,7 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Goose Hollow/SW Jefferson St MAX Station
                       </div>
                     </li>
@@ -16230,7 +16230,7 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Kings Hill/SW Salmon St MAX Station
                       </div>
                     </li>
@@ -16238,7 +16238,7 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Providence Park MAX Station
                       </div>
                     </li>
@@ -16246,7 +16246,7 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Library/SW 9th Ave MAX Station
                       </div>
                     </li>
@@ -16254,7 +16254,7 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Pioneer Square South MAX Station
                       </div>
                     </li>
@@ -16262,7 +16262,7 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Mall/SW 4th Ave MAX Station
                       </div>
                     </li>
@@ -16270,7 +16270,7 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Yamhill District MAX Station
                       </div>
                     </li>
@@ -17218,7 +17218,7 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -18131,7 +18131,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -19044,7 +19044,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -19957,7 +19957,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -20654,7 +20654,7 @@ exports[`ItineraryBody/otp-ui TncTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         W Burnside &amp; SW 2nd
                       </div>
                     </li>
@@ -20662,7 +20662,7 @@ exports[`ItineraryBody/otp-ui TncTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         E Burnside &amp; SE 8th
                       </div>
                     </li>
@@ -21580,7 +21580,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Philadelphia Airport Terminals E &amp; F
                       </div>
                     </li>
@@ -21588,7 +21588,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Bartram Av &amp; 90th St
                       </div>
                     </li>
@@ -21596,7 +21596,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         89th St &amp; Bartram Av - FS
                       </div>
                     </li>
@@ -21837,7 +21837,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Tinicum Blvd &amp; 88th St - FS
                       </div>
                     </li>
@@ -21845,7 +21845,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Tinicum Blvd &amp; 86th St - MBFS
                       </div>
                     </li>
@@ -21853,7 +21853,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Bartram Av &amp; 84th St - MBNS
                       </div>
                     </li>
@@ -21861,7 +21861,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Bartram Av &amp; 84th St - MBFS
                       </div>
                     </li>
@@ -21869,7 +21869,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Island Av &amp; Penrose Av - MBNS
                       </div>
                     </li>
@@ -21877,7 +21877,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Island Av &amp; Penrose Av - MBFS
                       </div>
                     </li>
@@ -21885,7 +21885,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Island Av &amp; Escort Av - MBNS
                       </div>
                     </li>
@@ -21893,7 +21893,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Island Av &amp; Escort Av
                       </div>
                     </li>
@@ -21901,7 +21901,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Island Av &amp; Escort Av - MBFS
                       </div>
                     </li>
@@ -21909,7 +21909,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Enterprise Av &amp; Executive Av
                       </div>
                     </li>
@@ -21917,7 +21917,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Executive Av &amp; Enterprise Av - FS
                       </div>
                     </li>
@@ -21925,7 +21925,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Executive Av &amp; Escort Av
                       </div>
                     </li>
@@ -21933,7 +21933,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Escort Av &amp; Island Av
                       </div>
                     </li>
@@ -21941,7 +21941,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Island Av &amp; Penrose Av - MBNS
                       </div>
                     </li>
@@ -21949,7 +21949,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Island Av &amp; Penrose Av - MBNS
                       </div>
                     </li>
@@ -21957,7 +21957,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Penrose Av &amp; 26th St - MBNS
                       </div>
                     </li>
@@ -21965,7 +21965,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Penrose &amp; Pattison Av - MBNS
                       </div>
                     </li>
@@ -21973,7 +21973,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Penrose &amp; Pattison Av - FS
                       </div>
                     </li>
@@ -21981,7 +21981,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Penrose Av &amp; 20th St
                       </div>
                     </li>
@@ -21989,7 +21989,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Penrose Av &amp; 20th St - FS
                       </div>
                     </li>
@@ -21997,7 +21997,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Moyamensing Av &amp; Pollock St
                       </div>
                     </li>
@@ -22005,7 +22005,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Moyamensing Av &amp; 18th St
                       </div>
                     </li>
@@ -22013,7 +22013,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Moyamensing Av &amp; 17th St
                       </div>
                     </li>
@@ -22021,7 +22021,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Moyamensing Av &amp; 16th St
                       </div>
                     </li>
@@ -22029,7 +22029,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Moyamensing Av &amp; 15th St
                       </div>
                     </li>
@@ -23682,7 +23682,7 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Washington Park MAX Station
                       </div>
                     </li>
@@ -23690,7 +23690,7 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Goose Hollow/SW Jefferson St MAX Station
                       </div>
                     </li>
@@ -23698,7 +23698,7 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Kings Hill/SW Salmon St MAX Station
                       </div>
                     </li>
@@ -23706,7 +23706,7 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Providence Park MAX Station
                       </div>
                     </li>
@@ -23714,7 +23714,7 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Library/SW 9th Ave MAX Station
                       </div>
                     </li>
@@ -23722,7 +23722,7 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Pioneer Square South MAX Station
                       </div>
                     </li>
@@ -23730,7 +23730,7 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Mall/SW 4th Ave MAX Station
                       </div>
                     </li>
@@ -23738,7 +23738,7 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Yamhill District MAX Station
                       </div>
                     </li>
@@ -25240,7 +25240,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Washington Park MAX Station
                       </div>
                     </li>
@@ -25248,7 +25248,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Goose Hollow/SW Jefferson St MAX Station
                       </div>
                     </li>
@@ -25256,7 +25256,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Kings Hill/SW Salmon St MAX Station
                       </div>
                     </li>
@@ -25264,7 +25264,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Providence Park MAX Station
                       </div>
                     </li>
@@ -25272,7 +25272,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Library/SW 9th Ave MAX Station
                       </div>
                     </li>
@@ -25280,7 +25280,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Pioneer Square South MAX Station
                       </div>
                     </li>
@@ -25288,7 +25288,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Mall/SW 4th Ave MAX Station
                       </div>
                     </li>
@@ -25296,7 +25296,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Yamhill District MAX Station
                       </div>
                     </li>
@@ -26777,7 +26777,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Washington Park MAX Station
                       </div>
                     </li>
@@ -26785,7 +26785,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Goose Hollow/SW Jefferson St MAX Station
                       </div>
                     </li>
@@ -26793,7 +26793,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Kings Hill/SW Salmon St MAX Station
                       </div>
                     </li>
@@ -26801,7 +26801,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Providence Park MAX Station
                       </div>
                     </li>
@@ -26809,7 +26809,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Library/SW 9th Ave MAX Station
                       </div>
                     </li>
@@ -26817,7 +26817,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Pioneer Square South MAX Station
                       </div>
                     </li>
@@ -26825,7 +26825,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Mall/SW 4th Ave MAX Station
                       </div>
                     </li>
@@ -26833,7 +26833,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Yamhill District MAX Station
                       </div>
                     </li>
@@ -27751,7 +27751,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Broadway &amp; 34th St
                       </div>
                     </li>
@@ -27759,7 +27759,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         South Everett Fwy Station Bay 3
                       </div>
                     </li>
@@ -27767,7 +27767,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Ash Way Park &amp; Ride Bay 1
                       </div>
                     </li>
@@ -27775,7 +27775,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Lynnwood Transit Center Bay D3
                       </div>
                     </li>
@@ -27783,7 +27783,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Mountlake Terrace Fwy Station Bay 6
                       </div>
                     </li>
@@ -28024,7 +28024,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         1st Ave NE &amp; NE 95th St
                       </div>
                     </li>
@@ -28032,7 +28032,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N 92nd St &amp; Corliss Ave N
                       </div>
                     </li>
@@ -28040,7 +28040,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         College Way N &amp; N 97th St
                       </div>
                     </li>
@@ -28048,7 +28048,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         College Way N &amp; N 103rd St
                       </div>
                     </li>
@@ -28056,7 +28056,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Meridian Ave N &amp; N 105th St
                       </div>
                     </li>
@@ -28064,7 +28064,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N Northgate Way &amp; Meridian Ave N
                       </div>
                     </li>
@@ -28072,7 +28072,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N Northgate Way &amp; Stone Ave N
                       </div>
                     </li>
@@ -28483,7 +28483,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 100th St
                       </div>
                     </li>
@@ -28491,7 +28491,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 95th St
                       </div>
                     </li>
@@ -28499,7 +28499,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 90th St
                       </div>
                     </li>
@@ -28507,7 +28507,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 85th St
                       </div>
                     </li>
@@ -28515,7 +28515,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 80th St
                       </div>
                     </li>
@@ -28523,7 +28523,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 76th St
                       </div>
                     </li>
@@ -28531,7 +28531,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 65th St
                       </div>
                     </li>
@@ -28539,7 +28539,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 46th St
                       </div>
                     </li>
@@ -28547,7 +28547,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Lynn St
                       </div>
                     </li>
@@ -28555,7 +28555,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Galer St
                       </div>
                     </li>
@@ -28563,7 +28563,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         7th Ave N &amp; Thomas St
                       </div>
                     </li>
@@ -28571,7 +28571,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Wall St &amp; 5th Ave
                       </div>
                     </li>
@@ -28579,7 +28579,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Bell St
                       </div>
                     </li>
@@ -28587,7 +28587,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Virginia St
                       </div>
                     </li>
@@ -28595,7 +28595,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Pike St
                       </div>
                     </li>
@@ -28603,7 +28603,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Seneca St
                       </div>
                     </li>
@@ -29531,7 +29531,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Cesar Chavez Blvd &amp; Clinton
                       </div>
                     </li>
@@ -29539,7 +29539,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Cesar Chavez Blvd &amp; Division
                       </div>
                     </li>
@@ -29547,7 +29547,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Cesar Chavez Blvd &amp; Lincoln
                       </div>
                     </li>
@@ -29555,7 +29555,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Cesar Chavez Blvd &amp; Stephens
                       </div>
                     </li>
@@ -29971,7 +29971,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Hawthorne &amp; 37th
                       </div>
                     </li>
@@ -29979,7 +29979,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Hawthorne &amp; 34th
                       </div>
                     </li>
@@ -29987,7 +29987,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Hawthorne &amp; 32nd
                       </div>
                     </li>
@@ -29995,7 +29995,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Hawthorne &amp; 30th
                       </div>
                     </li>
@@ -30754,7 +30754,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Cesar Chavez Blvd &amp; Clinton
                       </div>
                     </li>
@@ -30762,7 +30762,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Cesar Chavez Blvd &amp; Division
                       </div>
                     </li>
@@ -30770,7 +30770,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Cesar Chavez Blvd &amp; Lincoln
                       </div>
                     </li>
@@ -30778,7 +30778,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Cesar Chavez Blvd &amp; Stephens
                       </div>
                     </li>
@@ -31228,7 +31228,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Hawthorne &amp; 37th
                       </div>
                     </li>
@@ -31236,7 +31236,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Hawthorne &amp; 34th
                       </div>
                     </li>
@@ -31244,7 +31244,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Hawthorne &amp; 32nd
                       </div>
                     </li>
@@ -31252,7 +31252,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         SE Hawthorne &amp; 30th
                       </div>
                     </li>
@@ -32158,7 +32158,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -33082,7 +33082,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -33998,9 +33998,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk"
-                           style="color: rgb(191, 62, 58);"
-                      >
+                      <div class="styled__StopName-sc-1q8npbl-76 jlyFEH">
                         Galleria/SW 10th Ave MAX Station (Closed)
                       </div>
                     </li>
@@ -34916,7 +34914,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -35848,7 +35846,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -36752,7 +36750,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameCompone
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -37661,7 +37659,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -38578,7 +38576,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -39491,7 +39489,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Galleria/SW 10th Ave MAX Station
                       </div>
                     </li>
@@ -40377,7 +40375,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Broadway &amp; 34th St
                       </div>
                     </li>
@@ -40385,7 +40383,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         South Everett Fwy Station Bay 3
                       </div>
                     </li>
@@ -40393,7 +40391,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Ash Way Park &amp; Ride Bay 1
                       </div>
                     </li>
@@ -40401,7 +40399,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Lynnwood Transit Center Bay D3
                       </div>
                     </li>
@@ -40409,7 +40407,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Mountlake Terrace Fwy Station Bay 6
                       </div>
                     </li>
@@ -40650,7 +40648,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         1st Ave NE &amp; NE 95th St
                       </div>
                     </li>
@@ -40658,7 +40656,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N 92nd St &amp; Corliss Ave N
                       </div>
                     </li>
@@ -40666,7 +40664,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         College Way N &amp; N 97th St
                       </div>
                     </li>
@@ -40674,7 +40672,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         College Way N &amp; N 103rd St
                       </div>
                     </li>
@@ -40682,7 +40680,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Meridian Ave N &amp; N 105th St
                       </div>
                     </li>
@@ -40690,7 +40688,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N Northgate Way &amp; Meridian Ave N
                       </div>
                     </li>
@@ -40698,7 +40696,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N Northgate Way &amp; Stone Ave N
                       </div>
                     </li>
@@ -41109,7 +41107,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 100th St
                       </div>
                     </li>
@@ -41117,7 +41115,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 95th St
                       </div>
                     </li>
@@ -41125,7 +41123,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 90th St
                       </div>
                     </li>
@@ -41133,7 +41131,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 85th St
                       </div>
                     </li>
@@ -41141,7 +41139,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 80th St
                       </div>
                     </li>
@@ -41149,7 +41147,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 76th St
                       </div>
                     </li>
@@ -41157,7 +41155,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 65th St
                       </div>
                     </li>
@@ -41165,7 +41163,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 46th St
                       </div>
                     </li>
@@ -41173,7 +41171,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Lynn St
                       </div>
                     </li>
@@ -41181,7 +41179,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Galer St
                       </div>
                     </li>
@@ -41189,7 +41187,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         7th Ave N &amp; Thomas St
                       </div>
                     </li>
@@ -41197,7 +41195,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Wall St &amp; 5th Ave
                       </div>
                     </li>
@@ -41205,7 +41203,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Bell St
                       </div>
                     </li>
@@ -41213,7 +41211,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Virginia St
                       </div>
                     </li>
@@ -41221,7 +41219,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Pike St
                       </div>
                     </li>
@@ -41229,7 +41227,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Seneca St
                       </div>
                     </li>
@@ -42033,7 +42031,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Broadway &amp; 34th St
                       </div>
                     </li>
@@ -42041,7 +42039,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         South Everett Fwy Station Bay 3
                       </div>
                     </li>
@@ -42049,7 +42047,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Ash Way Park &amp; Ride Bay 1
                       </div>
                     </li>
@@ -42057,7 +42055,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Lynnwood Transit Center Bay D3
                       </div>
                     </li>
@@ -42065,7 +42063,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Mountlake Terrace Fwy Station Bay 6
                       </div>
                     </li>
@@ -42306,7 +42304,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         1st Ave NE &amp; NE 95th St
                       </div>
                     </li>
@@ -42314,7 +42312,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N 92nd St &amp; Corliss Ave N
                       </div>
                     </li>
@@ -42322,7 +42320,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         College Way N &amp; N 97th St
                       </div>
                     </li>
@@ -42330,7 +42328,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         College Way N &amp; N 103rd St
                       </div>
                     </li>
@@ -42338,7 +42336,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Meridian Ave N &amp; N 105th St
                       </div>
                     </li>
@@ -42346,7 +42344,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N Northgate Way &amp; Meridian Ave N
                       </div>
                     </li>
@@ -42354,7 +42352,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N Northgate Way &amp; Stone Ave N
                       </div>
                     </li>
@@ -42765,7 +42763,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 100th St
                       </div>
                     </li>
@@ -42773,7 +42771,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 95th St
                       </div>
                     </li>
@@ -42781,7 +42779,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 90th St
                       </div>
                     </li>
@@ -42789,7 +42787,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 85th St
                       </div>
                     </li>
@@ -42797,7 +42795,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 80th St
                       </div>
                     </li>
@@ -42805,7 +42803,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 76th St
                       </div>
                     </li>
@@ -42813,7 +42811,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 65th St
                       </div>
                     </li>
@@ -42821,7 +42819,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 46th St
                       </div>
                     </li>
@@ -42829,7 +42827,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Lynn St
                       </div>
                     </li>
@@ -42837,7 +42835,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Galer St
                       </div>
                     </li>
@@ -42845,7 +42843,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         7th Ave N &amp; Thomas St
                       </div>
                     </li>
@@ -42853,7 +42851,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Wall St &amp; 5th Ave
                       </div>
                     </li>
@@ -42861,7 +42859,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Bell St
                       </div>
                     </li>
@@ -42869,7 +42867,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Virginia St
                       </div>
                     </li>
@@ -42877,7 +42875,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Pike St
                       </div>
                     </li>
@@ -42885,7 +42883,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Seneca St
                       </div>
                     </li>
@@ -43689,7 +43687,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Broadway &amp; 34th St
                       </div>
                     </li>
@@ -43697,7 +43695,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         South Everett Fwy Station Bay 3
                       </div>
                     </li>
@@ -43705,7 +43703,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Ash Way Park &amp; Ride Bay 1
                       </div>
                     </li>
@@ -43713,7 +43711,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Lynnwood Transit Center Bay D3
                       </div>
                     </li>
@@ -43721,7 +43719,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Mountlake Terrace Fwy Station Bay 6
                       </div>
                     </li>
@@ -43962,7 +43960,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         1st Ave NE &amp; NE 95th St
                       </div>
                     </li>
@@ -43970,7 +43968,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N 92nd St &amp; Corliss Ave N
                       </div>
                     </li>
@@ -43978,7 +43976,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         College Way N &amp; N 97th St
                       </div>
                     </li>
@@ -43986,7 +43984,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         College Way N &amp; N 103rd St
                       </div>
                     </li>
@@ -43994,7 +43992,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Meridian Ave N &amp; N 105th St
                       </div>
                     </li>
@@ -44002,7 +44000,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N Northgate Way &amp; Meridian Ave N
                       </div>
                     </li>
@@ -44010,7 +44008,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         N Northgate Way &amp; Stone Ave N
                       </div>
                     </li>
@@ -44421,7 +44419,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 100th St
                       </div>
                     </li>
@@ -44429,7 +44427,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 95th St
                       </div>
                     </li>
@@ -44437,7 +44435,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 90th St
                       </div>
                     </li>
@@ -44445,7 +44443,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 85th St
                       </div>
                     </li>
@@ -44453,7 +44451,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 80th St
                       </div>
                     </li>
@@ -44461,7 +44459,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 76th St
                       </div>
                     </li>
@@ -44469,7 +44467,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 65th St
                       </div>
                     </li>
@@ -44477,7 +44475,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; N 46th St
                       </div>
                     </li>
@@ -44485,7 +44483,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Lynn St
                       </div>
                     </li>
@@ -44493,7 +44491,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Aurora Ave N &amp; Galer St
                       </div>
                     </li>
@@ -44501,7 +44499,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         7th Ave N &amp; Thomas St
                       </div>
                     </li>
@@ -44509,7 +44507,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         Wall St &amp; 5th Ave
                       </div>
                     </li>
@@ -44517,7 +44515,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Bell St
                       </div>
                     </li>
@@ -44525,7 +44523,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Virginia St
                       </div>
                     </li>
@@ -44533,7 +44531,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Pike St
                       </div>
                     </li>
@@ -44541,7 +44539,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                       <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk">
+                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
                         3rd Ave &amp; Seneca St
                       </div>
                     </li>

--- a/packages/itinerary-body/src/stories/__snapshots__/OtpUiItineraryBody.story.tsx.snap
+++ b/packages/itinerary-body/src/stories/__snapshots__/OtpUiItineraryBody.story.tsx.snap
@@ -1057,8 +1057,6 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Washington Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -1069,8 +1067,6 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Goose Hollow/SW Jefferson St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -1081,8 +1077,6 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Kings Hill/SW Salmon St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -1093,8 +1087,6 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Providence Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -1105,8 +1097,6 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Library/SW 9th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -1117,8 +1107,6 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Pioneer Square South MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -1129,8 +1117,6 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Mall/SW 4th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -1141,8 +1127,6 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Yamhill District MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -4011,8 +3995,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; Lawrence
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4023,8 +4005,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; 28th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4035,8 +4015,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; 31st
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4047,8 +4025,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; 33rd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4059,8 +4035,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; Imperial
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4071,8 +4045,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; 38th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4083,8 +4055,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; 42nd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4095,8 +4065,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; 44th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4107,8 +4075,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; 48th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4119,8 +4085,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; 50th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4131,8 +4095,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; Sacramento
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -4143,8 +4105,6 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Sandy &amp; 54th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -5912,8 +5872,6 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -6967,8 +6925,6 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -8865,8 +8821,6 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Broadway &amp; 32nd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -8877,8 +8831,6 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE 33rd &amp; Schuyler
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -8889,8 +8841,6 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE 33rd &amp; US Grant Pl
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -8901,8 +8851,6 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE 33rd &amp; Brazee
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -8913,8 +8861,6 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE 33rd &amp; Knott
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -8925,8 +8871,6 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE 33rd &amp; Stanton
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -8937,8 +8881,6 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE 33rd &amp; Siskiyou
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -8949,8 +8891,6 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE 33rd &amp; Alameda
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -10338,8 +10278,6 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Washington Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -10350,8 +10288,6 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Goose Hollow/SW Jefferson St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -10362,8 +10298,6 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Kings Hill/SW Salmon St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -10374,8 +10308,6 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Providence Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -10386,8 +10318,6 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Library/SW 9th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -10398,8 +10328,6 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Pioneer Square South MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -10410,8 +10338,6 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Mall/SW 4th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -10422,8 +10348,6 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Yamhill District MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -11589,8 +11513,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           South Mount Vernon Park &amp; Ride
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -11601,8 +11523,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Broadway - Everett Community College
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -11613,8 +11533,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Broadway &amp; 14th  (near hospital)
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -11625,8 +11543,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Broadway just South of the Event Center
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -11952,8 +11868,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Broadway &amp; 34th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -11964,8 +11878,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           South Everett Fwy Station Bay 3
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -11976,8 +11888,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Ash Way Park &amp; Ride Bay 1
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -12303,8 +12213,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Alderwood Mall Pkwy &amp; Beech Rd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -12315,8 +12223,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Alderwood Mall Pkwy &amp; 184th St SW
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -12327,8 +12233,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Canyon Park Fwy Station Bay 4
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -12339,8 +12243,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Beardslee Blvd &amp; Ross Rd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -12351,8 +12253,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           UW Bothell &amp; Cascadia College
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -12677,8 +12577,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Woodinville Dr &amp; Kaysner Way
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -12689,8 +12587,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Bothell Way NE &amp; NE 180th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -12701,8 +12597,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Bothell Way &amp; 96th Ave NE
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -12713,8 +12607,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Bothell Way &amp; 91st Ave NE
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -12725,8 +12617,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Bothell Way &amp; 83rd Pl NE
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -12737,8 +12627,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Bothell Way &amp; 80th Ave NE
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -12749,8 +12637,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Bothell Way &amp; 77th Ct NE
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -12761,8 +12647,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Bothell Way &amp; Kenmore Park &amp; Ride
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -12773,8 +12657,6 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           NE Bothell Way &amp; 68th Ave NE
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -13619,8 +13501,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           S Main St &amp; Ken Pratt Blvd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -13631,8 +13511,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           S Main St &amp; Jersey Ave
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -13643,8 +13521,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           S Main St &amp; Missouri Ave
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -13655,8 +13531,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           S Main St &amp; Quebec Ave
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -13667,8 +13541,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           US 287 &amp; Pike Rd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -13679,8 +13551,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           US 287 &amp; Niwot Rd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -13691,8 +13561,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           US 287 &amp; Hwy 52
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -13703,8 +13571,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           US 287 &amp; Lookout Rd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -13715,8 +13581,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           US 287 &amp; Dawson Dr
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -13727,8 +13591,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           US 287 &amp; Goose Haven Dr
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -13739,8 +13601,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           US 287 &amp; Isabelle Rd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -14121,8 +13981,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Arapahoe Rd &amp; US 287
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14133,8 +13991,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Arapahoe Rd &amp; 111th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14145,8 +14001,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Arapahoe Rd &amp; Hawkridge Rd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14157,8 +14011,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           2800 Block 119th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14169,8 +14021,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           119th St &amp; Austin Ave
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14181,8 +14031,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Erie Pkwy &amp; Brennan St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -14193,8 +14041,6 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Erie Pkwy &amp; Meller St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -16526,8 +16372,6 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Washington Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -16538,8 +16382,6 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Goose Hollow/SW Jefferson St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -16550,8 +16392,6 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Kings Hill/SW Salmon St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -16562,8 +16402,6 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Providence Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -16574,8 +16412,6 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Library/SW 9th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -16586,8 +16422,6 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Pioneer Square South MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -16598,8 +16432,6 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Mall/SW 4th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -16610,8 +16442,6 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Yamhill District MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -17562,8 +17392,6 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -18479,8 +18307,6 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -19396,8 +19222,6 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -20313,8 +20137,6 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -21014,8 +20836,6 @@ exports[`ItineraryBody/otp-ui TncTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           W Burnside &amp; SW 2nd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -21026,8 +20846,6 @@ exports[`ItineraryBody/otp-ui TncTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           E Burnside &amp; SE 8th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -21948,8 +21766,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Philadelphia Airport Terminals E &amp; F
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -21960,8 +21776,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Bartram Av &amp; 90th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -21972,8 +21786,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           89th St &amp; Bartram Av - FS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -22217,8 +22029,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Tinicum Blvd &amp; 88th St - FS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22229,8 +22039,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Tinicum Blvd &amp; 86th St - MBFS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22241,8 +22049,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Bartram Av &amp; 84th St - MBNS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22253,8 +22059,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Bartram Av &amp; 84th St - MBFS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22265,8 +22069,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Island Av &amp; Penrose Av - MBNS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22277,8 +22079,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Island Av &amp; Penrose Av - MBFS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22289,8 +22089,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Island Av &amp; Escort Av - MBNS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22301,8 +22099,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Island Av &amp; Escort Av
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22313,8 +22109,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Island Av &amp; Escort Av - MBFS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22325,8 +22119,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Enterprise Av &amp; Executive Av
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22337,8 +22129,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Executive Av &amp; Enterprise Av - FS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22349,8 +22139,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Executive Av &amp; Escort Av
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22361,8 +22149,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Escort Av &amp; Island Av
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22373,8 +22159,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Island Av &amp; Penrose Av - MBNS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22385,8 +22169,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Island Av &amp; Penrose Av - MBNS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22397,8 +22179,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Penrose Av &amp; 26th St - MBNS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22409,8 +22189,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Penrose &amp; Pattison Av - MBNS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22421,8 +22199,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Penrose &amp; Pattison Av - FS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22433,8 +22209,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Penrose Av &amp; 20th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22445,8 +22219,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Penrose Av &amp; 20th St - FS
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22457,8 +22229,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Moyamensing Av &amp; Pollock St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22469,8 +22239,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Moyamensing Av &amp; 18th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22481,8 +22249,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Moyamensing Av &amp; 17th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22493,8 +22259,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Moyamensing Av &amp; 16th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -22505,8 +22269,6 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Moyamensing Av &amp; 15th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -24162,8 +23924,6 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Washington Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -24174,8 +23934,6 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Goose Hollow/SW Jefferson St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -24186,8 +23944,6 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Kings Hill/SW Salmon St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -24198,8 +23954,6 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Providence Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -24210,8 +23964,6 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Library/SW 9th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -24222,8 +23974,6 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Pioneer Square South MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -24234,8 +23984,6 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Mall/SW 4th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -24246,8 +23994,6 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Yamhill District MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -25752,8 +25498,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Washington Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25764,8 +25508,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Goose Hollow/SW Jefferson St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25776,8 +25518,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Kings Hill/SW Salmon St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25788,8 +25528,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Providence Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25800,8 +25538,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Library/SW 9th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25812,8 +25548,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Pioneer Square South MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25824,8 +25558,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Mall/SW 4th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -25836,8 +25568,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Yamhill District MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -27321,8 +27051,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Washington Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -27333,8 +27061,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Goose Hollow/SW Jefferson St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -27345,8 +27071,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Kings Hill/SW Salmon St MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -27357,8 +27081,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Providence Park MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -27369,8 +27091,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Library/SW 9th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -27381,8 +27101,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Pioneer Square South MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -27393,8 +27111,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Mall/SW 4th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -27405,8 +27121,6 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Yamhill District MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -28327,8 +28041,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Broadway &amp; 34th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -28339,8 +28051,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           South Everett Fwy Station Bay 3
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -28351,8 +28061,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Ash Way Park &amp; Ride Bay 1
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -28363,8 +28071,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Lynnwood Transit Center Bay D3
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -28375,8 +28081,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Mountlake Terrace Fwy Station Bay 6
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -28620,8 +28324,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           1st Ave NE &amp; NE 95th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -28632,8 +28334,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N 92nd St &amp; Corliss Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -28644,8 +28344,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           College Way N &amp; N 97th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -28656,8 +28354,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           College Way N &amp; N 103rd St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -28668,8 +28364,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Meridian Ave N &amp; N 105th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -28680,8 +28374,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N Northgate Way &amp; Meridian Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -28692,8 +28384,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N Northgate Way &amp; Stone Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -29107,8 +28797,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 100th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29119,8 +28807,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 95th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29131,8 +28817,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 90th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29143,8 +28827,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 85th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29155,8 +28837,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 80th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29167,8 +28847,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 76th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29179,8 +28857,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 65th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29191,8 +28867,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 46th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29203,8 +28877,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Lynn St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29215,8 +28887,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Galer St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29227,8 +28897,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           7th Ave N &amp; Thomas St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29239,8 +28907,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Wall St &amp; 5th Ave
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29251,8 +28917,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Bell St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29263,8 +28927,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Virginia St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29275,8 +28937,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Pike St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -29287,8 +28947,6 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Seneca St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -30219,8 +29877,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Cesar Chavez Blvd &amp; Clinton
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -30231,8 +29887,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Cesar Chavez Blvd &amp; Division
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -30243,8 +29897,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Cesar Chavez Blvd &amp; Lincoln
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -30255,8 +29907,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Cesar Chavez Blvd &amp; Stephens
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -30675,8 +30325,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Hawthorne &amp; 37th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -30687,8 +30335,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Hawthorne &amp; 34th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -30699,8 +30345,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Hawthorne &amp; 32nd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -30711,8 +30355,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Hawthorne &amp; 30th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -31474,8 +31116,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Cesar Chavez Blvd &amp; Clinton
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -31486,8 +31126,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Cesar Chavez Blvd &amp; Division
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -31498,8 +31136,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Cesar Chavez Blvd &amp; Lincoln
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -31510,8 +31146,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Cesar Chavez Blvd &amp; Stephens
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -31964,8 +31598,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Hawthorne &amp; 37th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -31976,8 +31608,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Hawthorne &amp; 34th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -31988,8 +31618,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Hawthorne &amp; 32nd
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -32000,8 +31628,6 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           SE Hawthorne &amp; 30th
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -32910,8 +32536,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -33838,8 +33462,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -34759,7 +34381,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
                           Galleria/SW 10th Ave MAX Station
                         </div>
                         <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                          (Closed)
+                          Closed
                         </span>
                       </div>
                     </li>
@@ -35679,8 +35301,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -36615,8 +36235,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -37523,8 +37141,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameCompone
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -38436,8 +38052,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -39357,8 +38971,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -40274,8 +39886,6 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Galleria/SW 10th Ave MAX Station
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -41164,8 +40774,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Broadway &amp; 34th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41176,8 +40784,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           South Everett Fwy Station Bay 3
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41188,8 +40794,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Ash Way Park &amp; Ride Bay 1
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41200,8 +40804,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Lynnwood Transit Center Bay D3
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41212,8 +40814,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Mountlake Terrace Fwy Station Bay 6
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -41457,8 +41057,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           1st Ave NE &amp; NE 95th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41469,8 +41067,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N 92nd St &amp; Corliss Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41481,8 +41077,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           College Way N &amp; N 97th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41493,8 +41087,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           College Way N &amp; N 103rd St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41505,8 +41097,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Meridian Ave N &amp; N 105th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41517,8 +41107,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N Northgate Way &amp; Meridian Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41529,8 +41117,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N Northgate Way &amp; Stone Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -41944,8 +41530,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 100th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41956,8 +41540,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 95th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41968,8 +41550,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 90th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41980,8 +41560,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 85th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -41992,8 +41570,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 80th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42004,8 +41580,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 76th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42016,8 +41590,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 65th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42028,8 +41600,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 46th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42040,8 +41610,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Lynn St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42052,8 +41620,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Galer St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42064,8 +41630,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           7th Ave N &amp; Thomas St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42076,8 +41640,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Wall St &amp; 5th Ave
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42088,8 +41650,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Bell St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42100,8 +41660,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Virginia St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42112,8 +41670,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Pike St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42124,8 +41680,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Seneca St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -42932,8 +42486,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Broadway &amp; 34th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42944,8 +42496,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           South Everett Fwy Station Bay 3
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42956,8 +42506,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Ash Way Park &amp; Ride Bay 1
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42968,8 +42516,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Lynnwood Transit Center Bay D3
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -42980,8 +42526,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Mountlake Terrace Fwy Station Bay 6
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -43225,8 +42769,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           1st Ave NE &amp; NE 95th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43237,8 +42779,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N 92nd St &amp; Corliss Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43249,8 +42789,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           College Way N &amp; N 97th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43261,8 +42799,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           College Way N &amp; N 103rd St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43273,8 +42809,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Meridian Ave N &amp; N 105th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43285,8 +42819,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N Northgate Way &amp; Meridian Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43297,8 +42829,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N Northgate Way &amp; Stone Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -43712,8 +43242,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 100th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43724,8 +43252,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 95th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43736,8 +43262,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 90th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43748,8 +43272,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 85th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43760,8 +43282,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 80th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43772,8 +43292,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 76th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43784,8 +43302,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 65th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43796,8 +43312,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 46th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43808,8 +43322,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Lynn St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43820,8 +43332,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Galer St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43832,8 +43342,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           7th Ave N &amp; Thomas St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43844,8 +43352,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Wall St &amp; 5th Ave
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43856,8 +43362,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Bell St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43868,8 +43372,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Virginia St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43880,8 +43382,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Pike St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -43892,8 +43392,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Seneca St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -44700,8 +44198,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Broadway &amp; 34th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -44712,8 +44208,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           South Everett Fwy Station Bay 3
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -44724,8 +44218,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Ash Way Park &amp; Ride Bay 1
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -44736,8 +44228,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Lynnwood Transit Center Bay D3
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -44748,8 +44238,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Mountlake Terrace Fwy Station Bay 6
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -44993,8 +44481,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           1st Ave NE &amp; NE 95th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45005,8 +44491,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N 92nd St &amp; Corliss Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45017,8 +44501,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           College Way N &amp; N 97th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45029,8 +44511,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           College Way N &amp; N 103rd St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45041,8 +44521,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Meridian Ave N &amp; N 105th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45053,8 +44531,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N Northgate Way &amp; Meridian Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45065,8 +44541,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           N Northgate Way &amp; Stone Ave N
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>
@@ -45480,8 +44954,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 100th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45492,8 +44964,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 95th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45504,8 +44974,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 90th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45516,8 +44984,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 85th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45528,8 +44994,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 80th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45540,8 +45004,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 76th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45552,8 +45014,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 65th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45564,8 +45024,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; N 46th St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45576,8 +45034,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Lynn St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45588,8 +45044,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Aurora Ave N &amp; Galer St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45600,8 +45054,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           7th Ave N &amp; Thomas St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45612,8 +45064,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           Wall St &amp; 5th Ave
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45624,8 +45074,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Bell St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45636,8 +45084,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Virginia St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45648,8 +45094,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Pike St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                     <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
@@ -45660,8 +45104,6 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                         <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
                           3rd Ave &amp; Seneca St
                         </div>
-                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
-                        </span>
                       </div>
                     </li>
                   </ol>

--- a/packages/itinerary-body/src/stories/__snapshots__/OtpUiItineraryBody.story.tsx.snap
+++ b/packages/itinerary-body/src/stories/__snapshots__/OtpUiItineraryBody.story.tsx.snap
@@ -843,7 +843,7 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Sunset TC MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9969
         </span>
       </span>
@@ -853,7 +853,7 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Sunset TC MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9969
       </span>
     </span>
@@ -883,7 +883,7 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Oak/ SW 1st Ave MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 8337
                 </span>
               </span>
@@ -899,7 +899,7 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__TransitAlertDiv-sc-1q8npbl-86 dNKGjA alert-toggle">
+          <div class="styled__TransitAlertDiv-sc-1q8npbl-88 bJSHRu alert-toggle">
             <svg viewbox="0 0 512 512"
                  height="15"
                  width="15"
@@ -907,7 +907,7 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -921,9 +921,9 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -931,7 +931,7 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -939,14 +939,14 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -968,8 +968,8 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -977,7 +977,7 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -985,14 +985,14 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -1017,9 +1017,9 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 21 min / 9 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -1047,70 +1047,102 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Washington Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Washington Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Goose Hollow/SW Jefferson St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Goose Hollow/SW Jefferson St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Kings Hill/SW Salmon St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Kings Hill/SW Salmon St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Providence Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Providence Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Library/SW 9th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Library/SW 9th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Pioneer Square South MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Pioneer Square South MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Mall/SW 4th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Mall/SW 4th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Yamhill District MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Yamhill District MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -1172,7 +1204,7 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Oak/ SW 1st Ave MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8337
         </span>
       </span>
@@ -1182,7 +1214,7 @@ exports[`ItineraryBody/otp-ui ApproximatePrefixItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Oak/ SW 1st Ave MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8337
       </span>
     </span>
@@ -3765,7 +3797,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         NE Sandy &amp; 24th
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 5066
         </span>
       </span>
@@ -3775,7 +3807,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from NE Sandy &amp; 24th
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 5066
       </span>
     </span>
@@ -3805,7 +3837,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at NE Sandy &amp; 57th
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 5104
                 </span>
               </span>
@@ -3821,7 +3853,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__TransitAlertDiv-sc-1q8npbl-86 dNKGjA alert-toggle">
+          <div class="styled__TransitAlertDiv-sc-1q8npbl-88 bJSHRu alert-toggle">
             <svg viewbox="0 0 512 512"
                  height="15"
                  width="15"
@@ -3829,7 +3861,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -3843,9 +3875,9 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -3853,7 +3885,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -3861,14 +3893,14 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     For trips to Tigard Transit Center, no service to the stop at NE Sandy &amp; 91st (Stop ID 5145) due to PBOT sidewalk construction. Use temporary stop on the west side of 91st.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of July 31, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -3890,8 +3922,8 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -3899,7 +3931,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -3907,14 +3939,14 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     For trips to Parkrose/Sumner Transit Center, no service to the stop at NE Sandy &amp; 47th (Stop ID 5094) due to long-term construction. Use the temporary stop located at NE Sandy &amp; 48th (Stop ID 14073).
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of July 12, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -3939,9 +3971,9 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 12 min / 13 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -3969,102 +4001,150 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; Lawrence
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; Lawrence
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; 28th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; 28th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; 31st
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; 31st
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; 33rd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; 33rd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; Imperial
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; Imperial
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; 38th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; 38th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; 42nd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; 42nd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; 44th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; 44th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; 48th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; 48th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; 50th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; 50th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; Sacramento
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; Sacramento
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Sandy &amp; 54th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Sandy &amp; 54th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -4126,7 +4206,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         NE Sandy &amp; 57th
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 5104
         </span>
       </span>
@@ -4136,7 +4216,7 @@ exports[`ItineraryBody/otp-ui BikeRentalTransitItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from NE Sandy &amp; 57th
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 5104
       </span>
     </span>
@@ -5618,7 +5698,7 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Pioneer Square North MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8383
         </span>
       </span>
@@ -5628,7 +5708,7 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Pioneer Square North MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8383
       </span>
     </span>
@@ -5658,7 +5738,7 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Providence Park MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 9757
                 </span>
               </span>
@@ -5674,7 +5754,7 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__TransitAlertDiv-sc-1q8npbl-86 dNKGjA alert-toggle">
+          <div class="styled__TransitAlertDiv-sc-1q8npbl-88 bJSHRu alert-toggle">
             <svg viewbox="0 0 512 512"
                  height="15"
                  width="15"
@@ -5682,7 +5762,7 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -5696,9 +5776,9 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -5706,7 +5786,7 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -5714,14 +5794,14 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -5743,8 +5823,8 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -5752,7 +5832,7 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -5760,14 +5840,14 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -5792,9 +5872,9 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -5822,14 +5902,18 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -5891,7 +5975,7 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Providence Park MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9757
         </span>
       </span>
@@ -5901,7 +5985,7 @@ exports[`ItineraryBody/otp-ui BikeTransitBikeItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Providence Park MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9757
       </span>
     </span>
@@ -6602,7 +6686,7 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Pioneer Square North MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8383
         </span>
       </span>
@@ -6612,7 +6696,7 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Pioneer Square North MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8383
       </span>
     </span>
@@ -6642,7 +6726,7 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Providence Park MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 9757
                 </span>
               </span>
@@ -6659,7 +6743,7 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
              role="group"
         >
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 448 512"
                  height="15"
@@ -6701,9 +6785,9 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -6719,14 +6803,14 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -6748,8 +6832,8 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -6765,14 +6849,14 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -6794,8 +6878,8 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -6811,14 +6895,14 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -6843,9 +6927,9 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -6873,14 +6957,18 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -6945,7 +7033,7 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Providence Park MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9757
         </span>
       </span>
@@ -6955,7 +7043,7 @@ exports[`ItineraryBody/otp-ui CustomAlertIconsItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Providence Park MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9757
       </span>
     </span>
@@ -8674,7 +8762,7 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         NE Broadway &amp; 28th
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 638
         </span>
       </span>
@@ -8684,7 +8772,7 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from NE Broadway &amp; 28th
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 638
       </span>
     </span>
@@ -8714,7 +8802,7 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at NE 33rd &amp; Shaver
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 7393
                 </span>
               </span>
@@ -8737,9 +8825,9 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 8 min / 9 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -8767,70 +8855,102 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Broadway &amp; 32nd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Broadway &amp; 32nd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE 33rd &amp; Schuyler
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE 33rd &amp; Schuyler
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE 33rd &amp; US Grant Pl
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE 33rd &amp; US Grant Pl
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE 33rd &amp; Brazee
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE 33rd &amp; Brazee
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE 33rd &amp; Knott
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE 33rd &amp; Knott
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE 33rd &amp; Stanton
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE 33rd &amp; Stanton
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE 33rd &amp; Siskiyou
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE 33rd &amp; Siskiyou
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE 33rd &amp; Alameda
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE 33rd &amp; Alameda
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -8892,7 +9012,7 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         NE 33rd &amp; Shaver
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 7393
         </span>
       </span>
@@ -8902,7 +9022,7 @@ exports[`ItineraryBody/otp-ui EScooterRentalTransitItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from NE 33rd &amp; Shaver
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 7393
       </span>
     </span>
@@ -10004,7 +10124,7 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Sunset TC MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9969
         </span>
       </span>
@@ -10014,7 +10134,7 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Sunset TC MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9969
       </span>
     </span>
@@ -10044,7 +10164,7 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Oak/ SW 1st Ave MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 8337
                 </span>
               </span>
@@ -10060,7 +10180,7 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__TransitAlertDiv-sc-1q8npbl-86 dNKGjA alert-toggle">
+          <div class="styled__TransitAlertDiv-sc-1q8npbl-88 bJSHRu alert-toggle">
             <svg viewbox="0 0 512 512"
                  height="15"
                  width="15"
@@ -10068,7 +10188,7 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -10082,9 +10202,9 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -10092,7 +10212,7 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -10100,14 +10220,14 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -10129,8 +10249,8 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -10138,7 +10258,7 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -10146,14 +10266,14 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -10178,9 +10298,9 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 21 min / 9 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -10208,70 +10328,102 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Washington Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Washington Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Goose Hollow/SW Jefferson St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Goose Hollow/SW Jefferson St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Kings Hill/SW Salmon St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Kings Hill/SW Salmon St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Providence Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Providence Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Library/SW 9th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Library/SW 9th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Pioneer Square South MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Pioneer Square South MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Mall/SW 4th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Mall/SW 4th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Yamhill District MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Yamhill District MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -10333,7 +10485,7 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Oak/ SW 1st Ave MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8337
         </span>
       </span>
@@ -10343,7 +10495,7 @@ exports[`ItineraryBody/otp-ui HideDrivingDirections smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Oak/ SW 1st Ave MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8337
       </span>
     </span>
@@ -11393,13 +11545,13 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 1 hr 0 min / 5 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -11427,38 +11579,54 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        South Mount Vernon Park &amp; Ride
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          South Mount Vernon Park &amp; Ride
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Broadway - Everett Community College
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Broadway - Everett Community College
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Broadway &amp; 14th  (near hospital)
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Broadway &amp; 14th  (near hospital)
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Broadway just South of the Event Center
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Broadway just South of the Event Center
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -11740,13 +11908,13 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 26 min / 4 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -11774,30 +11942,42 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Broadway &amp; 34th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Broadway &amp; 34th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        South Everett Fwy Station Bay 3
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          South Everett Fwy Station Bay 3
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Ash Way Park &amp; Ride Bay 1
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Ash Way Park &amp; Ride Bay 1
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -12079,13 +12259,13 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 25 min / 6 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -12113,46 +12293,66 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Alderwood Mall Pkwy &amp; Beech Rd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Alderwood Mall Pkwy &amp; Beech Rd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Alderwood Mall Pkwy &amp; 184th St SW
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Alderwood Mall Pkwy &amp; 184th St SW
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Canyon Park Fwy Station Bay 4
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Canyon Park Fwy Station Bay 4
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Beardslee Blvd &amp; Ross Rd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Beardslee Blvd &amp; Ross Rd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        UW Bothell &amp; Cascadia College
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          UW Bothell &amp; Cascadia College
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -12433,13 +12633,13 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 11 min / 10 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -12467,78 +12667,114 @@ exports[`ItineraryBody/otp-ui IndividualLegFareComponents smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Woodinville Dr &amp; Kaysner Way
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Woodinville Dr &amp; Kaysner Way
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Bothell Way NE &amp; NE 180th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Bothell Way NE &amp; NE 180th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Bothell Way &amp; 96th Ave NE
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Bothell Way &amp; 96th Ave NE
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Bothell Way &amp; 91st Ave NE
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Bothell Way &amp; 91st Ave NE
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Bothell Way &amp; 83rd Pl NE
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Bothell Way &amp; 83rd Pl NE
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Bothell Way &amp; 80th Ave NE
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Bothell Way &amp; 80th Ave NE
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Bothell Way &amp; 77th Ct NE
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Bothell Way &amp; 77th Ct NE
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Bothell Way &amp; Kenmore Park &amp; Ride
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Bothell Way &amp; Kenmore Park &amp; Ride
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        NE Bothell Way &amp; 68th Ave NE
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          NE Bothell Way &amp; 68th Ave NE
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -13280,7 +13516,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         S Main St &amp; 1st Ave
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 25633
         </span>
       </span>
@@ -13290,7 +13526,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from S Main St &amp; 1st Ave
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 25633
       </span>
     </span>
@@ -13320,7 +13556,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at US 287 &amp; Arapahoe Rd
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 33109
                 </span>
               </span>
@@ -13343,9 +13579,9 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 18 min / 12 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -13373,94 +13609,138 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        S Main St &amp; Ken Pratt Blvd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          S Main St &amp; Ken Pratt Blvd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        S Main St &amp; Jersey Ave
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          S Main St &amp; Jersey Ave
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        S Main St &amp; Missouri Ave
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          S Main St &amp; Missouri Ave
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        S Main St &amp; Quebec Ave
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          S Main St &amp; Quebec Ave
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        US 287 &amp; Pike Rd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          US 287 &amp; Pike Rd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        US 287 &amp; Niwot Rd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          US 287 &amp; Niwot Rd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        US 287 &amp; Hwy 52
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          US 287 &amp; Hwy 52
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        US 287 &amp; Lookout Rd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          US 287 &amp; Lookout Rd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        US 287 &amp; Dawson Dr
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          US 287 &amp; Dawson Dr
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        US 287 &amp; Goose Haven Dr
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          US 287 &amp; Goose Haven Dr
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        US 287 &amp; Isabelle Rd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          US 287 &amp; Isabelle Rd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -13522,7 +13802,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         US 287 &amp; Arapahoe Rd
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 33109
         </span>
       </span>
@@ -13532,7 +13812,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from US 287 &amp; Arapahoe Rd
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 33109
       </span>
     </span>
@@ -13738,7 +14018,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Arapahoe Rd &amp; Stonehenge Dr
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 33465
         </span>
       </span>
@@ -13748,7 +14028,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Arapahoe Rd &amp; Stonehenge Dr
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 33465
       </span>
     </span>
@@ -13778,7 +14058,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Erie Community Center
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 33200
                 </span>
               </span>
@@ -13801,9 +14081,9 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 9 min / 8 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -13831,62 +14111,90 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Arapahoe Rd &amp; US 287
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Arapahoe Rd &amp; US 287
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Arapahoe Rd &amp; 111th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Arapahoe Rd &amp; 111th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Arapahoe Rd &amp; Hawkridge Rd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Arapahoe Rd &amp; Hawkridge Rd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        2800 Block 119th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          2800 Block 119th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        119th St &amp; Austin Ave
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          119th St &amp; Austin Ave
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Erie Pkwy &amp; Brennan St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Erie Pkwy &amp; Brennan St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Erie Pkwy &amp; Meller St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Erie Pkwy &amp; Meller St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -13948,7 +14256,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Erie Community Center
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 33200
         </span>
       </span>
@@ -13958,7 +14266,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Erie Community Center
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 33200
       </span>
     </span>
@@ -14164,7 +14472,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         60plusride-co-us:area_626
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID area_626
         </span>
       </span>
@@ -14174,7 +14482,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from 60plusride-co-us:area_626
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID area_626
       </span>
     </span>
@@ -14200,7 +14508,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at 60plusride-co-us:area_626
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID area_626
                 </span>
               </span>
@@ -14301,7 +14609,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         60plusride-co-us:area_626
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID area_626
         </span>
       </span>
@@ -14311,7 +14619,7 @@ exports[`ItineraryBody/otp-ui OTP2FlexItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       Arrive at 60plusride-co-us:area_626
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID area_626
       </span>
     </span>
@@ -16004,7 +16312,7 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Sunset TC MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9969
         </span>
       </span>
@@ -16014,7 +16322,7 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Sunset TC MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9969
       </span>
     </span>
@@ -16044,7 +16352,7 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Oak/ SW 1st Ave MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 8337
                 </span>
               </span>
@@ -16060,7 +16368,7 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__TransitAlertDiv-sc-1q8npbl-86 dNKGjA alert-toggle">
+          <div class="styled__TransitAlertDiv-sc-1q8npbl-88 bJSHRu alert-toggle">
             <svg viewbox="0 0 512 512"
                  height="15"
                  width="15"
@@ -16068,7 +16376,7 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -16082,9 +16390,9 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -16092,7 +16400,7 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -16100,14 +16408,14 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -16129,8 +16437,8 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -16138,7 +16446,7 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -16146,14 +16454,14 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -16178,9 +16486,9 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 21 min / 9 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -16208,70 +16516,102 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Washington Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Washington Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Goose Hollow/SW Jefferson St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Goose Hollow/SW Jefferson St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Kings Hill/SW Salmon St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Kings Hill/SW Salmon St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Providence Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Providence Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Library/SW 9th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Library/SW 9th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Pioneer Square South MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Pioneer Square South MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Mall/SW 4th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Mall/SW 4th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Yamhill District MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Yamhill District MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -16333,7 +16673,7 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Oak/ SW 1st Ave MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8337
         </span>
       </span>
@@ -16343,7 +16683,7 @@ exports[`ItineraryBody/otp-ui ParkAndRideItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Oak/ SW 1st Ave MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8337
       </span>
     </span>
@@ -16941,7 +17281,7 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Pioneer Square North MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8383
         </span>
       </span>
@@ -16951,7 +17291,7 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Pioneer Square North MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8383
       </span>
     </span>
@@ -16981,7 +17321,7 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Providence Park MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 9757
                 </span>
               </span>
@@ -16998,7 +17338,7 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
              role="group"
         >
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -17007,7 +17347,7 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -17040,9 +17380,9 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -17050,7 +17390,7 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -17058,14 +17398,14 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -17087,8 +17427,8 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -17096,7 +17436,7 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -17104,14 +17444,14 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -17133,8 +17473,8 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -17142,7 +17482,7 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -17150,14 +17490,14 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -17182,9 +17522,9 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -17212,14 +17552,18 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -17284,7 +17628,7 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Providence Park MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9757
         </span>
       </span>
@@ -17294,7 +17638,7 @@ exports[`ItineraryBody/otp-ui StyledWalkTransitWalkItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Providence Park MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9757
       </span>
     </span>
@@ -17854,7 +18198,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Pioneer Square North MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8383
         </span>
       </span>
@@ -17864,7 +18208,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Pioneer Square North MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8383
       </span>
     </span>
@@ -17894,7 +18238,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Providence Park MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 9757
                 </span>
               </span>
@@ -17911,7 +18255,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
              role="group"
         >
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -17920,7 +18264,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -17953,9 +18297,9 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -17963,7 +18307,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -17971,14 +18315,14 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -18000,8 +18344,8 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -18009,7 +18353,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -18017,14 +18361,14 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -18046,8 +18390,8 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -18055,7 +18399,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -18063,14 +18407,14 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -18095,9 +18439,9 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -18125,14 +18469,18 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -18197,7 +18545,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Providence Park MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9757
         </span>
       </span>
@@ -18207,7 +18555,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Providence Park MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9757
       </span>
     </span>
@@ -18767,7 +19115,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Pioneer Square North MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8383
         </span>
       </span>
@@ -18777,7 +19125,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Pioneer Square North MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8383
       </span>
     </span>
@@ -18807,7 +19155,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Providence Park MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 9757
                 </span>
               </span>
@@ -18824,7 +19172,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
              role="group"
         >
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -18833,7 +19181,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -18866,9 +19214,9 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -18876,7 +19224,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -18884,14 +19232,14 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -18913,8 +19261,8 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -18922,7 +19270,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -18930,14 +19278,14 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -18959,8 +19307,8 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -18968,7 +19316,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -18976,14 +19324,14 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -19008,9 +19356,9 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -19038,14 +19386,18 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -19110,7 +19462,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Providence Park MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9757
         </span>
       </span>
@@ -19120,7 +19472,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Providence Park MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9757
       </span>
     </span>
@@ -19680,7 +20032,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Pioneer Square North MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8383
         </span>
       </span>
@@ -19690,7 +20042,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Pioneer Square North MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8383
       </span>
     </span>
@@ -19720,7 +20072,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Providence Park MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 9757
                 </span>
               </span>
@@ -19737,7 +20089,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
              role="group"
         >
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -19746,7 +20098,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -19779,9 +20131,9 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -19789,7 +20141,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -19797,14 +20149,14 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -19826,8 +20178,8 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -19835,7 +20187,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -19843,14 +20195,14 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -19872,8 +20224,8 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -19881,7 +20233,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -19889,14 +20241,14 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -19921,9 +20273,9 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -19951,14 +20303,18 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -20023,7 +20379,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Providence Park MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9757
         </span>
       </span>
@@ -20033,7 +20389,7 @@ exports[`ItineraryBody/otp-ui ThreeAlertsWithoutCollapsingProp smoke-test 1`] = 
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Providence Park MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9757
       </span>
     </span>
@@ -20618,9 +20974,9 @@ exports[`ItineraryBody/otp-ui TncTransitItinerary smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 6 min / 3 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -20648,22 +21004,30 @@ exports[`ItineraryBody/otp-ui TncTransitItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        W Burnside &amp; SW 2nd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          W Burnside &amp; SW 2nd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        E Burnside &amp; SE 8th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          E Burnside &amp; SE 8th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -21483,7 +21847,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Philadelphia Airport Terminal D
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 17105
         </span>
       </span>
@@ -21493,7 +21857,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Philadelphia Airport Terminal D
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 17105
       </span>
     </span>
@@ -21519,7 +21883,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at PNC Center
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 617
                 </span>
               </span>
@@ -21540,13 +21904,13 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 8 min / 4 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -21574,30 +21938,42 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Philadelphia Airport Terminals E &amp; F
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Philadelphia Airport Terminals E &amp; F
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Bartram Av &amp; 90th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Bartram Av &amp; 90th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        89th St &amp; Bartram Av - FS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          89th St &amp; Bartram Av - FS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -21659,7 +22035,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         PNC Center
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 617
         </span>
       </span>
@@ -21669,7 +22045,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from PNC Center
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 617
       </span>
     </span>
@@ -21740,7 +22116,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         PNC Center
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 617
         </span>
       </span>
@@ -21750,7 +22126,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from PNC Center
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 617
       </span>
     </span>
@@ -21776,7 +22152,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Oregon Av &amp; Broad St
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 31308
                 </span>
               </span>
@@ -21797,13 +22173,13 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 20 min / 26 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -21831,206 +22207,306 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Tinicum Blvd &amp; 88th St - FS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Tinicum Blvd &amp; 88th St - FS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Tinicum Blvd &amp; 86th St - MBFS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Tinicum Blvd &amp; 86th St - MBFS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Bartram Av &amp; 84th St - MBNS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Bartram Av &amp; 84th St - MBNS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Bartram Av &amp; 84th St - MBFS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Bartram Av &amp; 84th St - MBFS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Island Av &amp; Penrose Av - MBNS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Island Av &amp; Penrose Av - MBNS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Island Av &amp; Penrose Av - MBFS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Island Av &amp; Penrose Av - MBFS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Island Av &amp; Escort Av - MBNS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Island Av &amp; Escort Av - MBNS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Island Av &amp; Escort Av
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Island Av &amp; Escort Av
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Island Av &amp; Escort Av - MBFS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Island Av &amp; Escort Av - MBFS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Enterprise Av &amp; Executive Av
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Enterprise Av &amp; Executive Av
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Executive Av &amp; Enterprise Av - FS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Executive Av &amp; Enterprise Av - FS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Executive Av &amp; Escort Av
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Executive Av &amp; Escort Av
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Escort Av &amp; Island Av
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Escort Av &amp; Island Av
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Island Av &amp; Penrose Av - MBNS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Island Av &amp; Penrose Av - MBNS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Island Av &amp; Penrose Av - MBNS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Island Av &amp; Penrose Av - MBNS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Penrose Av &amp; 26th St - MBNS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Penrose Av &amp; 26th St - MBNS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Penrose &amp; Pattison Av - MBNS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Penrose &amp; Pattison Av - MBNS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Penrose &amp; Pattison Av - FS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Penrose &amp; Pattison Av - FS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Penrose Av &amp; 20th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Penrose Av &amp; 20th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Penrose Av &amp; 20th St - FS
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Penrose Av &amp; 20th St - FS
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Moyamensing Av &amp; Pollock St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Moyamensing Av &amp; Pollock St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Moyamensing Av &amp; 18th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Moyamensing Av &amp; 18th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Moyamensing Av &amp; 17th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Moyamensing Av &amp; 17th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Moyamensing Av &amp; 16th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Moyamensing Av &amp; 16th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Moyamensing Av &amp; 15th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Moyamensing Av &amp; 15th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -22092,7 +22568,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Oregon Av &amp; Broad St
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 31308
         </span>
       </span>
@@ -22102,7 +22578,7 @@ exports[`ItineraryBody/otp-ui TransferLegItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Oregon Av &amp; Broad St
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 31308
       </span>
     </span>
@@ -23472,7 +23948,7 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Sunset TC MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9969
         </span>
       </span>
@@ -23482,7 +23958,7 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Sunset TC MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9969
       </span>
     </span>
@@ -23512,7 +23988,7 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Oak/ SW 1st Ave MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 8337
                 </span>
               </span>
@@ -23528,7 +24004,7 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__TransitAlertDiv-sc-1q8npbl-86 dNKGjA alert-toggle">
+          <div class="styled__TransitAlertDiv-sc-1q8npbl-88 bJSHRu alert-toggle">
             <svg viewbox="0 0 512 512"
                  height="15"
                  width="15"
@@ -23536,7 +24012,7 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -23550,9 +24026,9 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -23560,7 +24036,7 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -23568,14 +24044,14 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -23597,8 +24073,8 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -23606,7 +24082,7 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -23614,14 +24090,14 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -23646,9 +24122,9 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 21 min / 9 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -23676,70 +24152,102 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Washington Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Washington Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Goose Hollow/SW Jefferson St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Goose Hollow/SW Jefferson St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Kings Hill/SW Salmon St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Kings Hill/SW Salmon St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Providence Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Providence Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Library/SW 9th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Library/SW 9th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Pioneer Square South MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Pioneer Square South MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Mall/SW 4th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Mall/SW 4th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Yamhill District MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Yamhill District MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -23801,7 +24309,7 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Oak/ SW 1st Ave MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8337
         </span>
       </span>
@@ -23811,7 +24319,7 @@ exports[`ItineraryBody/otp-ui TwoAlertWithoutCollapsingProp smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Oak/ SW 1st Ave MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8337
       </span>
     </span>
@@ -25009,7 +25517,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Sunset TC MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9969
         </span>
       </span>
@@ -25019,7 +25527,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Sunset TC MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9969
       </span>
     </span>
@@ -25049,7 +25557,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Oak/ SW 1st Ave MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 8337
                 </span>
               </span>
@@ -25066,7 +25574,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
              role="group"
         >
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -25075,7 +25583,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -25108,9 +25616,9 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -25118,7 +25626,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -25126,14 +25634,14 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -25155,8 +25663,8 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -25164,7 +25672,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -25172,14 +25680,14 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -25204,9 +25712,9 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 21 min / 9 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -25234,70 +25742,102 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Washington Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Washington Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Goose Hollow/SW Jefferson St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Goose Hollow/SW Jefferson St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Kings Hill/SW Salmon St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Kings Hill/SW Salmon St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Providence Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Providence Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Library/SW 9th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Library/SW 9th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Pioneer Square South MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Pioneer Square South MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Mall/SW 4th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Mall/SW 4th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Yamhill District MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Yamhill District MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -25359,7 +25899,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Oak/ SW 1st Ave MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8337
         </span>
       </span>
@@ -25369,7 +25909,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Oak/ SW 1st Ave MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8337
       </span>
     </span>
@@ -26567,7 +27107,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Sunset TC MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9969
         </span>
       </span>
@@ -26577,7 +27117,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Sunset TC MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9969
       </span>
     </span>
@@ -26607,7 +27147,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Oak/ SW 1st Ave MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 8337
                 </span>
               </span>
@@ -26623,7 +27163,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__TransitAlertDiv-sc-1q8npbl-86 dNKGjA alert-toggle">
+          <div class="styled__TransitAlertDiv-sc-1q8npbl-88 bJSHRu alert-toggle">
             <svg viewbox="0 0 512 512"
                  height="15"
                  width="15"
@@ -26631,7 +27171,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -26645,9 +27185,9 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                style="height: auto; overflow: visible;"
           >
             <div>
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -26655,7 +27195,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -26663,14 +27203,14 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -26692,8 +27232,8 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -26701,7 +27241,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -26709,14 +27249,14 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -26741,9 +27281,9 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 21 min / 9 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -26771,70 +27311,102 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Washington Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Washington Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Goose Hollow/SW Jefferson St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Goose Hollow/SW Jefferson St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Kings Hill/SW Salmon St MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Kings Hill/SW Salmon St MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Providence Park MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Providence Park MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Library/SW 9th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Library/SW 9th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Pioneer Square South MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Pioneer Square South MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Mall/SW 4th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Mall/SW 4th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Yamhill District MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Yamhill District MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -26896,7 +27468,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Oak/ SW 1st Ave MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8337
         </span>
       </span>
@@ -26906,7 +27478,7 @@ exports[`ItineraryBody/otp-ui TwoAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Oak/ SW 1st Ave MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8337
       </span>
     </span>
@@ -27656,7 +28228,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Everett Station Bay C1
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 2345
         </span>
       </span>
@@ -27666,7 +28238,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Everett Station Bay C1
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 2345
       </span>
     </span>
@@ -27692,7 +28264,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Northgate Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 2191
                 </span>
               </span>
@@ -27715,9 +28287,9 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 47 min / 6 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -27745,46 +28317,66 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Broadway &amp; 34th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Broadway &amp; 34th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        South Everett Fwy Station Bay 3
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          South Everett Fwy Station Bay 3
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Ash Way Park &amp; Ride Bay 1
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Ash Way Park &amp; Ride Bay 1
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Lynnwood Transit Center Bay D3
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Lynnwood Transit Center Bay D3
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Mountlake Terrace Fwy Station Bay 6
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Mountlake Terrace Fwy Station Bay 6
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -27846,7 +28438,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Northgate Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 2191
         </span>
       </span>
@@ -27856,7 +28448,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Northgate Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 2191
       </span>
     </span>
@@ -27929,7 +28521,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Northgate Station - Bay 4
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 35318
         </span>
       </span>
@@ -27939,7 +28531,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Northgate Station - Bay 4
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 35318
       </span>
     </span>
@@ -27965,7 +28557,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at N 105th St &amp; Aurora Ave N
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 40032
                 </span>
               </span>
@@ -27988,9 +28580,9 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 11 min / 8 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -28018,62 +28610,90 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        1st Ave NE &amp; NE 95th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          1st Ave NE &amp; NE 95th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N 92nd St &amp; Corliss Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N 92nd St &amp; Corliss Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        College Way N &amp; N 97th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          College Way N &amp; N 97th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        College Way N &amp; N 103rd St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          College Way N &amp; N 103rd St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Meridian Ave N &amp; N 105th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Meridian Ave N &amp; N 105th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N Northgate Way &amp; Meridian Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N Northgate Way &amp; Meridian Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N Northgate Way &amp; Stone Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N Northgate Way &amp; Stone Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -28135,7 +28755,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         N 105th St &amp; Aurora Ave N
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 40032
         </span>
       </span>
@@ -28145,7 +28765,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from N 105th St &amp; Aurora Ave N
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 40032
       </span>
     </span>
@@ -28388,7 +29008,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Aurora Ave N &amp; N 105th St
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 7080
         </span>
       </span>
@@ -28398,7 +29018,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Aurora Ave N &amp; N 105th St
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 7080
       </span>
     </span>
@@ -28424,7 +29044,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at 3rd Ave &amp; Cherry St
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 490
                 </span>
               </span>
@@ -28447,9 +29067,9 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 31 min / 17 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -28477,134 +29097,198 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 100th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 100th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 95th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 95th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 90th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 90th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 85th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 85th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 80th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 80th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 76th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 76th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 65th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 65th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 46th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 46th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Lynn St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Lynn St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Galer St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Galer St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        7th Ave N &amp; Thomas St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          7th Ave N &amp; Thomas St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Wall St &amp; 5th Ave
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Wall St &amp; 5th Ave
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Bell St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Bell St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Virginia St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Virginia St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Pike St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Pike St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Seneca St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Seneca St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -28666,7 +29350,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         3rd Ave &amp; Cherry St
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 490
         </span>
       </span>
@@ -28676,7 +29360,7 @@ exports[`ItineraryBody/otp-ui WalkInterlinedTransitItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from 3rd Ave &amp; Cherry St
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 490
       </span>
     </span>
@@ -29432,7 +30116,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         SE Cesar Chavez Blvd &amp; Brooklyn
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 7439
         </span>
       </span>
@@ -29442,7 +30126,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from SE Cesar Chavez Blvd &amp; Brooklyn
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 7439
       </span>
     </span>
@@ -29472,7 +30156,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at SE Cesar Chavez Blvd &amp; Hawthorne
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 7459
                 </span>
               </span>
@@ -29495,9 +30179,9 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 4 min / 5 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -29525,38 +30209,54 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Cesar Chavez Blvd &amp; Clinton
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Cesar Chavez Blvd &amp; Clinton
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Cesar Chavez Blvd &amp; Division
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Cesar Chavez Blvd &amp; Division
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Cesar Chavez Blvd &amp; Lincoln
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Cesar Chavez Blvd &amp; Lincoln
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Cesar Chavez Blvd &amp; Stephens
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Cesar Chavez Blvd &amp; Stephens
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -29618,7 +30318,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         SE Cesar Chavez Blvd &amp; Hawthorne
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 7459
         </span>
       </span>
@@ -29628,7 +30328,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from SE Cesar Chavez Blvd &amp; Hawthorne
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 7459
       </span>
     </span>
@@ -29872,7 +30572,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         SE Hawthorne &amp; Cesar Chavez Blvd
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 2626
         </span>
       </span>
@@ -29882,7 +30582,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from SE Hawthorne &amp; Cesar Chavez Blvd
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 2626
       </span>
     </span>
@@ -29912,7 +30612,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at SE Hawthorne &amp; 27th
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 2613
                 </span>
               </span>
@@ -29935,9 +30635,9 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 4 min / 5 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -29965,38 +30665,54 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Hawthorne &amp; 37th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Hawthorne &amp; 37th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Hawthorne &amp; 34th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Hawthorne &amp; 34th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Hawthorne &amp; 32nd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Hawthorne &amp; 32nd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Hawthorne &amp; 30th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Hawthorne &amp; 30th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -30058,7 +30774,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         SE Hawthorne &amp; 27th
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 2613
         </span>
       </span>
@@ -30068,7 +30784,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from SE Hawthorne &amp; 27th
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 2613
       </span>
     </span>
@@ -30621,7 +31337,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         SE Cesar Chavez Blvd &amp; Brooklyn
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 7439
         </span>
       </span>
@@ -30662,7 +31378,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from SE Cesar Chavez Blvd &amp; Brooklyn
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 7439
       </span>
     </span>
@@ -30692,7 +31408,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at SE Cesar Chavez Blvd &amp; Hawthorne
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 7459
                 </span>
               </span>
@@ -30718,9 +31434,9 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 4 min / 5 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -30748,38 +31464,54 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Cesar Chavez Blvd &amp; Clinton
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Cesar Chavez Blvd &amp; Clinton
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Cesar Chavez Blvd &amp; Division
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Cesar Chavez Blvd &amp; Division
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Cesar Chavez Blvd &amp; Lincoln
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Cesar Chavez Blvd &amp; Lincoln
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Cesar Chavez Blvd &amp; Stephens
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Cesar Chavez Blvd &amp; Stephens
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -30841,7 +31573,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         SE Cesar Chavez Blvd &amp; Hawthorne
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 7459
         </span>
       </span>
@@ -30851,7 +31583,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from SE Cesar Chavez Blvd &amp; Hawthorne
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 7459
       </span>
     </span>
@@ -31095,7 +31827,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         SE Hawthorne &amp; Cesar Chavez Blvd
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 2626
         </span>
       </span>
@@ -31136,7 +31868,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from SE Hawthorne &amp; Cesar Chavez Blvd
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 2626
       </span>
     </span>
@@ -31166,7 +31898,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at SE Hawthorne &amp; 27th
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 2613
                 </span>
               </span>
@@ -31192,9 +31924,9 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 4 min / 5 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -31222,38 +31954,54 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Hawthorne &amp; 37th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Hawthorne &amp; 37th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Hawthorne &amp; 34th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Hawthorne &amp; 34th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Hawthorne &amp; 32nd
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Hawthorne &amp; 32nd
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        SE Hawthorne &amp; 30th
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          SE Hawthorne &amp; 30th
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -31315,7 +32063,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         SE Hawthorne &amp; 27th
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 2613
         </span>
       </span>
@@ -31356,7 +32104,7 @@ exports[`ItineraryBody/otp-ui WalkTransitTransferWithA11yItinerary smoke-test 1`
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from SE Hawthorne &amp; 27th
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 2613
       </span>
     </span>
@@ -31878,7 +32626,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Pioneer Square North MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8383
         </span>
       </span>
@@ -31888,7 +32636,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Pioneer Square North MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8383
       </span>
     </span>
@@ -31918,7 +32666,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Providence Park MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 9757
                 </span>
               </span>
@@ -31938,7 +32686,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
              role="group"
         >
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -31947,7 +32695,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -31980,9 +32728,9 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -31990,7 +32738,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -31998,14 +32746,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -32027,8 +32775,8 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -32036,7 +32784,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -32044,14 +32792,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -32073,8 +32821,8 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -32082,7 +32830,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -32090,14 +32838,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -32122,9 +32870,9 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -32152,14 +32900,18 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -32224,7 +32976,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Providence Park MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9757
         </span>
       </span>
@@ -32234,7 +32986,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItinerary smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Providence Park MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9757
       </span>
     </span>
@@ -32797,7 +33549,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
             class="styled__PlaceName-sc-1q8npbl-55 dWLmtN place-row-place-name"
       >
         Pioneer Square North MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8383
         </span>
       </span>
@@ -32812,7 +33564,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Pioneer Square North MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8383
       </span>
     </span>
@@ -32842,7 +33594,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Providence Park MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 9757
                 </span>
               </span>
@@ -32862,7 +33614,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
              role="group"
         >
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -32871,7 +33623,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -32904,9 +33656,9 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -32914,7 +33666,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -32922,14 +33674,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -32951,8 +33703,8 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -32960,7 +33712,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -32968,14 +33720,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -32997,8 +33749,8 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -33006,7 +33758,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -33014,14 +33766,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -33046,9 +33798,9 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -33076,14 +33828,18 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -33148,7 +33904,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Providence Park MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9757
         </span>
       </span>
@@ -33158,7 +33914,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Providence Park MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9757
       </span>
     </span>
@@ -33718,7 +34474,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Pioneer Square North MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8383
         </span>
       </span>
@@ -33728,7 +34484,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Pioneer Square North MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8383
       </span>
     </span>
@@ -33758,7 +34514,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Providence Park MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 9757
                 </span>
               </span>
@@ -33778,7 +34534,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
              role="group"
         >
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -33787,7 +34543,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -33820,9 +34576,9 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -33830,7 +34586,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -33838,14 +34594,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -33867,8 +34623,8 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -33876,7 +34632,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -33884,14 +34640,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -33913,8 +34669,8 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -33922,7 +34678,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -33930,14 +34686,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -33962,9 +34718,9 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -33992,14 +34748,19 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 jlyFEH">
-                        Galleria/SW 10th Ave MAX Station (Closed)
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 ivKDyt">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                          (Closed)
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -34064,7 +34825,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Providence Park MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9757
         </span>
       </span>
@@ -34074,7 +34835,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] 
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Providence Park MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9757
       </span>
     </span>
@@ -34637,7 +35398,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Pioneer Square North MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8383
         </span>
       </span>
@@ -34647,7 +35408,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Pioneer Square North MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8383
       </span>
     </span>
@@ -34677,7 +35438,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Providence Park MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 9757
                 </span>
               </span>
@@ -34694,7 +35455,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
              role="group"
         >
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -34703,7 +35464,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -34736,9 +35497,9 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -34746,7 +35507,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -34754,14 +35515,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -34783,8 +35544,8 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -34792,7 +35553,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -34800,14 +35561,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -34829,8 +35590,8 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -34838,7 +35599,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -34846,14 +35607,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -34878,9 +35639,9 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -34908,14 +35669,18 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -34980,7 +35745,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Providence Park MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9757
         </span>
       </span>
@@ -34990,7 +35755,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Providence Park MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9757
       </span>
     </span>
@@ -35553,7 +36318,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Pioneer Square North MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8383
         </span>
       </span>
@@ -35563,7 +36328,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Pioneer Square North MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8383
       </span>
     </span>
@@ -35593,7 +36358,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Providence Park MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 9757
                 </span>
               </span>
@@ -35609,7 +36374,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
              aria-label="Leg details"
              role="group"
         >
-          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-94 bfvyIo imkcrg agency-info">
+          <div class="styled__LinkContainer-sc-1q8npbl-4 styled__AgencyInfo-sc-1q8npbl-96 bfvyIo fHQOPe agency-info">
             Service operated by
             <a href="http://trimet.org/"
                rel="noopener noreferrer"
@@ -35626,7 +36391,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
             </a>
           </div>
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -35635,7 +36400,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -35668,9 +36433,9 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -35678,7 +36443,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -35686,14 +36451,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -35715,8 +36480,8 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -35724,7 +36489,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -35732,14 +36497,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -35761,8 +36526,8 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -35770,7 +36535,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -35778,14 +36543,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -35810,9 +36575,9 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -35840,14 +36605,18 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -35912,7 +36681,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Providence Park MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9757
         </span>
       </span>
@@ -35922,7 +36691,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAgencyInformation smok
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Providence Park MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9757
       </span>
     </span>
@@ -36530,7 +37299,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameCompone
              role="group"
         >
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -36539,7 +37308,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameCompone
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -36572,9 +37341,9 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameCompone
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -36582,7 +37351,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameCompone
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -36590,14 +37359,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameCompone
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -36619,8 +37388,8 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameCompone
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -36628,7 +37397,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameCompone
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -36636,14 +37405,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameCompone
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -36665,8 +37434,8 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameCompone
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -36674,7 +37443,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameCompone
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -36682,14 +37451,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameCompone
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -36714,9 +37483,9 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameCompone
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -36744,14 +37513,18 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomPlaceNameCompone
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -37380,7 +38153,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Pioneer Square North MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8383
         </span>
       </span>
@@ -37390,7 +38163,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Pioneer Square North MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8383
       </span>
     </span>
@@ -37420,7 +38193,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Providence Park MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 9757
                 </span>
               </span>
@@ -37437,7 +38210,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
              role="group"
         >
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -37446,7 +38219,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -37479,9 +38252,9 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -37489,7 +38262,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -37497,14 +38270,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -37526,8 +38299,8 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -37535,7 +38308,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -37543,14 +38316,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -37572,8 +38345,8 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -37581,7 +38354,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -37589,14 +38362,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -37621,8 +38394,8 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
               <div>
                 <span>
                   Ride for a custom duration of 3.583 minutes
@@ -37653,14 +38426,18 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -37725,7 +38502,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Providence Park MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9757
         </span>
       </span>
@@ -37735,7 +38512,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomTransitLegSummar
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Providence Park MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9757
       </span>
     </span>
@@ -38294,7 +39071,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Pioneer Square North MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8383
         </span>
       </span>
@@ -38304,7 +39081,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Pioneer Square North MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8383
       </span>
     </span>
@@ -38334,7 +39111,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Providence Park MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 9757
                 </span>
               </span>
@@ -38351,7 +39128,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
              role="group"
         >
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -38360,7 +39137,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -38393,9 +39170,9 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -38403,7 +39180,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -38411,14 +39188,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -38440,8 +39217,8 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -38449,7 +39226,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -38457,14 +39234,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -38486,8 +39263,8 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -38495,7 +39272,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -38503,14 +39280,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -38535,9 +39312,9 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -38570,14 +39347,18 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -38642,7 +39423,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Providence Park MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9757
         </span>
       </span>
@@ -38652,7 +39433,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithCustomViewTripButtonAc
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Providence Park MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9757
       </span>
     </span>
@@ -39212,7 +39993,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Pioneer Square North MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 8383
         </span>
       </span>
@@ -39222,7 +40003,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Pioneer Square North MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 8383
       </span>
     </span>
@@ -39252,7 +40033,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Providence Park MAX Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 9757
                 </span>
               </span>
@@ -39269,7 +40050,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
              role="group"
         >
           <button aria-expanded="false"
-                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-87 jOzsRd fBKrLZ alert-toggle"
           >
             <svg viewbox="0 0 512 512"
                  height="15"
@@ -39278,7 +40059,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
                  focusable="false"
                  fill="currentColor"
                  xmlns="http://www.w3.org/2000/svg"
-                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-94 eNLeXG"
             >
               <path fill="currentColor"
                     d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -39311,9 +40092,9 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
                style="height: 0px; overflow: hidden;"
           >
             <div style="display: none;">
-              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-86 grTpVL alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -39321,7 +40102,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -39329,14 +40110,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of December 15, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -39358,8 +40139,8 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -39367,7 +40148,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -39375,14 +40156,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 6, 2019
                     <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -39404,8 +40185,8 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
                     </a>
                   </div>
                 </li>
-                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
-                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                <li class="styled__TransitAlert-sc-1q8npbl-80 gOLNfM">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-85 hSpahq">
                     <svg viewbox="0 0 512 512"
                          height="18"
                          width="18"
@@ -39413,7 +40194,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
                          focusable="false"
                          fill="currentColor"
                          xmlns="http://www.w3.org/2000/svg"
-                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-95 cToKgF"
                     >
                       <path fill="currentColor"
                             d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
@@ -39421,14 +40202,14 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
                       </path>
                     </svg>
                   </div>
-                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-82 gHZUfW">
                     The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
                   </div>
-                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-83 kawYNV">
                     Effective as of November 3, 2019
                     <a href="http://trimet.org/alerts/"
                        target="_blank"
-                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-81 hsNgbu"
                     >
                       <svg viewbox="0 0 512 512"
                            height="10"
@@ -39453,9 +40234,9 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
               </ul>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 3 min / 2 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -39483,14 +40264,18 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Galleria/SW 10th Ave MAX Station
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Galleria/SW 10th Ave MAX Station
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -39558,7 +40343,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Providence Park MAX Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 9757
         </span>
       </span>
@@ -39568,7 +40353,7 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithTransitLegFooter smoke
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Providence Park MAX Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 9757
       </span>
     </span>
@@ -40280,7 +41065,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Everett Station Bay C1
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 2345
         </span>
       </span>
@@ -40290,7 +41075,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Everett Station Bay C1
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 2345
       </span>
     </span>
@@ -40316,7 +41101,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Northgate Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 2191
                 </span>
               </span>
@@ -40339,9 +41124,9 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 47 min / 6 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -40369,46 +41154,66 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Broadway &amp; 34th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Broadway &amp; 34th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        South Everett Fwy Station Bay 3
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          South Everett Fwy Station Bay 3
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Ash Way Park &amp; Ride Bay 1
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Ash Way Park &amp; Ride Bay 1
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Lynnwood Transit Center Bay D3
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Lynnwood Transit Center Bay D3
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Mountlake Terrace Fwy Station Bay 6
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Mountlake Terrace Fwy Station Bay 6
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -40470,7 +41275,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Northgate Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 2191
         </span>
       </span>
@@ -40480,7 +41285,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Northgate Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 2191
       </span>
     </span>
@@ -40553,7 +41358,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Northgate Station - Bay 4
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 35318
         </span>
       </span>
@@ -40563,7 +41368,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Northgate Station - Bay 4
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 35318
       </span>
     </span>
@@ -40589,7 +41394,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at N 105th St &amp; Aurora Ave N
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 40032
                 </span>
               </span>
@@ -40612,9 +41417,9 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 11 min / 8 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -40642,62 +41447,90 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        1st Ave NE &amp; NE 95th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          1st Ave NE &amp; NE 95th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N 92nd St &amp; Corliss Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N 92nd St &amp; Corliss Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        College Way N &amp; N 97th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          College Way N &amp; N 97th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        College Way N &amp; N 103rd St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          College Way N &amp; N 103rd St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Meridian Ave N &amp; N 105th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Meridian Ave N &amp; N 105th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N Northgate Way &amp; Meridian Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N Northgate Way &amp; Meridian Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N Northgate Way &amp; Stone Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N Northgate Way &amp; Stone Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -40759,7 +41592,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         N 105th St &amp; Aurora Ave N
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 40032
         </span>
       </span>
@@ -40769,7 +41602,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from N 105th St &amp; Aurora Ave N
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 40032
       </span>
     </span>
@@ -41012,7 +41845,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Aurora Ave N &amp; N 105th St
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 7080
         </span>
       </span>
@@ -41022,7 +41855,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Aurora Ave N &amp; N 105th St
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 7080
       </span>
     </span>
@@ -41048,7 +41881,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at 3rd Ave &amp; Cherry St
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 490
                 </span>
               </span>
@@ -41071,9 +41904,9 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 31 min / 17 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -41101,134 +41934,198 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 100th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 100th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 95th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 95th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 90th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 90th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 85th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 85th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 80th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 80th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 76th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 76th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 65th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 65th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 46th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 46th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Lynn St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Lynn St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Galer St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Galer St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        7th Ave N &amp; Thomas St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          7th Ave N &amp; Thomas St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Wall St &amp; 5th Ave
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Wall St &amp; 5th Ave
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Bell St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Bell St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Virginia St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Virginia St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Pike St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Pike St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Seneca St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Seneca St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -41290,7 +42187,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         3rd Ave &amp; Cherry St
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 490
         </span>
       </span>
@@ -41300,7 +42197,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from 3rd Ave &amp; Cherry St
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 490
       </span>
     </span>
@@ -41936,7 +42833,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Everett Station Bay C1
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 2345
         </span>
       </span>
@@ -41946,7 +42843,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Everett Station Bay C1
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 2345
       </span>
     </span>
@@ -41972,7 +42869,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Northgate Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 2191
                 </span>
               </span>
@@ -41995,9 +42892,9 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 47 min / 6 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -42025,46 +42922,66 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Broadway &amp; 34th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Broadway &amp; 34th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        South Everett Fwy Station Bay 3
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          South Everett Fwy Station Bay 3
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Ash Way Park &amp; Ride Bay 1
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Ash Way Park &amp; Ride Bay 1
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Lynnwood Transit Center Bay D3
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Lynnwood Transit Center Bay D3
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Mountlake Terrace Fwy Station Bay 6
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Mountlake Terrace Fwy Station Bay 6
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -42126,7 +43043,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Northgate Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 2191
         </span>
       </span>
@@ -42136,7 +43053,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Northgate Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 2191
       </span>
     </span>
@@ -42209,7 +43126,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Northgate Station - Bay 4
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 35318
         </span>
       </span>
@@ -42219,7 +43136,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Northgate Station - Bay 4
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 35318
       </span>
     </span>
@@ -42245,7 +43162,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at N 105th St &amp; Aurora Ave N
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 40032
                 </span>
               </span>
@@ -42268,9 +43185,9 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 11 min / 8 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -42298,62 +43215,90 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        1st Ave NE &amp; NE 95th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          1st Ave NE &amp; NE 95th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N 92nd St &amp; Corliss Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N 92nd St &amp; Corliss Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        College Way N &amp; N 97th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          College Way N &amp; N 97th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        College Way N &amp; N 103rd St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          College Way N &amp; N 103rd St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Meridian Ave N &amp; N 105th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Meridian Ave N &amp; N 105th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N Northgate Way &amp; Meridian Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N Northgate Way &amp; Meridian Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N Northgate Way &amp; Stone Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N Northgate Way &amp; Stone Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -42415,7 +43360,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         N 105th St &amp; Aurora Ave N
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 40032
         </span>
       </span>
@@ -42425,7 +43370,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from N 105th St &amp; Aurora Ave N
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 40032
       </span>
     </span>
@@ -42668,7 +43613,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Aurora Ave N &amp; N 105th St
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 7080
         </span>
       </span>
@@ -42678,7 +43623,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Aurora Ave N &amp; N 105th St
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 7080
       </span>
     </span>
@@ -42704,7 +43649,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at 3rd Ave &amp; Cherry St
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 490
                 </span>
               </span>
@@ -42727,9 +43672,9 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 31 min / 17 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -42757,134 +43702,198 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 100th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 100th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 95th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 95th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 90th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 90th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 85th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 85th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 80th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 80th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 76th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 76th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 65th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 65th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 46th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 46th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Lynn St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Lynn St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Galer St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Galer St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        7th Ave N &amp; Thomas St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          7th Ave N &amp; Thomas St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Wall St &amp; 5th Ave
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Wall St &amp; 5th Ave
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Bell St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Bell St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Virginia St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Virginia St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Pike St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Pike St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Seneca St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Seneca St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -42946,7 +43955,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         3rd Ave &amp; Cherry St
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 490
         </span>
       </span>
@@ -42956,7 +43965,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsNotAlwaysCollapsing smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from 3rd Ave &amp; Cherry St
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 490
       </span>
     </span>
@@ -43592,7 +44601,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Everett Station Bay C1
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 2345
         </span>
       </span>
@@ -43602,7 +44611,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Everett Station Bay C1
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 2345
       </span>
     </span>
@@ -43628,7 +44637,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at Northgate Station
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 2191
                 </span>
               </span>
@@ -43651,9 +44660,9 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 47 min / 6 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -43681,46 +44690,66 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Broadway &amp; 34th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Broadway &amp; 34th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        South Everett Fwy Station Bay 3
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          South Everett Fwy Station Bay 3
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Ash Way Park &amp; Ride Bay 1
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Ash Way Park &amp; Ride Bay 1
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Lynnwood Transit Center Bay D3
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Lynnwood Transit Center Bay D3
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Mountlake Terrace Fwy Station Bay 6
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Mountlake Terrace Fwy Station Bay 6
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -43782,7 +44811,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Northgate Station
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 2191
         </span>
       </span>
@@ -43792,7 +44821,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Northgate Station
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 2191
       </span>
     </span>
@@ -43865,7 +44894,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Northgate Station - Bay 4
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 35318
         </span>
       </span>
@@ -43875,7 +44904,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Northgate Station - Bay 4
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 35318
       </span>
     </span>
@@ -43901,7 +44930,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at N 105th St &amp; Aurora Ave N
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 40032
                 </span>
               </span>
@@ -43924,9 +44953,9 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 11 min / 8 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -43954,62 +44983,90 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        1st Ave NE &amp; NE 95th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          1st Ave NE &amp; NE 95th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N 92nd St &amp; Corliss Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N 92nd St &amp; Corliss Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        College Way N &amp; N 97th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          College Way N &amp; N 97th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        College Way N &amp; N 103rd St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          College Way N &amp; N 103rd St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Meridian Ave N &amp; N 105th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Meridian Ave N &amp; N 105th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N Northgate Way &amp; Meridian Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N Northgate Way &amp; Meridian Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        N Northgate Way &amp; Stone Ave N
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          N Northgate Way &amp; Stone Ave N
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -44071,7 +45128,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         N 105th St &amp; Aurora Ave N
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 40032
         </span>
       </span>
@@ -44081,7 +45138,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from N 105th St &amp; Aurora Ave N
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 40032
       </span>
     </span>
@@ -44324,7 +45381,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         Aurora Ave N &amp; N 105th St
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 7080
         </span>
       </span>
@@ -44334,7 +45391,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from Aurora Ave N &amp; N 105th St
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 7080
       </span>
     </span>
@@ -44360,7 +45417,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
               </span>
               <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
                 - Disembark at 3rd Ave &amp; Cherry St
-                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
                   ID 490
                 </span>
               </span>
@@ -44383,9 +45440,9 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
             <div>
             </div>
           </div>
-          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
-            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
-              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+          <div class="styled__TransitLegDetails-sc-1q8npbl-89 gtDisd transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-90 iPGOIJ">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-93 jOzsRd iRlSdo">
                 Ride 31 min / 17 stops
                 <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
                   <svg viewbox="0 0 320 512"
@@ -44413,134 +45470,198 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
                  style="height: 0px; overflow: hidden;"
             >
               <div style="display: none;">
-                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-91 btfTDq">
                   <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 100th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 100th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 95th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 95th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 90th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 90th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 85th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 85th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 80th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 80th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 76th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 76th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 65th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 65th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; N 46th St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; N 46th St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Lynn St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Lynn St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Aurora Ave N &amp; Galer St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Aurora Ave N &amp; Galer St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        7th Ave N &amp; Thomas St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          7th Ave N &amp; Thomas St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        Wall St &amp; 5th Ave
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          Wall St &amp; 5th Ave
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Bell St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Bell St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Virginia St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Virginia St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Pike St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Pike St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
-                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
-                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                    <li class="styled__StopRow-sc-1q8npbl-79 dQStbA">
+                      <div class="styled__StopMarker-sc-1q8npbl-76 jDpyDk">
                         •
                       </div>
-                      <div class="styled__StopName-sc-1q8npbl-76 ggAtZD">
-                        3rd Ave &amp; Seneca St
+                      <div class="styled__StopNameContainer-sc-1q8npbl-78 dLyHrM">
+                        <div class="styled__StopName-sc-1q8npbl-77 zrQxV">
+                          3rd Ave &amp; Seneca St
+                        </div>
+                        <span class="styled__StopClosed-sc-1q8npbl-74 cRSTqr">
+                        </span>
                       </div>
                     </li>
                   </ol>
@@ -44602,7 +45723,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
             class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
       >
         3rd Ave &amp; Cherry St
-        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
           ID 490
         </span>
       </span>
@@ -44612,7 +45733,7 @@ exports[`ItineraryBody/otp-ui ZeroAlertsWithoutCollapsingProp smoke-test 1`] = `
     </div>
     <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
       from 3rd Ave &amp; Cherry St
-      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+      <span class="styled__StopIdSpan-sc-1q8npbl-75 gURBTs">
         ID 490
       </span>
     </span>

--- a/packages/itinerary-body/src/stories/__snapshots__/OtpUiItineraryBody.story.tsx.snap
+++ b/packages/itinerary-body/src/stories/__snapshots__/OtpUiItineraryBody.story.tsx.snap
@@ -33475,6 +33475,924 @@ exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryCanceled smoke-test 1`] = 
 </ol>
 `;
 
+exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryClosedStop smoke-test 1`] = `
+<ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF">
+  <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
+    <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
+      <div class="styled__LegLine-sc-1q8npbl-43 gaszkj">
+        <div mode="WALK"
+             class="styled__InnerLine-sc-1q8npbl-24 jYqfbx"
+        >
+        </div>
+        <div class="styled__LineBadgeContainer-sc-1q8npbl-44 hDJMuu">
+          <div aria-label="Travel by walking"
+               mode="WALK"
+               class="styled__AccessBadge-sc-1q8npbl-6 isNGRG"
+          >
+            <svg viewbox="0 0 390 390"
+                 leg="[object Object]"
+                 width="66%"
+            >
+              <title>
+                Travel by walking
+              </title>
+              <path d="m 207.60225,19.503527 c 16.02,0 29.07,13.05 29.07,29.07 0,16.020001 -13.05,29.07 -29.07,29.07 -16.02,0 -29.07,-13.049999 -29.07,-29.07 0,-16.02 13.05,-29.07 29.07,-29.07 z m 88.65,181.620003 c -4.05,5.94 -12.15,7.47 -18.09,3.42 0,0 -40.23,-27.45 -43.11,-29.43 -2.88,-1.98 -4.59,-6.12 -5.85,-8.82 -0.9,-1.8 -5.4,-10.62 -8.37,-16.47 l -3.6,15.3 -9.36,42.39 c 0,0 50.13,59.04 51.12,60.21 1.44,1.62 2.25,4.95 2.88,7.47 0.63,2.43 13.41,71.91 13.41,71.91 1.98,10.71 -5.13,21.06 -15.84,23.13 -10.71,1.98001 -21.06,-5.13 -23.13,-15.84 l -12.78,-68.67 -41.67,-45.54 c 0,0 -9.27,43.29 -9.45,44.19 -0.18,0.9 -0.63,2.25 -1.17,3.51 -0.54,1.17 -42.84,72.99 -42.84,72.99 -5.58,9.36 -17.73,12.51 -27.18,6.93 -9.359998,-5.58 -12.509998,-17.73 -6.929998,-27.18 l 37.619998,-63.27 30.24,-136.89 -20.34,16.2 -11.25,49.59 c 0,7.02 -7.92,11.61 -14.94,10.08 -7.02,-1.53 -11.16,-4.41 -9.54,-15.39 h 0.18 c 0,0 11.7,-55.08 12.6,-57.51 0.81,-2.43 2.07,-5.13 3.33,-6.12 8.46,-6.84 41.22,-33.66 50.85,-41.400003 11.07,-9.000001 15.93,-12.329999 25.38,-12.329999 7.11,0 14.85,2.159999 23.04,10.62 3.6,3.690001 6.21,9.720002 8.01,13.500002 1.8,3.69 24.39,48.33 24.39,48.33 l 38.97,27 c 5.94,4.05 7.47,12.15 3.42,18.09 z">
+              </path>
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="styled__PlaceHeader-sc-1q8npbl-54 hMGsin">
+      <span aria-hidden="true"
+            class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
+      >
+        KGW Studio on the Sq, Portland, OR, USA
+      </span>
+    </div>
+    <div class="styled__TimeColumn-sc-1q8npbl-49 kSAQNU">
+      3:44 PM
+    </div>
+    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+      from KGW Studio on the Sq, Portland, OR, USA
+    </span>
+    <div class="styled__PlaceDetails-sc-1q8npbl-53 cHqDbl place-details ">
+      <div class="styled__LegBody-sc-1q8npbl-30 JONmo">
+        <div class="styled__LegClickable-sc-1q8npbl-31 dtGQxb">
+          <span class="styled__LegDescription-sc-1q8npbl-33 hYfuZi">
+            <span class="styled__LegIconAndRouteShortName-sc-1q8npbl-42 iUQXKp">
+            </span>
+            <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+              -
+            </span>
+            <span class="styled__AccessLegDescriptionHeading-sc-1q8npbl-29 gNdrYT walk-leg">
+              Walk 269 feet to
+              <span class="styled__LegDescriptionPlace-sc-1q8npbl-37 idePhS">
+                Pioneer Square North MAX Station
+              </span>
+            </span>
+            <button class="styled__TransparentButton-sc-1q8npbl-1 styled__LegClickableButton-sc-1q8npbl-32 jOzsRd LYxWc">
+              <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                Zoom to leg on map
+              </span>
+            </button>
+          </span>
+        </div>
+        <span class="styled__LegDetails-sc-1q8npbl-46 breQFf">
+          <span class="styled__StepsHeaderAndMapLink-sc-1q8npbl-67 byVRQm">
+            <button aria-expanded="false"
+                    class="styled__TransparentButton-sc-1q8npbl-1 styled__StepsHeaderButton-sc-1q8npbl-68 jOzsRd flixGN"
+            >
+              1 min
+              <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
+                <svg viewbox="0 0 320 512"
+                     height="15"
+                     width="15"
+                     aria-hidden="true"
+                     focusable="false"
+                     fill="currentColor"
+                     xmlns="http://www.w3.org/2000/svg"
+                     class="StyledIconBase-sc-ea9ulj-0 ebjPRL"
+                >
+                  <path fill="currentColor"
+                        d="M137.4 374.6c12.5 12.5 32.8 12.5 45.3 0l128-128c9.2-9.2 11.9-22.9 6.9-34.9S301 191.9 288 191.9L32 192c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9l128 128z"
+                  >
+                  </path>
+                </svg>
+              </span>
+              <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                (Expand details)
+              </span>
+            </button>
+            <a aria-label="Show street imagery at this location"
+               role="link"
+               title="Show street imagery at this location"
+               class="mapillary-button__Container-sc-l7gdsc-0 fUOQNZ"
+            >
+              <svg viewbox="0 0 512 512"
+                   aria-hidden="true"
+                   focusable="false"
+                   fill="currentColor"
+                   xmlns="http://www.w3.org/2000/svg"
+                   class="StyledIconBase-sc-ea9ulj-0 ebjPRL mapillary-button__Icon-sc-l7gdsc-1 dQCpQk"
+                   style="padding-bottom: 1px;"
+              >
+                <path fill="currentColor"
+                      d="M320 64c0-35.3-28.7-64-64-64s-64 28.7-64 64 28.7 64 64 64 64-28.7 64-64zm-96 96c-35.3 0-64 28.7-64 64v48c0 17.7 14.3 32 32 32h1.8l11.1 99.5c1.8 16.2 15.5 28.5 31.8 28.5h38.7c16.3 0 30-12.3 31.8-28.5l11-99.5h1.8c17.7 0 32-14.3 32-32v-48c0-35.3-28.7-64-64-64h-64zm-91.7 234.2c13-2.4 21.7-14.9 19.3-27.9s-14.9-21.7-27.9-19.3c-32.4 5.9-60.9 14.2-82 24.8-10.5 5.3-20.3 11.7-27.8 19.6C6.4 399.5 0 410.5 0 424c0 21.4 15.5 36.1 29.1 45 14.7 9.6 34.3 17.3 56.4 23.4C130.2 504.7 190.4 512 256 512s125.8-7.3 170.4-19.6c22.1-6.1 41.8-13.8 56.4-23.4 13.7-8.9 29.1-23.6 29.1-45 0-13.5-6.4-24.5-14-32.6-7.5-7.9-17.3-14.3-27.8-19.6-21-10.6-49.5-18.9-82-24.8-13-2.4-25.5 6.3-27.9 19.3s6.3 25.5 19.3 27.9c30.2 5.5 53.7 12.8 69 20.5 3.2 1.6 5.8 3.1 7.9 4.5 3.6 2.4 3.6 7.2 0 9.6-8.8 5.7-23.1 11.8-43 17.3C374.3 457 318.5 464 256 464s-118.3-7-157.7-17.9c-19.9-5.5-34.2-11.6-43-17.3-3.6-2.4-3.6-7.2 0-9.6 2.1-1.4 4.8-2.9 7.9-4.5 15.3-7.7 38.8-14.9 69-20.5z"
+                >
+                </path>
+              </svg>
+            </a>
+          </span>
+          <div aria-hidden="true"
+               class="rah-static rah-static--height-zero "
+               style="grid-column: 1 / span 2; height: 0px; overflow: hidden;"
+          >
+            <div style="display: none;">
+              <ol class="styled__Steps-sc-1q8npbl-65 bEBTRA">
+                <li class="styled__StepRow-sc-1q8npbl-71 kVZYtk">
+                  <div class="styled__StepIconContainer-sc-1q8npbl-70 fosTFg">
+                    <svg viewbox="0 0 261 261">
+                      <path d="M100.5 110.5v150h60v-150h40l-70-110-70 110h40z">
+                      </path>
+                    </svg>
+                  </div>
+                  <div class="styled__StepDescriptionContainer-sc-1q8npbl-66 tiDJD">
+                    <span>
+                      Head northwest on
+                      <span class="styled__StepStreetName-sc-1q8npbl-72 iJrUDA">
+                        Unnamed Path
+                      </span>
+                      <span class="styled__StepLength-sc-1q8npbl-73 cCaIgd">
+                        167 feet
+                      </span>
+                    </span>
+                    <a aria-label="Show street imagery at this location"
+                       role="link"
+                       title="Show street imagery at this location"
+                       class="mapillary-button__Container-sc-l7gdsc-0 fUOQNZ"
+                    >
+                      <svg viewbox="0 0 512 512"
+                           aria-hidden="true"
+                           focusable="false"
+                           fill="currentColor"
+                           xmlns="http://www.w3.org/2000/svg"
+                           class="StyledIconBase-sc-ea9ulj-0 ebjPRL mapillary-button__Icon-sc-l7gdsc-1 dQCpQk"
+                           style="padding-bottom: 1px;"
+                      >
+                        <path fill="currentColor"
+                              d="M320 64c0-35.3-28.7-64-64-64s-64 28.7-64 64 28.7 64 64 64 64-28.7 64-64zm-96 96c-35.3 0-64 28.7-64 64v48c0 17.7 14.3 32 32 32h1.8l11.1 99.5c1.8 16.2 15.5 28.5 31.8 28.5h38.7c16.3 0 30-12.3 31.8-28.5l11-99.5h1.8c17.7 0 32-14.3 32-32v-48c0-35.3-28.7-64-64-64h-64zm-91.7 234.2c13-2.4 21.7-14.9 19.3-27.9s-14.9-21.7-27.9-19.3c-32.4 5.9-60.9 14.2-82 24.8-10.5 5.3-20.3 11.7-27.8 19.6C6.4 399.5 0 410.5 0 424c0 21.4 15.5 36.1 29.1 45 14.7 9.6 34.3 17.3 56.4 23.4C130.2 504.7 190.4 512 256 512s125.8-7.3 170.4-19.6c22.1-6.1 41.8-13.8 56.4-23.4 13.7-8.9 29.1-23.6 29.1-45 0-13.5-6.4-24.5-14-32.6-7.5-7.9-17.3-14.3-27.8-19.6-21-10.6-49.5-18.9-82-24.8-13-2.4-25.5 6.3-27.9 19.3s6.3 25.5 19.3 27.9c30.2 5.5 53.7 12.8 69 20.5 3.2 1.6 5.8 3.1 7.9 4.5 3.6 2.4 3.6 7.2 0 9.6-8.8 5.7-23.1 11.8-43 17.3C374.3 457 318.5 464 256 464s-118.3-7-157.7-17.9c-19.9-5.5-34.2-11.6-43-17.3-3.6-2.4-3.6-7.2 0-9.6 2.1-1.4 4.8-2.9 7.9-4.5 15.3-7.7 38.8-14.9 69-20.5z"
+                        >
+                        </path>
+                      </svg>
+                    </a>
+                  </div>
+                </li>
+                <li class="styled__StepRow-sc-1q8npbl-71 kVZYtk">
+                  <div class="styled__StepIconContainer-sc-1q8npbl-70 fosTFg">
+                    <svg viewbox="0 0 261 261">
+                      <path d="M114.5 100.5h60v160h60v-170c0-30-20-50-50-50h-70V.5l-100 69.14 100 70.86v-40z">
+                      </path>
+                    </svg>
+                  </div>
+                  <div class="styled__StepDescriptionContainer-sc-1q8npbl-66 tiDJD">
+                    <span>
+                      Left on
+                      <span class="styled__StepStreetName-sc-1q8npbl-72 iJrUDA">
+                        Pioneer Sq N (path)
+                      </span>
+                      <span class="styled__StepLength-sc-1q8npbl-73 cCaIgd">
+                        101 feet
+                      </span>
+                    </span>
+                    <a aria-label="Show street imagery at this location"
+                       role="link"
+                       title="Show street imagery at this location"
+                       class="mapillary-button__Container-sc-l7gdsc-0 fUOQNZ"
+                    >
+                      <svg viewbox="0 0 512 512"
+                           aria-hidden="true"
+                           focusable="false"
+                           fill="currentColor"
+                           xmlns="http://www.w3.org/2000/svg"
+                           class="StyledIconBase-sc-ea9ulj-0 ebjPRL mapillary-button__Icon-sc-l7gdsc-1 dQCpQk"
+                           style="padding-bottom: 1px;"
+                      >
+                        <path fill="currentColor"
+                              d="M320 64c0-35.3-28.7-64-64-64s-64 28.7-64 64 28.7 64 64 64 64-28.7 64-64zm-96 96c-35.3 0-64 28.7-64 64v48c0 17.7 14.3 32 32 32h1.8l11.1 99.5c1.8 16.2 15.5 28.5 31.8 28.5h38.7c16.3 0 30-12.3 31.8-28.5l11-99.5h1.8c17.7 0 32-14.3 32-32v-48c0-35.3-28.7-64-64-64h-64zm-91.7 234.2c13-2.4 21.7-14.9 19.3-27.9s-14.9-21.7-27.9-19.3c-32.4 5.9-60.9 14.2-82 24.8-10.5 5.3-20.3 11.7-27.8 19.6C6.4 399.5 0 410.5 0 424c0 21.4 15.5 36.1 29.1 45 14.7 9.6 34.3 17.3 56.4 23.4C130.2 504.7 190.4 512 256 512s125.8-7.3 170.4-19.6c22.1-6.1 41.8-13.8 56.4-23.4 13.7-8.9 29.1-23.6 29.1-45 0-13.5-6.4-24.5-14-32.6-7.5-7.9-17.3-14.3-27.8-19.6-21-10.6-49.5-18.9-82-24.8-13-2.4-25.5 6.3-27.9 19.3s6.3 25.5 19.3 27.9c30.2 5.5 53.7 12.8 69 20.5 3.2 1.6 5.8 3.1 7.9 4.5 3.6 2.4 3.6 7.2 0 9.6-8.8 5.7-23.1 11.8-43 17.3C374.3 457 318.5 464 256 464s-118.3-7-157.7-17.9c-19.9-5.5-34.2-11.6-43-17.3-3.6-2.4-3.6-7.2 0-9.6 2.1-1.4 4.8-2.9 7.9-4.5 15.3-7.7 38.8-14.9 69-20.5z"
+                        >
+                        </path>
+                      </svg>
+                    </a>
+                  </div>
+                </li>
+              </ol>
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+    <div class="styled__LightBorderDiv-sc-1q8npbl-0 styled__MapButtonColumn-sc-1q8npbl-51 jEDQHy fekzJr">
+      <button aria-label="View on map"
+              title="View on map"
+              class="styled__TransparentButton-sc-1q8npbl-1 styled__LinkButton-sc-1q8npbl-3 styled__MapButton-sc-1q8npbl-50 jOzsRd eTOvCo hUNvHM"
+      >
+        <svg viewbox="0 0 390 390"
+             width="15"
+             height="15"
+             role="img"
+             class="styled__MapIcon-sc-1q8npbl-52 uCCmf"
+        >
+          <title>
+            View on map
+          </title>
+          <path d="M260.4 54.2L129.6 0 6.6 50.9v335.8l123-50.9L260.4 390l123-50.9V3.3l-123 50.9zM139.2 25l111.5 46.2v294L139.2 319V25zM25.9 63.9l94.1-39v294l-94.1 39v-294zm338.2 262.2l-94.1 39V71.2l94.1-39v293.9z">
+          </path>
+        </svg>
+      </button>
+    </div>
+  </li>
+  <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper transit  ">
+    <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
+      <div class="styled__LegLine-sc-1q8npbl-43 gaszkj">
+        <div mode="TRAM"
+             class="styled__InnerLine-sc-1q8npbl-24 eDAAkh"
+        >
+        </div>
+        <div class="styled__LineBadgeContainer-sc-1q8npbl-44 hDJMuu">
+          <div class="styled__RouteBadge-sc-1q8npbl-62 fODqKp">
+            <span aria-hidden="true"
+                  class="styled__SRHidden-sc-1q8npbl-64 bdFlNW"
+            >
+              MA
+            </span>
+            <span class="styled__SROnly-sc-1q8npbl-63 haVgW">
+              MAX Blue Line
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="styled__PlaceHeader-sc-1q8npbl-54 hMGsin">
+      <span aria-hidden="true"
+            class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
+      >
+        Pioneer Square North MAX Station
+        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+          ID 8383
+        </span>
+      </span>
+    </div>
+    <div class="styled__TimeColumn-sc-1q8npbl-49 kSAQNU">
+      3:46 PM
+    </div>
+    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+      from Pioneer Square North MAX Station
+      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        ID 8383
+      </span>
+    </span>
+    <div class="styled__PlaceDetails-sc-1q8npbl-53 cHqDbl place-details transit">
+      <div class="styled__LegBody-sc-1q8npbl-30 JONmo">
+        <div class="styled__LegClickable-sc-1q8npbl-31 dtGQxb">
+          <span class="styled__LegDescription-sc-1q8npbl-33 hYfuZi">
+            <span>
+              <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                - Ride
+              </span>
+              <span class="styled__LegDescription-sc-1q8npbl-33 styled__LegDescriptionForTransit-sc-1q8npbl-40 hYfuZi dMulzk">
+                <div>
+                  <span class="styled__LegDescriptionRouteShortName-sc-1q8npbl-39 dtVjki">
+                    MAX Blue Line
+                  </span>
+                </div>
+                <span class="styled__LegDescriptionRouteLongName-sc-1q8npbl-38 ctSday">
+                  <span>
+                    MAX Blue Line
+                    <span class="styled__LegDescriptionHeadsignPrefix-sc-1q8npbl-35 eGbGrz">
+                      to
+                    </span>
+                    Hillsboro
+                  </span>
+                </span>
+              </span>
+              <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                - Disembark at Providence Park MAX Station
+                <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+                  ID 9757
+                </span>
+              </span>
+            </span>
+            <button class="styled__TransparentButton-sc-1q8npbl-1 styled__LegClickableButton-sc-1q8npbl-32 jOzsRd LYxWc transit-leg-button">
+              <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                Zoom to leg on map
+              </span>
+            </button>
+          </span>
+        </div>
+        <button class="styled__ArrivalTimeContainer-sc-1q8npbl-7 cUfuYX">
+          Arrives in 3 minutes
+        </button>
+        <div class="transit-leg-details-wrapper"
+             aria-label="Leg details"
+             role="group"
+        >
+          <button aria-expanded="false"
+                  class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitAlertToggle-sc-1q8npbl-85 jOzsRd eGqaoT alert-toggle"
+          >
+            <svg viewbox="0 0 512 512"
+                 height="15"
+                 width="15"
+                 aria-hidden="true"
+                 focusable="false"
+                 fill="currentColor"
+                 xmlns="http://www.w3.org/2000/svg"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertToggleIcon-sc-1q8npbl-92 bxMTZM"
+            >
+              <path fill="currentColor"
+                    d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
+              >
+              </path>
+            </svg>
+            3 alerts
+            <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
+              <svg viewbox="0 0 320 512"
+                   height="15"
+                   width="15"
+                   aria-hidden="true"
+                   focusable="false"
+                   fill="currentColor"
+                   xmlns="http://www.w3.org/2000/svg"
+                   class="StyledIconBase-sc-ea9ulj-0 ebjPRL"
+              >
+                <path fill="currentColor"
+                      d="M137.4 374.6c12.5 12.5 32.8 12.5 45.3 0l128-128c9.2-9.2 11.9-22.9 6.9-34.9S301 191.9 288 191.9L32 192c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9l128 128z"
+                >
+                </path>
+              </svg>
+            </span>
+            <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+              (Expand details)
+            </span>
+          </button>
+          <div aria-hidden="true"
+               class="rah-static rah-static--height-zero "
+               style="height: 0px; overflow: hidden;"
+          >
+            <div style="display: none;">
+              <ul class="styled__TransitAlerts-sc-1q8npbl-84 gBbNSd alert-body">
+                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                    <svg viewbox="0 0 512 512"
+                         height="18"
+                         width="18"
+                         aria-hidden="true"
+                         focusable="false"
+                         fill="currentColor"
+                         xmlns="http://www.w3.org/2000/svg"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                    >
+                      <path fill="currentColor"
+                            d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
+                      >
+                      </path>
+                    </svg>
+                  </div>
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                    TriMet Customer Service will be unavailable to serve text messages or Twitter responses from 9:00 p.m.- 11:30 p.m. For immediate assistance regarding safety or security concerns, please contact the police via 911.
+                  </div>
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                    Effective as of December 15, 2019
+                    <a href="http://trimet.org/alerts/"
+                       target="_blank"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                    >
+                      <svg viewbox="0 0 512 512"
+                           height="10"
+                           aria-hidden="true"
+                           focusable="false"
+                           fill="currentColor"
+                           xmlns="http://www.w3.org/2000/svg"
+                           class="StyledIconBase-sc-ea9ulj-0 ebjPRL"
+                      >
+                        <path fill="currentColor"
+                              d="M352 0c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9L370.7 96 201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L416 141.3l41.4 41.4c9.2 9.2 22.9 11.9 34.9 6.9s19.8-16.6 19.8-29.6V32c0-17.7-14.3-32-32-32H352zM80 32C35.8 32 0 67.8 0 112v320c0 44.2 35.8 80 80 80h320c44.2 0 80-35.8 80-80V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v112c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16h112c17.7 0 32-14.3 32-32s-14.3-32-32-32H80z"
+                        >
+                        </path>
+                      </svg>
+                      See alert on TriMet website
+                      <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                        (Opens new window)
+                      </span>
+                    </a>
+                  </div>
+                </li>
+                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                    <svg viewbox="0 0 512 512"
+                         height="18"
+                         width="18"
+                         aria-hidden="true"
+                         focusable="false"
+                         fill="currentColor"
+                         xmlns="http://www.w3.org/2000/svg"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                    >
+                      <path fill="currentColor"
+                            d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
+                      >
+                      </path>
+                    </svg>
+                  </div>
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                    The Park and Ride garage elevator at Sunset Transit Center is closed for approximately 3 months for improvements. During this time garage users must use the stairs or find alternate parking. Visit trimet.org/parkandride for a complete list of Park and Ride garages.
+                  </div>
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                    Effective as of November 6, 2019
+                    <a href="https://news.trimet.org/2019/11/next-up-for-elevator-improvements-sunset-transit-center-park-ride/"
+                       target="_blank"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                    >
+                      <svg viewbox="0 0 512 512"
+                           height="10"
+                           aria-hidden="true"
+                           focusable="false"
+                           fill="currentColor"
+                           xmlns="http://www.w3.org/2000/svg"
+                           class="StyledIconBase-sc-ea9ulj-0 ebjPRL"
+                      >
+                        <path fill="currentColor"
+                              d="M352 0c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9L370.7 96 201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L416 141.3l41.4 41.4c9.2 9.2 22.9 11.9 34.9 6.9s19.8-16.6 19.8-29.6V32c0-17.7-14.3-32-32-32H352zM80 32C35.8 32 0 67.8 0 112v320c0 44.2 35.8 80 80 80h320c44.2 0 80-35.8 80-80V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v112c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16h112c17.7 0 32-14.3 32-32s-14.3-32-32-32H80z"
+                        >
+                        </path>
+                      </svg>
+                      See alert on TriMet website
+                      <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                        (Opens new window)
+                      </span>
+                    </a>
+                  </div>
+                </li>
+                <li class="styled__TransitAlert-sc-1q8npbl-78 ilPDOT">
+                  <div class="styled__TransitAlertIconContainer-sc-1q8npbl-83 irQEYY">
+                    <svg viewbox="0 0 512 512"
+                         height="18"
+                         width="18"
+                         aria-hidden="true"
+                         focusable="false"
+                         fill="currentColor"
+                         xmlns="http://www.w3.org/2000/svg"
+                         class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__DefaultAlertBodyIcon-sc-1q8npbl-93 edZjhv"
+                    >
+                      <path fill="currentColor"
+                            d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7.2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8.2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24v112c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224c0-17.7-14.3-32-32-32s-32 14.3-32 32 14.3 32 32 32 32-14.3 32-32z"
+                      >
+                      </path>
+                    </svg>
+                  </div>
+                  <div class="styled__TransitAlertBody-sc-1q8npbl-80 DlBew">
+                    The west elevators at the Washington Park MAX Station are out of service. Please use east elevators to access street level and platforms.
+                  </div>
+                  <div class="styled__TransitAlertEffectiveDate-sc-1q8npbl-81 dXHcIX">
+                    Effective as of November 3, 2019
+                    <a href="http://trimet.org/alerts/"
+                       target="_blank"
+                       class="styled__TransitAlertExternalLink-sc-1q8npbl-79 kolXTB"
+                    >
+                      <svg viewbox="0 0 512 512"
+                           height="10"
+                           aria-hidden="true"
+                           focusable="false"
+                           fill="currentColor"
+                           xmlns="http://www.w3.org/2000/svg"
+                           class="StyledIconBase-sc-ea9ulj-0 ebjPRL"
+                      >
+                        <path fill="currentColor"
+                              d="M352 0c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9L370.7 96 201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L416 141.3l41.4 41.4c9.2 9.2 22.9 11.9 34.9 6.9s19.8-16.6 19.8-29.6V32c0-17.7-14.3-32-32-32H352zM80 32C35.8 32 0 67.8 0 112v320c0 44.2 35.8 80 80 80h320c44.2 0 80-35.8 80-80V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v112c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16h112c17.7 0 32-14.3 32-32s-14.3-32-32-32H80z"
+                        >
+                        </path>
+                      </svg>
+                      See alert on TriMet website
+                      <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                        (Opens new window)
+                      </span>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="styled__TransitLegDetails-sc-1q8npbl-87 gnpOev transit-leg-details">
+            <div class="styled__TransitLegDetailsHeader-sc-1q8npbl-88 vAjWY">
+              <button class="styled__TransparentButton-sc-1q8npbl-1 styled__TransitLegSummary-sc-1q8npbl-91 jOzsRd cArTkq">
+                Ride 3 min / 2 stops
+                <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
+                  <svg viewbox="0 0 320 512"
+                       height="15"
+                       width="15"
+                       aria-hidden="true"
+                       focusable="false"
+                       fill="currentColor"
+                       xmlns="http://www.w3.org/2000/svg"
+                       class="StyledIconBase-sc-ea9ulj-0 ebjPRL"
+                  >
+                    <path fill="currentColor"
+                          d="M137.4 374.6c12.5 12.5 32.8 12.5 45.3 0l128-128c9.2-9.2 11.9-22.9 6.9-34.9S301 191.9 288 191.9L32 192c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9l128 128z"
+                    >
+                    </path>
+                  </svg>
+                </span>
+                <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                  (Expand details)
+                </span>
+              </button>
+            </div>
+            <div aria-hidden="true"
+                 class="rah-static rah-static--height-zero "
+                 style="height: 0px; overflow: hidden;"
+            >
+              <div style="display: none;">
+                <div class="styled__TransitLegExpandedBody-sc-1q8npbl-89 QLKEv">
+                  <ol class="styled__IntermediateStops-sc-1q8npbl-27 gSrcEZ">
+                    <li class="styled__StopRow-sc-1q8npbl-77 ibEuUy">
+                      <div class="styled__StopMarker-sc-1q8npbl-75 dvinYV">
+                        •
+                      </div>
+                      <div class="styled__StopName-sc-1q8npbl-76 jzNMtk"
+                           style="color: rgb(191, 62, 58);"
+                      >
+                        Galleria/SW 10th Ave MAX Station (Closed)
+                      </div>
+                    </li>
+                  </ol>
+                </div>
+              </div>
+            </div>
+            <span>
+              Typical wait: 15 min
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="styled__LightBorderDiv-sc-1q8npbl-0 styled__MapButtonColumn-sc-1q8npbl-51 jEDQHy fekzJr">
+      <button aria-label="View on map"
+              title="View on map"
+              class="styled__TransparentButton-sc-1q8npbl-1 styled__LinkButton-sc-1q8npbl-3 styled__MapButton-sc-1q8npbl-50 jOzsRd eTOvCo hUNvHM"
+      >
+        <svg viewbox="0 0 390 390"
+             width="15"
+             height="15"
+             role="img"
+             class="styled__MapIcon-sc-1q8npbl-52 uCCmf"
+        >
+          <title>
+            View on map
+          </title>
+          <path d="M260.4 54.2L129.6 0 6.6 50.9v335.8l123-50.9L260.4 390l123-50.9V3.3l-123 50.9zM139.2 25l111.5 46.2v294L139.2 319V25zM25.9 63.9l94.1-39v294l-94.1 39v-294zm338.2 262.2l-94.1 39V71.2l94.1-39v293.9z">
+          </path>
+        </svg>
+      </button>
+    </div>
+  </li>
+  <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
+    <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
+      <div class="styled__LegLine-sc-1q8npbl-43 gaszkj">
+        <div mode="WALK"
+             class="styled__InnerLine-sc-1q8npbl-24 jYqfbx"
+        >
+        </div>
+        <div class="styled__LineBadgeContainer-sc-1q8npbl-44 hDJMuu">
+          <div aria-label="Travel by walking"
+               mode="WALK"
+               class="styled__AccessBadge-sc-1q8npbl-6 isNGRG"
+          >
+            <svg viewbox="0 0 390 390"
+                 leg="[object Object]"
+                 width="66%"
+            >
+              <title>
+                Travel by walking
+              </title>
+              <path d="m 207.60225,19.503527 c 16.02,0 29.07,13.05 29.07,29.07 0,16.020001 -13.05,29.07 -29.07,29.07 -16.02,0 -29.07,-13.049999 -29.07,-29.07 0,-16.02 13.05,-29.07 29.07,-29.07 z m 88.65,181.620003 c -4.05,5.94 -12.15,7.47 -18.09,3.42 0,0 -40.23,-27.45 -43.11,-29.43 -2.88,-1.98 -4.59,-6.12 -5.85,-8.82 -0.9,-1.8 -5.4,-10.62 -8.37,-16.47 l -3.6,15.3 -9.36,42.39 c 0,0 50.13,59.04 51.12,60.21 1.44,1.62 2.25,4.95 2.88,7.47 0.63,2.43 13.41,71.91 13.41,71.91 1.98,10.71 -5.13,21.06 -15.84,23.13 -10.71,1.98001 -21.06,-5.13 -23.13,-15.84 l -12.78,-68.67 -41.67,-45.54 c 0,0 -9.27,43.29 -9.45,44.19 -0.18,0.9 -0.63,2.25 -1.17,3.51 -0.54,1.17 -42.84,72.99 -42.84,72.99 -5.58,9.36 -17.73,12.51 -27.18,6.93 -9.359998,-5.58 -12.509998,-17.73 -6.929998,-27.18 l 37.619998,-63.27 30.24,-136.89 -20.34,16.2 -11.25,49.59 c 0,7.02 -7.92,11.61 -14.94,10.08 -7.02,-1.53 -11.16,-4.41 -9.54,-15.39 h 0.18 c 0,0 11.7,-55.08 12.6,-57.51 0.81,-2.43 2.07,-5.13 3.33,-6.12 8.46,-6.84 41.22,-33.66 50.85,-41.400003 11.07,-9.000001 15.93,-12.329999 25.38,-12.329999 7.11,0 14.85,2.159999 23.04,10.62 3.6,3.690001 6.21,9.720002 8.01,13.500002 1.8,3.69 24.39,48.33 24.39,48.33 l 38.97,27 c 5.94,4.05 7.47,12.15 3.42,18.09 z">
+              </path>
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="styled__PlaceHeader-sc-1q8npbl-54 hMGsin">
+      <span aria-hidden="true"
+            class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
+      >
+        Providence Park MAX Station
+        <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+          ID 9757
+        </span>
+      </span>
+    </div>
+    <div class="styled__TimeColumn-sc-1q8npbl-49 kSAQNU">
+      3:49 PM
+    </div>
+    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+      from Providence Park MAX Station
+      <span class="styled__StopIdSpan-sc-1q8npbl-74 bBzJyx">
+        ID 9757
+      </span>
+    </span>
+    <div class="styled__PlaceDetails-sc-1q8npbl-53 cHqDbl place-details ">
+      <div class="styled__LegBody-sc-1q8npbl-30 JONmo">
+        <div class="styled__LegClickable-sc-1q8npbl-31 dtGQxb">
+          <span class="styled__LegDescription-sc-1q8npbl-33 hYfuZi">
+            <span class="styled__LegIconAndRouteShortName-sc-1q8npbl-42 iUQXKp">
+            </span>
+            <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+              -
+            </span>
+            <span class="styled__AccessLegDescriptionHeading-sc-1q8npbl-29 gNdrYT walk-leg">
+              Walk 249 feet to
+              <span class="styled__LegDescriptionPlace-sc-1q8npbl-37 idePhS">
+                1737 SW Morrison St, Portland, OR, USA 97205
+              </span>
+            </span>
+            <button class="styled__TransparentButton-sc-1q8npbl-1 styled__LegClickableButton-sc-1q8npbl-32 jOzsRd LYxWc">
+              <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                Zoom to leg on map
+              </span>
+            </button>
+          </span>
+        </div>
+        <span class="styled__LegDetails-sc-1q8npbl-46 breQFf">
+          <span class="styled__StepsHeaderAndMapLink-sc-1q8npbl-67 byVRQm">
+            <button aria-expanded="false"
+                    class="styled__TransparentButton-sc-1q8npbl-1 styled__StepsHeaderButton-sc-1q8npbl-68 jOzsRd flixGN"
+            >
+              1 min
+              <span class="styled__CaretToggle-sc-1q8npbl-22 dcOaLK">
+                <svg viewbox="0 0 320 512"
+                     height="15"
+                     width="15"
+                     aria-hidden="true"
+                     focusable="false"
+                     fill="currentColor"
+                     xmlns="http://www.w3.org/2000/svg"
+                     class="StyledIconBase-sc-ea9ulj-0 ebjPRL"
+                >
+                  <path fill="currentColor"
+                        d="M137.4 374.6c12.5 12.5 32.8 12.5 45.3 0l128-128c9.2-9.2 11.9-22.9 6.9-34.9S301 191.9 288 191.9L32 192c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9l128 128z"
+                  >
+                  </path>
+                </svg>
+              </span>
+              <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+                (Expand details)
+              </span>
+            </button>
+            <a aria-label="Show street imagery at this location"
+               role="link"
+               title="Show street imagery at this location"
+               class="mapillary-button__Container-sc-l7gdsc-0 fUOQNZ"
+            >
+              <svg viewbox="0 0 512 512"
+                   aria-hidden="true"
+                   focusable="false"
+                   fill="currentColor"
+                   xmlns="http://www.w3.org/2000/svg"
+                   class="StyledIconBase-sc-ea9ulj-0 ebjPRL mapillary-button__Icon-sc-l7gdsc-1 dQCpQk"
+                   style="padding-bottom: 1px;"
+              >
+                <path fill="currentColor"
+                      d="M320 64c0-35.3-28.7-64-64-64s-64 28.7-64 64 28.7 64 64 64 64-28.7 64-64zm-96 96c-35.3 0-64 28.7-64 64v48c0 17.7 14.3 32 32 32h1.8l11.1 99.5c1.8 16.2 15.5 28.5 31.8 28.5h38.7c16.3 0 30-12.3 31.8-28.5l11-99.5h1.8c17.7 0 32-14.3 32-32v-48c0-35.3-28.7-64-64-64h-64zm-91.7 234.2c13-2.4 21.7-14.9 19.3-27.9s-14.9-21.7-27.9-19.3c-32.4 5.9-60.9 14.2-82 24.8-10.5 5.3-20.3 11.7-27.8 19.6C6.4 399.5 0 410.5 0 424c0 21.4 15.5 36.1 29.1 45 14.7 9.6 34.3 17.3 56.4 23.4C130.2 504.7 190.4 512 256 512s125.8-7.3 170.4-19.6c22.1-6.1 41.8-13.8 56.4-23.4 13.7-8.9 29.1-23.6 29.1-45 0-13.5-6.4-24.5-14-32.6-7.5-7.9-17.3-14.3-27.8-19.6-21-10.6-49.5-18.9-82-24.8-13-2.4-25.5 6.3-27.9 19.3s6.3 25.5 19.3 27.9c30.2 5.5 53.7 12.8 69 20.5 3.2 1.6 5.8 3.1 7.9 4.5 3.6 2.4 3.6 7.2 0 9.6-8.8 5.7-23.1 11.8-43 17.3C374.3 457 318.5 464 256 464s-118.3-7-157.7-17.9c-19.9-5.5-34.2-11.6-43-17.3-3.6-2.4-3.6-7.2 0-9.6 2.1-1.4 4.8-2.9 7.9-4.5 15.3-7.7 38.8-14.9 69-20.5z"
+                >
+                </path>
+              </svg>
+            </a>
+          </span>
+          <div aria-hidden="true"
+               class="rah-static rah-static--height-zero "
+               style="grid-column: 1 / span 2; height: 0px; overflow: hidden;"
+          >
+            <div style="display: none;">
+              <ol class="styled__Steps-sc-1q8npbl-65 bEBTRA">
+                <li class="styled__StepRow-sc-1q8npbl-71 kVZYtk">
+                  <div class="styled__StepIconContainer-sc-1q8npbl-70 fosTFg">
+                    <svg viewbox="0 0 261 261">
+                      <path d="M100.5 110.5v150h60v-150h40l-70-110-70 110h40z">
+                      </path>
+                    </svg>
+                  </div>
+                  <div class="styled__StepDescriptionContainer-sc-1q8npbl-66 tiDJD">
+                    <span>
+                      Head west on
+                      <span class="styled__StepStreetName-sc-1q8npbl-72 iJrUDA">
+                        Providence Park (path)
+                      </span>
+                      <span class="styled__StepLength-sc-1q8npbl-73 cCaIgd">
+                        19 feet
+                      </span>
+                    </span>
+                    <a aria-label="Show street imagery at this location"
+                       role="link"
+                       title="Show street imagery at this location"
+                       class="mapillary-button__Container-sc-l7gdsc-0 fUOQNZ"
+                    >
+                      <svg viewbox="0 0 512 512"
+                           aria-hidden="true"
+                           focusable="false"
+                           fill="currentColor"
+                           xmlns="http://www.w3.org/2000/svg"
+                           class="StyledIconBase-sc-ea9ulj-0 ebjPRL mapillary-button__Icon-sc-l7gdsc-1 dQCpQk"
+                           style="padding-bottom: 1px;"
+                      >
+                        <path fill="currentColor"
+                              d="M320 64c0-35.3-28.7-64-64-64s-64 28.7-64 64 28.7 64 64 64 64-28.7 64-64zm-96 96c-35.3 0-64 28.7-64 64v48c0 17.7 14.3 32 32 32h1.8l11.1 99.5c1.8 16.2 15.5 28.5 31.8 28.5h38.7c16.3 0 30-12.3 31.8-28.5l11-99.5h1.8c17.7 0 32-14.3 32-32v-48c0-35.3-28.7-64-64-64h-64zm-91.7 234.2c13-2.4 21.7-14.9 19.3-27.9s-14.9-21.7-27.9-19.3c-32.4 5.9-60.9 14.2-82 24.8-10.5 5.3-20.3 11.7-27.8 19.6C6.4 399.5 0 410.5 0 424c0 21.4 15.5 36.1 29.1 45 14.7 9.6 34.3 17.3 56.4 23.4C130.2 504.7 190.4 512 256 512s125.8-7.3 170.4-19.6c22.1-6.1 41.8-13.8 56.4-23.4 13.7-8.9 29.1-23.6 29.1-45 0-13.5-6.4-24.5-14-32.6-7.5-7.9-17.3-14.3-27.8-19.6-21-10.6-49.5-18.9-82-24.8-13-2.4-25.5 6.3-27.9 19.3s6.3 25.5 19.3 27.9c30.2 5.5 53.7 12.8 69 20.5 3.2 1.6 5.8 3.1 7.9 4.5 3.6 2.4 3.6 7.2 0 9.6-8.8 5.7-23.1 11.8-43 17.3C374.3 457 318.5 464 256 464s-118.3-7-157.7-17.9c-19.9-5.5-34.2-11.6-43-17.3-3.6-2.4-3.6-7.2 0-9.6 2.1-1.4 4.8-2.9 7.9-4.5 15.3-7.7 38.8-14.9 69-20.5z"
+                        >
+                        </path>
+                      </svg>
+                    </a>
+                  </div>
+                </li>
+                <li class="styled__StepRow-sc-1q8npbl-71 kVZYtk">
+                  <div class="styled__StepIconContainer-sc-1q8npbl-70 fosTFg">
+                    <svg viewbox="0 0 261 261">
+                      <path d="M146.5 140.5l100-70.86L146.5.5v40h-70c-30 0-50 20-50 50v170h60v-160h60v40z">
+                      </path>
+                    </svg>
+                  </div>
+                  <div class="styled__StepDescriptionContainer-sc-1q8npbl-66 tiDJD">
+                    <span>
+                      Right on
+                      <span class="styled__StepStreetName-sc-1q8npbl-72 iJrUDA">
+                        Unnamed Path
+                      </span>
+                      <span class="styled__StepLength-sc-1q8npbl-73 cCaIgd">
+                        104 feet
+                      </span>
+                    </span>
+                    <a aria-label="Show street imagery at this location"
+                       role="link"
+                       title="Show street imagery at this location"
+                       class="mapillary-button__Container-sc-l7gdsc-0 fUOQNZ"
+                    >
+                      <svg viewbox="0 0 512 512"
+                           aria-hidden="true"
+                           focusable="false"
+                           fill="currentColor"
+                           xmlns="http://www.w3.org/2000/svg"
+                           class="StyledIconBase-sc-ea9ulj-0 ebjPRL mapillary-button__Icon-sc-l7gdsc-1 dQCpQk"
+                           style="padding-bottom: 1px;"
+                      >
+                        <path fill="currentColor"
+                              d="M320 64c0-35.3-28.7-64-64-64s-64 28.7-64 64 28.7 64 64 64 64-28.7 64-64zm-96 96c-35.3 0-64 28.7-64 64v48c0 17.7 14.3 32 32 32h1.8l11.1 99.5c1.8 16.2 15.5 28.5 31.8 28.5h38.7c16.3 0 30-12.3 31.8-28.5l11-99.5h1.8c17.7 0 32-14.3 32-32v-48c0-35.3-28.7-64-64-64h-64zm-91.7 234.2c13-2.4 21.7-14.9 19.3-27.9s-14.9-21.7-27.9-19.3c-32.4 5.9-60.9 14.2-82 24.8-10.5 5.3-20.3 11.7-27.8 19.6C6.4 399.5 0 410.5 0 424c0 21.4 15.5 36.1 29.1 45 14.7 9.6 34.3 17.3 56.4 23.4C130.2 504.7 190.4 512 256 512s125.8-7.3 170.4-19.6c22.1-6.1 41.8-13.8 56.4-23.4 13.7-8.9 29.1-23.6 29.1-45 0-13.5-6.4-24.5-14-32.6-7.5-7.9-17.3-14.3-27.8-19.6-21-10.6-49.5-18.9-82-24.8-13-2.4-25.5 6.3-27.9 19.3s6.3 25.5 19.3 27.9c30.2 5.5 53.7 12.8 69 20.5 3.2 1.6 5.8 3.1 7.9 4.5 3.6 2.4 3.6 7.2 0 9.6-8.8 5.7-23.1 11.8-43 17.3C374.3 457 318.5 464 256 464s-118.3-7-157.7-17.9c-19.9-5.5-34.2-11.6-43-17.3-3.6-2.4-3.6-7.2 0-9.6 2.1-1.4 4.8-2.9 7.9-4.5 15.3-7.7 38.8-14.9 69-20.5z"
+                        >
+                        </path>
+                      </svg>
+                    </a>
+                  </div>
+                </li>
+                <li class="styled__StepRow-sc-1q8npbl-71 kVZYtk">
+                  <div class="styled__StepIconContainer-sc-1q8npbl-70 fosTFg">
+                    <svg viewbox="0 0 261 261">
+                      <path d="M146.5 140.5l100-70.86L146.5.5v40h-70c-30 0-50 20-50 50v170h60v-160h60v40z">
+                      </path>
+                    </svg>
+                  </div>
+                  <div class="styled__StepDescriptionContainer-sc-1q8npbl-66 tiDJD">
+                    <span>
+                      Right on
+                      <span class="styled__StepStreetName-sc-1q8npbl-72 iJrUDA">
+                        Unnamed Path
+                      </span>
+                      <span class="styled__StepLength-sc-1q8npbl-73 cCaIgd">
+                        27 feet
+                      </span>
+                    </span>
+                    <a aria-label="Show street imagery at this location"
+                       role="link"
+                       title="Show street imagery at this location"
+                       class="mapillary-button__Container-sc-l7gdsc-0 fUOQNZ"
+                    >
+                      <svg viewbox="0 0 512 512"
+                           aria-hidden="true"
+                           focusable="false"
+                           fill="currentColor"
+                           xmlns="http://www.w3.org/2000/svg"
+                           class="StyledIconBase-sc-ea9ulj-0 ebjPRL mapillary-button__Icon-sc-l7gdsc-1 dQCpQk"
+                           style="padding-bottom: 1px;"
+                      >
+                        <path fill="currentColor"
+                              d="M320 64c0-35.3-28.7-64-64-64s-64 28.7-64 64 28.7 64 64 64 64-28.7 64-64zm-96 96c-35.3 0-64 28.7-64 64v48c0 17.7 14.3 32 32 32h1.8l11.1 99.5c1.8 16.2 15.5 28.5 31.8 28.5h38.7c16.3 0 30-12.3 31.8-28.5l11-99.5h1.8c17.7 0 32-14.3 32-32v-48c0-35.3-28.7-64-64-64h-64zm-91.7 234.2c13-2.4 21.7-14.9 19.3-27.9s-14.9-21.7-27.9-19.3c-32.4 5.9-60.9 14.2-82 24.8-10.5 5.3-20.3 11.7-27.8 19.6C6.4 399.5 0 410.5 0 424c0 21.4 15.5 36.1 29.1 45 14.7 9.6 34.3 17.3 56.4 23.4C130.2 504.7 190.4 512 256 512s125.8-7.3 170.4-19.6c22.1-6.1 41.8-13.8 56.4-23.4 13.7-8.9 29.1-23.6 29.1-45 0-13.5-6.4-24.5-14-32.6-7.5-7.9-17.3-14.3-27.8-19.6-21-10.6-49.5-18.9-82-24.8-13-2.4-25.5 6.3-27.9 19.3s6.3 25.5 19.3 27.9c30.2 5.5 53.7 12.8 69 20.5 3.2 1.6 5.8 3.1 7.9 4.5 3.6 2.4 3.6 7.2 0 9.6-8.8 5.7-23.1 11.8-43 17.3C374.3 457 318.5 464 256 464s-118.3-7-157.7-17.9c-19.9-5.5-34.2-11.6-43-17.3-3.6-2.4-3.6-7.2 0-9.6 2.1-1.4 4.8-2.9 7.9-4.5 15.3-7.7 38.8-14.9 69-20.5z"
+                        >
+                        </path>
+                      </svg>
+                    </a>
+                  </div>
+                </li>
+                <li class="styled__StepRow-sc-1q8npbl-71 kVZYtk">
+                  <div class="styled__StepIconContainer-sc-1q8npbl-70 fosTFg">
+                    <svg viewbox="0 0 261 261">
+                      <path d="M146.5 140.5l100-70.86L146.5.5v40h-70c-30 0-50 20-50 50v170h60v-160h60v40z">
+                      </path>
+                    </svg>
+                  </div>
+                  <div class="styled__StepDescriptionContainer-sc-1q8npbl-66 tiDJD">
+                    <span>
+                      Right on
+                      <span class="styled__StepStreetName-sc-1q8npbl-72 iJrUDA">
+                        SW Morrison St
+                      </span>
+                      <span class="styled__StepLength-sc-1q8npbl-73 cCaIgd">
+                        99 feet
+                      </span>
+                    </span>
+                    <a aria-label="Show street imagery at this location"
+                       role="link"
+                       title="Show street imagery at this location"
+                       class="mapillary-button__Container-sc-l7gdsc-0 fUOQNZ"
+                    >
+                      <svg viewbox="0 0 512 512"
+                           aria-hidden="true"
+                           focusable="false"
+                           fill="currentColor"
+                           xmlns="http://www.w3.org/2000/svg"
+                           class="StyledIconBase-sc-ea9ulj-0 ebjPRL mapillary-button__Icon-sc-l7gdsc-1 dQCpQk"
+                           style="padding-bottom: 1px;"
+                      >
+                        <path fill="currentColor"
+                              d="M320 64c0-35.3-28.7-64-64-64s-64 28.7-64 64 28.7 64 64 64 64-28.7 64-64zm-96 96c-35.3 0-64 28.7-64 64v48c0 17.7 14.3 32 32 32h1.8l11.1 99.5c1.8 16.2 15.5 28.5 31.8 28.5h38.7c16.3 0 30-12.3 31.8-28.5l11-99.5h1.8c17.7 0 32-14.3 32-32v-48c0-35.3-28.7-64-64-64h-64zm-91.7 234.2c13-2.4 21.7-14.9 19.3-27.9s-14.9-21.7-27.9-19.3c-32.4 5.9-60.9 14.2-82 24.8-10.5 5.3-20.3 11.7-27.8 19.6C6.4 399.5 0 410.5 0 424c0 21.4 15.5 36.1 29.1 45 14.7 9.6 34.3 17.3 56.4 23.4C130.2 504.7 190.4 512 256 512s125.8-7.3 170.4-19.6c22.1-6.1 41.8-13.8 56.4-23.4 13.7-8.9 29.1-23.6 29.1-45 0-13.5-6.4-24.5-14-32.6-7.5-7.9-17.3-14.3-27.8-19.6-21-10.6-49.5-18.9-82-24.8-13-2.4-25.5 6.3-27.9 19.3s6.3 25.5 19.3 27.9c30.2 5.5 53.7 12.8 69 20.5 3.2 1.6 5.8 3.1 7.9 4.5 3.6 2.4 3.6 7.2 0 9.6-8.8 5.7-23.1 11.8-43 17.3C374.3 457 318.5 464 256 464s-118.3-7-157.7-17.9c-19.9-5.5-34.2-11.6-43-17.3-3.6-2.4-3.6-7.2 0-9.6 2.1-1.4 4.8-2.9 7.9-4.5 15.3-7.7 38.8-14.9 69-20.5z"
+                        >
+                        </path>
+                      </svg>
+                    </a>
+                  </div>
+                </li>
+              </ol>
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+    <div class="styled__LightBorderDiv-sc-1q8npbl-0 styled__MapButtonColumn-sc-1q8npbl-51 jEDQHy fekzJr">
+      <button aria-label="View on map"
+              title="View on map"
+              class="styled__TransparentButton-sc-1q8npbl-1 styled__LinkButton-sc-1q8npbl-3 styled__MapButton-sc-1q8npbl-50 jOzsRd eTOvCo hUNvHM"
+      >
+        <svg viewbox="0 0 390 390"
+             width="15"
+             height="15"
+             role="img"
+             class="styled__MapIcon-sc-1q8npbl-52 uCCmf"
+        >
+          <title>
+            View on map
+          </title>
+          <path d="M260.4 54.2L129.6 0 6.6 50.9v335.8l123-50.9L260.4 390l123-50.9V3.3l-123 50.9zM139.2 25l111.5 46.2v294L139.2 319V25zM25.9 63.9l94.1-39v294l-94.1 39v-294zm338.2 262.2l-94.1 39V71.2l94.1-39v293.9z">
+          </path>
+        </svg>
+      </button>
+    </div>
+  </li>
+  <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">
+    <div class="styled__LineColumn-sc-1q8npbl-45 kGfRfT">
+      <div class="styled__LegLine-sc-1q8npbl-43 gaszkj">
+        <div class="styled__LineBadgeContainer-sc-1q8npbl-44 hDJMuu">
+          <div class="styled__Destination-sc-1q8npbl-23 aFigx">
+            <svg viewbox="0 0 384 512"
+                 height="25"
+                 width="25"
+                 aria-hidden="true"
+                 focusable="false"
+                 fill="currentColor"
+                 xmlns="http://www.w3.org/2000/svg"
+                 class="StyledIconBase-sc-ea9ulj-0 ebjPRL styled__ToIcon-sc-n5xcvc-2 gZxRwk"
+            >
+              <path fill="currentColor"
+                    d="M215.7 499.2C267 435 384 279.4 384 192 384 86 298 0 192 0S0 86 0 192c0 87.4 117 243 168.3 307.2 12.3 15.3 35.1 15.3 47.4 0zM192 256c-35.3 0-64-28.7-64-64s28.7-64 64-64 64 28.7 64 64-28.7 64-64 64z"
+              >
+              </path>
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="styled__PlaceHeader-sc-1q8npbl-54 hMGsin">
+      <span aria-hidden="true"
+            class="styled__PlaceName-sc-1q8npbl-55 cgulMm place-row-place-name"
+      >
+        1737 SW Morrison St, Portland, OR, USA 97205
+      </span>
+    </div>
+    <div class="styled__TimeColumn-sc-1q8npbl-49 kSAQNU">
+      3:50 PM
+    </div>
+    <span class="styled__InvisibleAdditionalDetails-sc-1q8npbl-34 fVKoeN invisible-additional-details">
+      Arrive at 1737 SW Morrison St, Portland, OR, USA 97205
+    </span>
+    <div class="styled__PlaceDetails-sc-1q8npbl-53 cHqDbl place-details ">
+    </div>
+    <div class="styled__LightBorderDiv-sc-1q8npbl-0 styled__MapButtonColumn-sc-1q8npbl-51 jEDQHy fekzJr">
+      <button aria-label="View on map"
+              title="View on map"
+              class="styled__TransparentButton-sc-1q8npbl-1 styled__LinkButton-sc-1q8npbl-3 styled__MapButton-sc-1q8npbl-50 jOzsRd eTOvCo hUNvHM"
+      >
+        <svg viewbox="0 0 390 390"
+             width="15"
+             height="15"
+             role="img"
+             class="styled__MapIcon-sc-1q8npbl-52 uCCmf"
+        >
+          <title>
+            View on map
+          </title>
+          <path d="M260.4 54.2L129.6 0 6.6 50.9v335.8l123-50.9L260.4 390l123-50.9V3.3l-123 50.9zM139.2 25l111.5 46.2v294L139.2 319V25zM25.9 63.9l94.1-39v294l-94.1 39v-294zm338.2 262.2l-94.1 39V71.2l94.1-39v293.9z">
+          </path>
+        </svg>
+      </button>
+    </div>
+  </li>
+</ol>
+`;
+
 exports[`ItineraryBody/otp-ui WalkTransitWalkItineraryWithAccessLegFooter smoke-test 1`] = `
 <ol class="styled__ItineraryBody-sc-1q8npbl-28 gVbIVF">
   <li class="styled__PlaceRowWrapper-sc-1q8npbl-47 keGMkz place-row-wrapper   ">

--- a/packages/itinerary-body/src/stories/itinerary-body-defaults-wrapper.tsx
+++ b/packages/itinerary-body/src/stories/itinerary-body-defaults-wrapper.tsx
@@ -45,6 +45,7 @@ export default class ItineraryBodyDefaultsWrapper extends Component<
   render(): ReactElement {
     const {
       alwaysCollapseAlerts,
+      closedStopIds,
       defaultFareSelector,
       hideDrivingDirections = false,
       itinerary,
@@ -93,6 +94,7 @@ export default class ItineraryBodyDefaultsWrapper extends Component<
         AlertBodyIcon={AlertBodyIcon}
         AlertToggleIcon={AlertToggleIcon}
         alwaysCollapseAlerts={alwaysCollapseAlerts}
+        closedStopIds={closedStopIds}
         config={config}
         defaultFareSelector={defaultFareSelector}
         diagramVisible={diagramVisible}

--- a/packages/itinerary-body/src/styled.tsx
+++ b/packages/itinerary-body/src/styled.tsx
@@ -689,8 +689,8 @@ export const StopMarker = styled.div`
   color: #fff;
 `;
 
-export const StopName = styled.div`
-  color: ${grey[700]};
+export const StopName = styled.div<{ closed?: boolean }>`
+  color: ${props => (props.closed ? red[700] : grey[700])};
   margin-top: 3px;
 `;
 

--- a/packages/itinerary-body/src/styled.tsx
+++ b/packages/itinerary-body/src/styled.tsx
@@ -677,6 +677,11 @@ export const StepLength = styled.span`
   padding-left: 1ch;
 `;
 
+export const StopClosed = styled.span`
+  color: ${red[700]};
+  margin-left: 3px;
+`;
+
 export const StopIdSpan = styled.span`
   font-weight: 200;
   font-size: 0.9em;
@@ -685,13 +690,18 @@ export const StopIdSpan = styled.span`
 
 export const StopMarker = styled.div`
   float: left;
-  margin-left: -36px;
+  margin-left: -22.45px;
   color: #fff;
 `;
 
 export const StopName = styled.div<{ closed?: boolean }>`
   color: ${props => (props.closed ? red[700] : grey[700])};
-  margin-top: 3px;
+  text-decoration: ${props => (props.closed ? "line-through" : "")};
+`;
+
+export const StopNameContainer = styled.div`
+  display: flex;
+  flex-direction: row;
 `;
 
 export const StopRow = styled.li`

--- a/packages/itinerary-body/src/types.ts
+++ b/packages/itinerary-body/src/types.ts
@@ -136,6 +136,8 @@ interface ItineraryBodySharedProps {
    * Used for additional styling with styled components for example.
    */
   className?: string;
+  /** A set of stop IDs for stops that should be marked as closed in the itinerary */
+  closedStopIds?: Set<string>;
   /** Contains OTP configuration details. */
   config: Config;
   /**


### PR DESCRIPTION
Adds an annotation to any closed intermediate stops in the itinerary view when the stops are expanded. Requires the consumer to provide a `Set<string>` of stop gtfsIds that are closed.

<details>
<summary>Example</summary>
<img width="486" height="1338" alt="Screenshot 2026-08-31 at 1 32 39 PM" src="https://github.com/user-attachments/assets/ee4ab42d-6a1c-44e8-b2f9-e16c7053a858" />


</details>