### PR TITLE
Timetable trip specific notes

### DIFF
--- a/packages/timetable/__mocks__/route-mock.json
+++ b/packages/timetable/__mocks__/route-mock.json
@@ -1036,7 +1036,8 @@
                     "name": "Nicollet Ave S & 46th St E"
                   }
                 }
-              ]
+              ],
+              "gtfsId": "38863"
             },
             {
               "blockId": "169047",
@@ -2068,7 +2069,8 @@
                     "name": "Nicollet Ave S & 46th St E"
                   }
                 }
-              ]
+              ],
+              "gtfsId": "99796"
             },
             {
               "blockId": "168373",
@@ -3100,7 +3102,8 @@
                     "name": "Nicollet Ave S & 46th St E"
                   }
                 }
-              ]
+              ],
+              "gtfsId": "83504"
             }
           ]
         },
@@ -3384,7 +3387,8 @@
                     "name": "4th Ave S & Lake St E"
                   }
                 }
-              ]
+              ],
+              "gtfsId": "37153"
             }
           ]
         },
@@ -4448,7 +4452,8 @@
                     "name": "Columbia Heights Transit Center C"
                   }
                 }
-              ]
+              ],
+              "gtfsId": "15668"
             },
             {
               "blockId": "160633",
@@ -5506,7 +5511,8 @@
                     "name": "Columbia Heights Transit Center C"
                   }
                 }
-              ]
+              ],
+              "gtfsId": "34761"
             }
           ]
         },
@@ -6076,7 +6082,8 @@
                     "name": "Pleasant Ave & 50th St / Busch Terrace"
                   }
                 }
-              ]
+              ],
+              "gtfsId": "41121"
             }
           ]
         }

--- a/packages/timetable/__mocks__/route-mock.json
+++ b/packages/timetable/__mocks__/route-mock.json
@@ -8,6 +8,17 @@
           "tripsForDate": [
             {
               "blockId": "169111",
+              "notices": [
+                {
+                  "text": "Example notice"
+                },
+                {
+                  "text": "Exit through front door"
+                },
+                {
+                  "text": "Trip runs only on school days"
+                }
+              ],
               "stoptimesForDate": [
                 {
                   "serviceDay": 1780290000,
@@ -3113,6 +3124,14 @@
           "tripsForDate": [
             {
               "blockId": "153063",
+              "notices": [
+                {
+                  "text": "Example notice"
+                },
+                {
+                  "text": "Trip runs late on game days"
+                }
+              ],
               "stoptimesForDate": [
                 {
                   "serviceDay": 1780290000,

--- a/packages/timetable/__mocks__/route-mock.json
+++ b/packages/timetable/__mocks__/route-mock.json
@@ -17,6 +17,9 @@
                 },
                 {
                   "text": "Trip runs only on school days"
+                },
+                {
+                  "text": "This is a longer notice. The purpose of this notice is to ensure that acceptable standards of placement, readability, and formatting are achieved. This trip will be canceled if the sufficient layout and readability concerns are not addressed!"
                 }
               ],
               "stoptimesForDate": [
@@ -2085,6 +2088,20 @@
             },
             {
               "blockId": "168373",
+              "notices": [
+                {
+                  "text": "Example notice"
+                },
+                {
+                  "text": "Exit through front door"
+                },
+                {
+                  "text": "Trip runs only on school days"
+                },
+                {
+                  "text": "This is a longer notice. The purpose of this notice is to ensure that acceptable standards of placement, readability, and formatting are achieved. This trip will be canceled if the sufficient layout and readability concerns are not addressed!"
+                }
+              ],
               "stoptimesForDate": [
                 {
                   "serviceDay": 1780290000,
@@ -3129,7 +3146,13 @@
                   "text": "Example notice"
                 },
                 {
-                  "text": "Trip runs late on game days"
+                  "text": "Exit through front door"
+                },
+                {
+                  "text": "Trip runs only on school days"
+                },
+                {
+                  "text": "This is a longer notice. The purpose of this notice is to ensure that acceptable standards of placement, readability, and formatting are achieved. This trip will be canceled if the sufficient layout and readability concerns are not addressed!"
                 }
               ],
               "stoptimesForDate": [

--- a/packages/timetable/package.json
+++ b/packages/timetable/package.json
@@ -18,6 +18,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
+    "@opentripplanner/building-blocks": "workspace:^",
     "toposort": "^2.0.2"
   },
   "devDependencies": {

--- a/packages/timetable/src/index.tsx
+++ b/packages/timetable/src/index.tsx
@@ -3,7 +3,40 @@ import { IntlShape } from "react-intl";
 import styled from "styled-components";
 import toposort from "toposort";
 
+import colors from "@opentripplanner/building-blocks";
+
 const COLUMN_WIDTH = "85px";
+
+const NoticeSymbol = styled.span`
+  cursor: default;
+  border: solid black;
+  padding: 3px;
+  size: 15;
+`;
+
+const Notice = styled.div`
+  .hidden-child {
+    display: none;
+  }
+
+  :hover .hidden-child {
+    background-color: ${colors.grey[200]};
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+  }
+`;
+
+const GenerateNotice = (content: string[]) => (
+  <Notice>
+    <NoticeSymbol>{"\u2139"}</NoticeSymbol>
+    <div className="hidden-child">
+      {content.map(s => (
+        <span key={s}>{s}</span>
+      ))}
+    </div>
+  </Notice>
+);
 
 const Table = styled.table`
   display: block;
@@ -42,6 +75,7 @@ interface TimetableTrip {
    * day. Used for sorting trips by first stop time
    */
   firstStopTime: number;
+  gtfsId: string;
   /** A map of stop GTFS ID to stop detail */
   stops: Map<string, StopDetail>;
 }
@@ -63,6 +97,7 @@ interface Pattern {
 
 interface Trip {
   blockId: string;
+  gtfsId: string;
   stoptimesForDate: Stoptime[];
 }
 
@@ -111,6 +146,7 @@ const createDwellStops = (trips: Trip[], timepoints: Set<string>): Trip[] => {
     });
     withDwellStops.push({
       blockId: trip.blockId,
+      gtfsId: trip.gtfsId,
       stoptimesForDate: updatedStopTimes
     });
   });
@@ -194,6 +230,8 @@ interface TimeTableProps {
   showBlockId?: boolean;
   /** Time zone in which to display stop times if no intl object is provided */
   timeZone?: string;
+  /** Text notes that should be shown as a hoverable popup on each individual trip in the timetable */
+  tripNotes?: Map<string, string[]>;
 }
 
 const TimeTable = (props: TimeTableProps): JSX.Element => {
@@ -206,7 +244,8 @@ const TimeTable = (props: TimeTableProps): JSX.Element => {
     route,
     showBlockId,
     timepointsOnly,
-    timeZone
+    timeZone,
+    tripNotes
   } = props;
 
   const { patterns } = route;
@@ -302,6 +341,7 @@ const TimeTable = (props: TimeTableProps): JSX.Element => {
         return {
           blockId: t.blockId,
           firstStopTime: firstStop.serviceDay + firstStop.scheduledArrival,
+          gtfsId: t.gtfsId,
           stops: new Map(
             t.stoptimesForDate.map(st => {
               return [
@@ -318,31 +358,48 @@ const TimeTable = (props: TimeTableProps): JSX.Element => {
       .sort(comparator);
   }, [allTrips, comparator]);
 
+  const leadingColumns: { id: string; name: string }[] = useMemo(() => {
+    const arr: { id: string; name: string }[] = [];
+
+    if (tripNotes) arr.push({ id: "tripNotesHeader", name: "Trip Notes" });
+    if (showBlockId) arr.push({ id: "blockIdHeader", name: "Block ID" });
+
+    return arr;
+  }, [showBlockId, tripNotes]);
+
   return (
     <Table className="timetable-table" tabIndex={0}>
       <thead className="timetable-thead">
         <tr>
-          {(showBlockId ? [{ id: "blockIdHeader", name: "Block ID" }] : [])
-            .concat(filteredPatternStops)
-            .map((s, index) => {
-              return (
-                <TH
-                  className="timetable-th"
-                  key={index}
-                  scope="col"
-                  closed={closedStops && closedStops.has(s.id)}
-                >
-                  {s.name}
-                </TH>
-              );
-            })}
+          {leadingColumns.concat(filteredPatternStops).map((s, index) => {
+            return (
+              <TH
+                className="timetable-th"
+                key={index}
+                scope="col"
+                closed={closedStops && closedStops.has(s.id)}
+              >
+                {s.name}
+              </TH>
+            );
+          })}
         </tr>
       </thead>
       <TBody className="timetable-tbody">
         {timetableTrips.map((t, index) => {
-          const rowValues: { closed: boolean; value: string }[] = showBlockId
-            ? [{ closed: false, value: t.blockId }]
-            : [];
+          const rowValues: {
+            closed: boolean;
+            value: string | JSX.Element;
+          }[] = [];
+          if (tripNotes) {
+            const notes = tripNotes.get(t.gtfsId);
+            rowValues.push({
+              closed: false,
+              value: notes ? GenerateNotice(notes) : ""
+            });
+          }
+          if (showBlockId) rowValues.push({ closed: false, value: t.blockId });
+
           filteredPatternStops.forEach(patternStop => {
             const stopDetail = t.stops.get(patternStop.id);
             rowValues.push({

--- a/packages/timetable/src/index.tsx
+++ b/packages/timetable/src/index.tsx
@@ -232,7 +232,7 @@ interface TimeTableProps {
   /** Time zone in which to display stop times if no intl object is provided */
   timeZone?: string;
   /** Enable notices to be shown as a hoverable popup on each individual trip in the timetable. Requires
-   * notices field on each trip record. See https://github.com/google/transit/pull/638
+   * notices field on each trip record. See https://github.com/google/transit/pull/638 for more information
    */
   showNotices?: boolean;
 }

--- a/packages/timetable/src/index.tsx
+++ b/packages/timetable/src/index.tsx
@@ -15,11 +15,11 @@ const NoticeSymbol = styled.span`
 `;
 
 const Notice = styled.div`
-  .hidden-child {
+  .trip-notice-hover-content {
     display: none;
   }
 
-  :hover .hidden-child {
+  :hover .trip-notice-hover-content {
     background-color: ${colors.grey[200]};
     display: flex;
     flex-direction: column;
@@ -29,8 +29,8 @@ const Notice = styled.div`
 
 const GenerateNotice = (content: string[]) => (
   <Notice>
-    <NoticeSymbol>{"\u2139"}</NoticeSymbol>
-    <div className="hidden-child">
+    <NoticeSymbol className="trip-notice-symbol">{"\u2139"}</NoticeSymbol>
+    <div className="trip-notice-hover-content">
       {content.map(s => (
         <span key={s}>{s}</span>
       ))}
@@ -78,6 +78,7 @@ interface TimetableTrip {
   gtfsId: string;
   /** A map of stop GTFS ID to stop detail */
   stops: Map<string, StopDetail>;
+  notices?: string[];
 }
 
 interface StopDetail {
@@ -99,6 +100,7 @@ interface Trip {
   blockId: string;
   gtfsId: string;
   stoptimesForDate: Stoptime[];
+  notices?: { text: string }[];
 }
 
 interface Stoptime {
@@ -145,8 +147,7 @@ const createDwellStops = (trips: Trip[], timepoints: Set<string>): Trip[] => {
       if (st.timepoint) timepoints.add(dwellStopId);
     });
     withDwellStops.push({
-      blockId: trip.blockId,
-      gtfsId: trip.gtfsId,
+      ...trip,
       stoptimesForDate: updatedStopTimes
     });
   });
@@ -230,8 +231,10 @@ interface TimeTableProps {
   showBlockId?: boolean;
   /** Time zone in which to display stop times if no intl object is provided */
   timeZone?: string;
-  /** Text notes that should be shown as a hoverable popup on each individual trip in the timetable */
-  tripNotes?: Map<string, string[]>;
+  /** Enable notices to be shown as a hoverable popup on each individual trip in the timetable. Requires
+   * notices field on each trip record. See https://github.com/google/transit/pull/638
+   */
+  showNotices?: boolean;
 }
 
 const TimeTable = (props: TimeTableProps): JSX.Element => {
@@ -245,7 +248,7 @@ const TimeTable = (props: TimeTableProps): JSX.Element => {
     showBlockId,
     timepointsOnly,
     timeZone,
-    tripNotes
+    showNotices
   } = props;
 
   const { patterns } = route;
@@ -336,7 +339,7 @@ const TimeTable = (props: TimeTableProps): JSX.Element => {
 
   const timetableTrips: TimetableTrip[] = useMemo<TimetableTrip[]>(() => {
     return allTrips
-      .map(t => {
+      .map<TimetableTrip>(t => {
         const firstStop = t.stoptimesForDate[0];
         return {
           blockId: t.blockId,
@@ -352,7 +355,8 @@ const TimeTable = (props: TimeTableProps): JSX.Element => {
                 }
               ];
             })
-          )
+          ),
+          notices: t.notices?.length ? t.notices.map(n => n.text) : undefined
         };
       })
       .sort(comparator);
@@ -361,11 +365,11 @@ const TimeTable = (props: TimeTableProps): JSX.Element => {
   const leadingColumns: { id: string; name: string }[] = useMemo(() => {
     const arr: { id: string; name: string }[] = [];
 
-    if (tripNotes) arr.push({ id: "tripNotesHeader", name: "Trip Notes" });
+    if (showNotices) arr.push({ id: "tripNotesHeader", name: "Notices" });
     if (showBlockId) arr.push({ id: "blockIdHeader", name: "Block ID" });
 
     return arr;
-  }, [showBlockId, tripNotes]);
+  }, [showBlockId, showNotices]);
 
   return (
     <Table className="timetable-table" tabIndex={0}>
@@ -391,11 +395,10 @@ const TimeTable = (props: TimeTableProps): JSX.Element => {
             closed: boolean;
             value: string | JSX.Element;
           }[] = [];
-          if (tripNotes) {
-            const notes = tripNotes.get(t.gtfsId);
+          if (showNotices) {
             rowValues.push({
               closed: false,
-              value: notes ? GenerateNotice(notes) : ""
+              value: t.notices ? GenerateNotice(t.notices) : ""
             });
           }
           if (showBlockId) rowValues.push({ closed: false, value: t.blockId });

--- a/packages/timetable/src/index.tsx
+++ b/packages/timetable/src/index.tsx
@@ -3,52 +3,9 @@ import { IntlShape } from "react-intl";
 import styled from "styled-components";
 import toposort from "toposort";
 
-import colors from "@opentripplanner/building-blocks";
+import Notice from "./Notice";
 
 const COLUMN_WIDTH = "85px";
-
-const NoticeSymbol = styled.span`
-  border: solid black;
-  border-radius: 50%;
-  cursor: default;
-  display: block;
-  height: 20px;
-  width: 20px;
-`;
-
-const Notice = styled.div`
-  display: flex;
-
-  .trip-notice-hover-content {
-    display: none;
-  }
-
-  :hover .trip-notice-hover-content {
-    background-color: ${colors.grey[200]};
-    border-radius: 10px;
-    display: flex;
-    flex-direction: column;
-    padding-right: 40px;
-    position: absolute;
-    text-align: left;
-    text-wrap: wrap;
-    transform: translateX(25px) translateY(-80%);
-    max-width: 600px;
-  }
-`;
-
-const GenerateNotice = (content: string[]) => (
-  <Notice>
-    <NoticeSymbol className="trip-notice-symbol">{"\u2139"}</NoticeSymbol>
-    <div className="trip-notice-hover-content">
-      <ul>
-        {content.map(s => (
-          <li key={s}>{s}</li>
-        ))}
-      </ul>
-    </div>
-  </Notice>
-);
 
 const Table = styled.table`
   display: block;
@@ -425,7 +382,7 @@ const TimeTable = (props: TimeTableProps): JSX.Element => {
           if (showNotices) {
             rowValues.push({
               closed: false,
-              value: t.notices ? GenerateNotice(t.notices) : ""
+              value: t.notices ? <Notice content={t.notices} /> : ""
             });
           }
           if (showBlockId) rowValues.push({ closed: false, value: t.blockId });

--- a/packages/timetable/src/index.tsx
+++ b/packages/timetable/src/index.tsx
@@ -91,6 +91,18 @@ interface Stop {
   name: string;
 }
 
+/** Describes the content of the header for a leading column. Leading
+ * columns are optional columns that are appended to the beginning of
+ * the timetable.
+ */
+interface LeadingColumnHeader {
+  /** ARIA label to use for leading columns that don't have header text */
+  ariaLabel?: string;
+  className?: string;
+  id: string;
+  name: string;
+}
+
 const createDwellStops = (trips: Trip[], timepoints: Set<string>): Trip[] => {
   // To accommodate "dwell stops" where arrival and departure time are different,
   // we need to look for such stops and create an additional "dwell stop" within
@@ -335,18 +347,15 @@ const TimeTable = (props: TimeTableProps): JSX.Element => {
       .sort(comparator);
   }, [allTrips, comparator]);
 
-  const leadingColumns: {
-    id: string;
-    name: string;
-    className?: string;
-  }[] = useMemo(() => {
-    const arr: { id: string; name: string; className?: string }[] = [];
+  const leadingColumns: LeadingColumnHeader[] = useMemo(() => {
+    const arr: LeadingColumnHeader[] = [];
 
     if (showNotices)
       arr.push({
+        ariaLabel: "Notices",
+        className: "notices-column",
         id: "tripNotesHeader",
-        name: "",
-        className: "notices-column"
+        name: ""
       });
     if (showBlockId) arr.push({ id: "blockIdHeader", name: "Block ID" });
 
@@ -357,13 +366,14 @@ const TimeTable = (props: TimeTableProps): JSX.Element => {
     <Table className="timetable-table" tabIndex={0}>
       <thead className="timetable-thead">
         <tr>
-          {leadingColumns.concat(filteredPatternStops).map((s, index) => {
+          {leadingColumns.concat(filteredPatternStops).map(s => {
             return (
               <TH
+                aria-label={s.ariaLabel}
                 className={`timetable-th${
                   s.className ? ` ${s.className}` : ""
                 }`}
-                key={index}
+                key={s.id}
                 scope="col"
                 closed={closedStops && closedStops.has(s.id)}
               >

--- a/packages/timetable/src/index.tsx
+++ b/packages/timetable/src/index.tsx
@@ -8,13 +8,18 @@ import colors from "@opentripplanner/building-blocks";
 const COLUMN_WIDTH = "85px";
 
 const NoticeSymbol = styled.span`
-  cursor: default;
   border: solid black;
-  padding: 3px;
-  size: 15;
+  border-radius: 50%;
+  cursor: default;
+  display: block;
+  height: 20px;
+  width: 20px;
 `;
 
 const Notice = styled.div`
+  display: flex;
+  justify-content: center;
+
   .trip-notice-hover-content {
     display: none;
   }
@@ -24,6 +29,7 @@ const Notice = styled.div`
     display: flex;
     flex-direction: column;
     position: absolute;
+    transform: translateY(25px);
   }
 `;
 

--- a/packages/timetable/src/index.tsx
+++ b/packages/timetable/src/index.tsx
@@ -18,7 +18,6 @@ const NoticeSymbol = styled.span`
 
 const Notice = styled.div`
   display: flex;
-  justify-content: center;
 
   .trip-notice-hover-content {
     display: none;
@@ -26,10 +25,15 @@ const Notice = styled.div`
 
   :hover .trip-notice-hover-content {
     background-color: ${colors.grey[200]};
+    border-radius: 10px;
     display: flex;
     flex-direction: column;
+    padding-right: 40px;
     position: absolute;
-    transform: translateY(25px);
+    text-align: left;
+    text-wrap: wrap;
+    transform: translateX(25px) translateY(-80%);
+    max-width: 600px;
   }
 `;
 
@@ -37,9 +41,11 @@ const GenerateNotice = (content: string[]) => (
   <Notice>
     <NoticeSymbol className="trip-notice-symbol">{"\u2139"}</NoticeSymbol>
     <div className="trip-notice-hover-content">
-      {content.map(s => (
-        <span key={s}>{s}</span>
-      ))}
+      <ul>
+        {content.map(s => (
+          <li key={s}>{s}</li>
+        ))}
+      </ul>
     </div>
   </Notice>
 );
@@ -48,6 +54,10 @@ const Table = styled.table`
   display: block;
   overflow: auto;
   width: 100%;
+
+  th.notices-column {
+    min-width: 0;
+  }
 `;
 
 const TBody = styled.tbody`
@@ -368,10 +378,19 @@ const TimeTable = (props: TimeTableProps): JSX.Element => {
       .sort(comparator);
   }, [allTrips, comparator]);
 
-  const leadingColumns: { id: string; name: string }[] = useMemo(() => {
-    const arr: { id: string; name: string }[] = [];
+  const leadingColumns: {
+    id: string;
+    name: string;
+    className?: string;
+  }[] = useMemo(() => {
+    const arr: { id: string; name: string; className?: string }[] = [];
 
-    if (showNotices) arr.push({ id: "tripNotesHeader", name: "Notices" });
+    if (showNotices)
+      arr.push({
+        id: "tripNotesHeader",
+        name: "",
+        className: "notices-column"
+      });
     if (showBlockId) arr.push({ id: "blockIdHeader", name: "Block ID" });
 
     return arr;
@@ -384,7 +403,9 @@ const TimeTable = (props: TimeTableProps): JSX.Element => {
           {leadingColumns.concat(filteredPatternStops).map((s, index) => {
             return (
               <TH
-                className="timetable-th"
+                className={`timetable-th${
+                  s.className ? ` ${s.className}` : ""
+                }`}
                 key={index}
                 scope="col"
                 closed={closedStops && closedStops.has(s.id)}

--- a/packages/timetable/src/index.tsx
+++ b/packages/timetable/src/index.tsx
@@ -3,7 +3,7 @@ import { IntlShape } from "react-intl";
 import styled from "styled-components";
 import toposort from "toposort";
 
-import Notice from "./Notice";
+import Notice from "./notice";
 
 const COLUMN_WIDTH = "85px";
 

--- a/packages/timetable/src/notice.tsx
+++ b/packages/timetable/src/notice.tsx
@@ -13,7 +13,7 @@ const NoticeSymbol = styled.span`
 `;
 
 const NoticeContent = styled.div`
-  background-color: ${colors.grey[200]};
+  background-color: ${colors.grey[100]};
   border-radius: 10px;
   display: flex;
   flex-direction: row;

--- a/packages/timetable/src/notice.tsx
+++ b/packages/timetable/src/notice.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+
+import colors from "@opentripplanner/building-blocks";
+
+const NoticeSymbol = styled.span`
+  border: solid black;
+  border-radius: 50%;
+  cursor: pointer;
+  display: block;
+  height: 20px;
+  width: 20px;
+`;
+
+const NoticeContent = styled.div`
+  background-color: ${colors.grey[200]};
+  border-radius: 10px;
+  display: flex;
+  flex-direction: row;
+  position: absolute;
+  text-align: left;
+  text-wrap: wrap;
+  transform: translateX(25px) translateY(-80%);
+  max-width: 600px;
+`;
+
+const NoticeContainer = styled.div`
+  display: flex;
+`;
+
+const CloseIcon = styled.div`
+  cursor: pointer;
+  padding: 10px;
+`;
+
+interface Props {
+  content: string[];
+}
+
+const Notice = (props: Props): JSX.Element => {
+  const { content } = props;
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <NoticeContainer>
+      <NoticeSymbol
+        className="trip-notice-symbol"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        {"\u2139"}
+      </NoticeSymbol>
+      {isOpen ? (
+        <NoticeContent>
+          <ul>
+            {content.map(s => (
+              <li key={s}>{s}</li>
+            ))}
+          </ul>
+          <CloseIcon onClick={() => setIsOpen(false)}>{"\u2715"}</CloseIcon>
+        </NoticeContent>
+      ) : null}
+    </NoticeContainer>
+  );
+};
+
+export default Notice;

--- a/packages/timetable/src/notice.tsx
+++ b/packages/timetable/src/notice.tsx
@@ -47,6 +47,7 @@ const Notice = (props: Props): JSX.Element => {
       <NoticeSymbol
         className="trip-notice-symbol"
         onClick={() => setIsOpen(!isOpen)}
+        role="button"
       >
         {"\u2139"}
       </NoticeSymbol>

--- a/packages/timetable/src/stories/Timetable.story.tsx
+++ b/packages/timetable/src/stories/Timetable.story.tsx
@@ -22,7 +22,7 @@ const meta = {
             control: "radio",
             options: [0, 1]
         },
-        tripNotes: {
+        showNotices: {
             control: "boolean",
         }
     }
@@ -31,18 +31,12 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const tripNotesMock = new Map<string, string[]>([
-        ["38863", ["Example notice", "Trips run late on game days"]],
-        ["37153", ["This is a trip notice", "Exit through front door", "Trip serves elementary school"]]
-    ]
-)
-
 export const Default: Story = {
     // eslint-disable-next-line react/display-name
     render: (args) => {
-        const { closedStops, tripNotes } = args;
+        const { closedStops, showNotices } = args;
         // eslint-disable-next-line react/jsx-props-no-spreading
-        return <TimeTable {...args} closedStops={new Set(closedStops)} tripNotes={tripNotes ? tripNotesMock : undefined} />
+        return <TimeTable {...args} closedStops={new Set(closedStops)} showNotices={showNotices} />
     },
     args: {
         directionId: 0,

--- a/packages/timetable/src/stories/Timetable.story.tsx
+++ b/packages/timetable/src/stories/Timetable.story.tsx
@@ -12,15 +12,18 @@ const meta = {
     argTypes: {
         closedStops: {
             options: ["Grand St NE & 29th Ave NE (Direction: 1)", "46th St & I-35W (Direction: 0)"],
-            control: { type: "check" },
+            control: "check",
             mapping: {
                 "Grand St NE & 29th Ave NE (Direction: 1)": "2:14634",
                 "46th St & I-35W (Direction: 0)": "2:53545"
             }
         },
         directionId: {
-            control: { type: "radio" },
+            control: "radio",
             options: [0, 1]
+        },
+        tripNotes: {
+            control: "boolean",
         }
     }
 } satisfies Meta<typeof TimeTable>;
@@ -28,12 +31,18 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const tripNotesMock = new Map<string, string[]>([
+        ["38863", ["Example notice", "Trips run late on game days"]],
+        ["37153", ["This is a trip notice", "Exit through front door", "Trip serves elementary school"]]
+    ]
+)
+
 export const Default: Story = {
     // eslint-disable-next-line react/display-name
     render: (args) => {
-        const { closedStops } = args;
+        const { closedStops, tripNotes } = args;
         // eslint-disable-next-line react/jsx-props-no-spreading
-        return <TimeTable {...args} closedStops={new Set(closedStops)} />
+        return <TimeTable {...args} closedStops={new Set(closedStops)} tripNotes={tripNotes ? tripNotesMock : undefined} />
     },
     args: {
         directionId: 0,

--- a/packages/timetable/src/stories/__snapshots__/Timetable.story.tsx.snap
+++ b/packages/timetable/src/stories/__snapshots__/Timetable.story.tsx.snap
@@ -1,199 +1,199 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Timetable Default smoke-test 1`] = `
-<table class="src__Table-sc-1glc48y-0 jGHfML timetable-table"
+<table class="src__Table-sc-1glc48y-2 cisdmp timetable-table"
        tabindex="0"
 >
   <thead class="timetable-thead">
     <tr>
-      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
+      <th class="src__TH-sc-1glc48y-4 feICLN timetable-th"
           scope="col"
       >
         Pleasant Ave &amp; 50th St / Busch Terrace
       </th>
-      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
+      <th class="src__TH-sc-1glc48y-4 feICLN timetable-th"
           scope="col"
       >
         Nicollet Ave S &amp; 46th St E
       </th>
-      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
+      <th class="src__TH-sc-1glc48y-4 feICLN timetable-th"
           scope="col"
       >
         46th St &amp; I-35W
       </th>
-      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
+      <th class="src__TH-sc-1glc48y-4 feICLN timetable-th"
           scope="col"
       >
         4th Ave S &amp; 38th St E
       </th>
-      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
+      <th class="src__TH-sc-1glc48y-4 feICLN timetable-th"
           scope="col"
       >
         4th Ave S &amp; Lake St E
       </th>
-      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
+      <th class="src__TH-sc-1glc48y-4 feICLN timetable-th"
           scope="col"
       >
         3rd Ave S &amp; Franklin Ave E
       </th>
-      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
+      <th class="src__TH-sc-1glc48y-4 feICLN timetable-th"
           scope="col"
       >
         Nicollet Mall &amp; Alice Rainville Pl
       </th>
-      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
+      <th class="src__TH-sc-1glc48y-4 feICLN timetable-th"
           scope="col"
       >
         Nicollet Mall &amp; 7th St S
       </th>
-      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
+      <th class="src__TH-sc-1glc48y-4 feICLN timetable-th"
           scope="col"
       >
         Nicollet Mall &amp; 3rd St S
       </th>
-      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
+      <th class="src__TH-sc-1glc48y-4 feICLN timetable-th"
           scope="col"
       >
         Hennepin Ave E &amp; Wilder St
       </th>
-      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
+      <th class="src__TH-sc-1glc48y-4 feICLN timetable-th"
           scope="col"
       >
         Lowry Ave NE &amp; 2nd St / 1st St NE
       </th>
-      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
+      <th class="src__TH-sc-1glc48y-4 feICLN timetable-th"
           scope="col"
       >
         Grand St NE &amp; 29th Ave NE
       </th>
-      <th class="src__TH-sc-1glc48y-2 gKSIbz timetable-th"
+      <th class="src__TH-sc-1glc48y-4 feICLN timetable-th"
           scope="col"
       >
         Columbia Heights Transit Center C
       </th>
     </tr>
   </thead>
-  <tbody class="src__TBody-sc-1glc48y-1 bZEJyp timetable-tbody">
-    <tr class="src__TR-sc-1glc48y-3 kosclq timetable-tr">
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+  <tbody class="src__TBody-sc-1glc48y-3 bbdcjP timetable-tbody">
+    <tr class="src__TR-sc-1glc48y-5 jhldgc timetable-tr">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         06:00
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         06:02
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         06:06
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         06:11
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         06:16
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         06:20
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         06:24
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         06:28
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         06:31
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         06:39
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         06:42
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         06:52
       </td>
     </tr>
-    <tr class="src__TR-sc-1glc48y-3 kosclq timetable-tr">
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+    <tr class="src__TR-sc-1glc48y-5 jhldgc timetable-tr">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         16:10
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         16:26
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         16:31
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         16:36
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         -
       </td>
     </tr>
-    <tr class="src__TR-sc-1glc48y-3 kosclq timetable-tr">
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+    <tr class="src__TR-sc-1glc48y-5 jhldgc timetable-tr">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         -
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         01:37
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         01:39
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         01:43
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         01:47
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         01:52
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         01:56
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         02:00
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         02:13
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         02:15
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         02:23
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         02:26
       </td>
-      <td class="src__TD-sc-1glc48y-4 jGGfBz timetable-td">
+      <td class="src__TD-sc-1glc48y-6 lneLax timetable-td">
         02:36
       </td>
     </tr>

--- a/packages/timetable/src/stories/__snapshots__/Timetable.story.tsx.snap
+++ b/packages/timetable/src/stories/__snapshots__/Timetable.story.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Timetable Default smoke-test 1`] = `
-<table class="src__Table-sc-1glc48y-2 cisdmp timetable-table"
+<table class="src__Table-sc-1glc48y-2 jiEjEr timetable-table"
        tabindex="0"
 >
   <thead class="timetable-thead">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1121,6 +1121,9 @@ importers:
 
   packages/timetable:
     dependencies:
+      '@opentripplanner/building-blocks':
+        specifier: workspace:^
+        version: link:../building-blocks
       react:
         specifier: 'catalog:'
         version: 18.3.1


### PR DESCRIPTION
Adds a `showNotices` flag prop that enables the timetable to show a hoverable icon in a new "Notices" column. When hovered, the notice for a trip will display.

For icons to show up, the timetable data fed to the component must include notices on trips. See google/transit#638 for more information on the notices field.

<img width="983" height="380" alt="Screenshot 2026-09-11 at 11 43 14 AM" src="https://github.com/user-attachments/assets/ab4cf9d0-48ae-41cd-93c0-7f62fb42f3e9" />

