### PR TITLE
Avoid crash on non-string font names

### DIFF
--- a/.changeset/cold-moose-kneel.md
+++ b/.changeset/cold-moose-kneel.md
@@ -1,0 +1,5 @@
+---
+"@opentripplanner/transitive-overlay": minor
+---
+
+avoid crash on non-string font name

--- a/packages/transitive-overlay/src/util.ts
+++ b/packages/transitive-overlay/src/util.ts
@@ -549,17 +549,20 @@ const getFontsFromVectorTiles = (map: MapRef): SortedFonts => {
   });
   // Once we have a list of unique fonts, sort them into bold and regular buckets.
   fonts.forEach(f => {
-    const fontLowerCase = f.toLowerCase();
-    switch (true) {
-      case fontLowerCase.includes("italic"):
-        sortedFonts.italic.push(f);
-        break;
-      case fontLowerCase.includes("bold"):
-        sortedFonts.bold.push(f);
-        break;
-      default:
-        sortedFonts.regular.push(f);
+    if (typeof f === "string") {
+      // eslint-disable-next-line default-case
+      switch (true) {
+        case f?.toLowerCase().includes("italic"):
+          sortedFonts.italic.push(f);
+          return;
+        case f?.toLowerCase().includes("bold"):
+          sortedFonts.bold.push(f);
+          return;
+      }
     }
+
+    // Default case has to fire even if we can't do string operations
+    sortedFonts.regular.push(f);
   });
 
   return sortedFonts;


### PR DESCRIPTION
#981 was very cool, but causes a WSOD on map layers with fonts that are specified as arrays (I had no idea that was possible...)

This fix is the cleanest I could come up with, but if someone has a cleaner idea then I'm all ears!